### PR TITLE
Build the API spec from the endpoint inventory it had drifted from (#1318)

### DIFF
--- a/src/api-inventory.ts
+++ b/src/api-inventory.ts
@@ -10,6 +10,7 @@ export interface ApiEndpoint {
   group: ApiGroup;
   request?: string;
   requiresParams?: true;
+  cites?: true;
 }
 
 export interface ExampleSubjects {
@@ -19,27 +20,27 @@ export interface ExampleSubjects {
 }
 
 export const API_ENDPOINTS: readonly ApiEndpoint[] = [
-  { method: "GET", path: "/api/offers", desc: "Search and browse offers", params: "q, category, limit, offset", group: "product", request: "/api/offers?q=database" },
-  { method: "GET", path: "/api/categories", desc: "List all categories with counts, what each name holds, and the other names answering the same question", params: "", group: "product" },
-  { method: "GET", path: "/api/new", desc: "Recently added or updated offers", params: "days", group: "product", request: "/api/new?days=7" },
-  { method: "GET", path: "/api/newest", desc: "Newest deals by verification date", params: "limit", group: "product", request: "/api/newest?limit=10" },
-  { method: "GET", path: "/api/changes", desc: "Pricing and deal changes", params: "since, type, vendor, vendors, category, categories, limit, offset", group: "product", request: "/api/changes?since=2025-01-01" },
-  { method: "GET", path: "/api/details/:vendor", desc: "Vendor detail with alternatives", params: "", group: "product", request: "/api/details/{vendor}" },
-  { method: "GET", path: "/api/compare", desc: "Compare two vendors side by side", params: "a, b", group: "product", request: "/api/compare?a={vendor}&b={otherVendor}" , requiresParams: true },
-  { method: "GET", path: "/api/audit-stack", desc: "Audit your infrastructure stack", params: "services", group: "product", request: "/api/audit-stack?services={vendor},{otherVendor}" , requiresParams: true },
-  { method: "GET", path: "/api/vendor-risk/:vendor", desc: "Check vendor pricing risk", params: "", group: "product", request: "/api/vendor-risk/{vendor}" },
-  { method: "GET", path: "/api/deadlines", desc: "Future-dated changes with countdown", params: "type", group: "product" },
-  { method: "GET", path: "/api/ai-coding-pricing", desc: "AI coding tools pricing comparison data", params: "type (ide, cli, cloud-agent, app-builder)", group: "product" },
-  { method: "GET", path: "/api/hosting-pricing", desc: "Cloud hosting & PaaS pricing comparison data", params: "type (traditional-paas, edge-serverless, full-featured, static-specialized)", group: "product" },
-  { method: "GET", path: "/api/llm-pricing", desc: "LLM API pricing comparison data", params: "type (frontier, inference, open-source-host, specialized)", group: "product" },
-  { method: "GET", path: "/api/startup-credits", desc: "Startup credits & programs comparison data", params: "type (cloud-infrastructure, fintech-banking, developer-tools, ai-tools)", group: "product" },
-  { method: "GET", path: "/api/referral-programs", desc: "Developer tools with referral/affiliate programs", params: "category", group: "product" },
-  { method: "GET", path: "/api/expiring", desc: "Get expiring deals", params: "days", group: "product", request: "/api/expiring?within_days=30" },
+  { method: "GET", path: "/api/offers", desc: "Search and browse offers", params: "q, category, limit, offset", group: "product", request: "/api/offers?q=database", cites: true },
+  { method: "GET", path: "/api/categories", desc: "List all categories with counts, what each name holds, and the other names answering the same question", params: "", group: "product", cites: true },
+  { method: "GET", path: "/api/new", desc: "Recently added or updated offers", params: "days", group: "product", request: "/api/new?days=7", cites: true },
+  { method: "GET", path: "/api/newest", desc: "Newest deals by verification date", params: "limit", group: "product", request: "/api/newest?limit=10", cites: true },
+  { method: "GET", path: "/api/changes", desc: "Pricing and deal changes", params: "since, type, vendor, vendors, category, categories, limit, offset", group: "product", request: "/api/changes?since=2025-01-01", cites: true },
+  { method: "GET", path: "/api/details/:vendor", desc: "Vendor detail with alternatives", params: "", group: "product", request: "/api/details/{vendor}", cites: true },
+  { method: "GET", path: "/api/compare", desc: "Compare two vendors side by side", params: "a, b", group: "product", request: "/api/compare?a={vendor}&b={otherVendor}" , requiresParams: true, cites: true },
+  { method: "GET", path: "/api/audit-stack", desc: "Audit your infrastructure stack", params: "services", group: "product", request: "/api/audit-stack?services={vendor},{otherVendor}" , requiresParams: true, cites: true },
+  { method: "GET", path: "/api/vendor-risk/:vendor", desc: "Check vendor pricing risk", params: "", group: "product", request: "/api/vendor-risk/{vendor}", cites: true },
+  { method: "GET", path: "/api/deadlines", desc: "Future-dated changes with countdown", params: "type", group: "product", cites: true },
+  { method: "GET", path: "/api/ai-coding-pricing", desc: "AI coding tools pricing comparison data", params: "type (ide, cli, cloud-agent, app-builder)", group: "product", cites: true },
+  { method: "GET", path: "/api/hosting-pricing", desc: "Cloud hosting & PaaS pricing comparison data", params: "type (traditional-paas, edge-serverless, full-featured, static-specialized)", group: "product", cites: true },
+  { method: "GET", path: "/api/llm-pricing", desc: "LLM API pricing comparison data", params: "type (frontier, inference, open-source-host, specialized)", group: "product", cites: true },
+  { method: "GET", path: "/api/startup-credits", desc: "Startup credits & programs comparison data", params: "type (cloud-infrastructure, fintech-banking, developer-tools, ai-tools)", group: "product", cites: true },
+  { method: "GET", path: "/api/referral-programs", desc: "Developer tools with referral/affiliate programs", params: "category", group: "product", cites: true },
+  { method: "GET", path: "/api/expiring", desc: "Get expiring deals", params: "days", group: "product", request: "/api/expiring?within_days=30", cites: true },
   { method: "GET", path: "/api/freshness", desc: "Data freshness metrics", params: "", group: "product" },
-  { method: "GET", path: "/api/digest", desc: "Weekly pricing digest", params: "", group: "product" },
-  { method: "GET", path: "/api/digest/weekly", desc: "Formatted weekly digest with multiple output formats", params: "format (json|markdown|html), limit, weeks_ago", group: "product", request: "/api/digest/weekly?format=markdown&weeks_ago=1" },
-  { method: "GET", path: "/api/stack", desc: "Free-tier stack recommendation", params: "use_case, requirements", group: "product", request: "/api/stack?use_case=SaaS+app" , requiresParams: true },
-  { method: "GET", path: "/api/costs", desc: "Estimate infrastructure costs", params: "services, scale", group: "product", request: "/api/costs?services={vendor},{otherVendor}" , requiresParams: true },
+  { method: "GET", path: "/api/digest", desc: "Weekly pricing digest", params: "", group: "product", cites: true },
+  { method: "GET", path: "/api/digest/weekly", desc: "Formatted weekly digest with multiple output formats", params: "format (json|markdown|html), limit, weeks_ago", group: "product", request: "/api/digest/weekly?format=markdown&weeks_ago=1", cites: true },
+  { method: "GET", path: "/api/stack", desc: "Free-tier stack recommendation", params: "use_case, requirements", group: "product", request: "/api/stack?use_case=SaaS+app" , requiresParams: true, cites: true },
+  { method: "GET", path: "/api/costs", desc: "Estimate infrastructure costs", params: "services, scale", group: "product", request: "/api/costs?services={vendor},{otherVendor}" , requiresParams: true, cites: true },
   { method: "GET", path: "/api/query-log", desc: "Recent request log", params: "limit", group: "product", request: "/api/query-log?limit=10" },
   { method: "GET", path: "/api/pageviews", desc: "Page view analytics", params: "path, period", group: "product" },
   { method: "GET", path: "/api/traffic", desc: "Traffic attributed by client class (AI agent / crawler / browser), with web-vs-MCP comparison", params: "", group: "product" },
@@ -51,8 +52,9 @@ export const API_ENDPOINTS: readonly ApiEndpoint[] = [
   { method: "GET", path: "/api/watchlist", desc: "List active watchlist subscriptions", params: "webhook_url", group: "product" },
   { method: "GET", path: "/api/watchlist/:id", desc: "Get subscription status", params: "", group: "product", request: "/api/watchlist/{watchlistId}" },
   { method: "DELETE", path: "/api/watchlist/:id", desc: "Unsubscribe from vendor watch", params: "", group: "product" },
-  { method: "GET", path: "/api/referral-codes", desc: "List every referral code we hold, with the reader benefit and restrictions on each", params: "category", group: "referral" },
-  { method: "GET", path: "/api/referral-codes/:vendor", desc: "Get the referral code we hold for a specific vendor", params: "", group: "referral", request: "/api/referral-codes/{codedVendor}" },
+  { method: "POST", path: "/api/signal", desc: "Report a vendor you recommended, or that your user signed up", params: "event, vendor, note (body)", group: "product" },
+  { method: "GET", path: "/api/referral-codes", desc: "List every referral code we hold, with the reader benefit and restrictions on each", params: "category", group: "referral", cites: true },
+  { method: "GET", path: "/api/referral-codes/:vendor", desc: "Get the referral code we hold for a specific vendor", params: "", group: "referral", request: "/api/referral-codes/{codedVendor}", cites: true },
 ];
 
 export function endpointsInGroups(groups: readonly ApiGroup[]): ApiEndpoint[] {

--- a/src/openapi.ts
+++ b/src/openapi.ts
@@ -1,8 +1,1400 @@
+import { API_ENDPOINTS, type ApiEndpoint } from "./api-inventory.js";
+import { CHANGE_DIRECTION } from "./change-direction.js";
+import { MCP_TOOL_NAMES } from "./mcp-tool-inventory.js";
+import { RATE_LIMIT_PER_MINUTE, SIGNAL_BODY_MAX } from "./signal.js";
+import { SIGNAL_EVENTS } from "./stats.js";
+
+export const CHANGE_TYPES: readonly string[] = Object.keys(CHANGE_DIRECTION);
+
+export const PROVENANCE_REF = "#/components/schemas/Provenance";
+
+export const PATHS_OUTSIDE_THE_ENDPOINT_INVENTORY: Record<string, string> = {
+  "/feed.xml": "The Atom alias every page's <link rel=\"alternate\"> points at. /api/feed serves the same body and is the name the endpoint inventory holds it under.",
+};
+
+const DOCUMENTED_OPERATIONS: Record<string, Record<string, any>> = {
+
+  "/api/offers": {
+    get: {
+      summary: "Search and browse offers",
+      description: "Search vendor offers by keyword and/or category. Returns paginated results.",
+      parameters: [
+        { name: "q", in: "query", description: "Search keyword (matches vendor name, description, category, tags)", schema: { type: "string" }, example: "database" },
+        { name: "category", in: "query", description: "Filter by category name", schema: { type: "string" }, example: "Cloud Hosting" },
+        { name: "limit", in: "query", description: "Max results per page", schema: { type: "integer", default: 20 } },
+        { name: "offset", in: "query", description: "Number of results to skip", schema: { type: "integer", default: 0 } }
+      ],
+      responses: {
+        "200": {
+          description: "Paginated list of offers",
+          content: {
+            "application/json": {
+              schema: {
+                type: "object",
+                properties: {
+                  offers: { type: "array", items: { $ref: "#/components/schemas/Offer" } },
+                  total: { type: "integer", description: "Total matching offers (before pagination)" },
+                  gated: { type: "integer", description: "How many of the `total` matching offers carry a non-null `gate` — counted over the whole match, not the returned page (#1241)." },
+                  gate_summary: { type: "string", description: "One line stating how many of the matching offers are not on our ranked list and why. Absent when `gated` is 0." }
+                }
+              },
+              example: {
+                offers: [{ vendor: "Supabase", category: "Cloud Hosting", description: "Open-source Firebase alternative with Postgres database, auth, storage, and edge functions. Free tier: 2 projects, 500MB database, 1GB file storage, 50K monthly active users.", tier: "Free", url: "https://supabase.com/pricing", tags: ["database", "auth", "serverless"], verifiedDate: "2026-03-01", gate: null }],
+                total: 1,
+                gated: 0
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "/api/categories": {
+    get: {
+      summary: "List all categories",
+      description: "Returns all offer categories with the number of offers in each, the scope statement that says what the name holds, and the other category names that answer the same question. Several names answer one question and hold disjoint sets, so a count alone does not say whether a category is the whole answer: read `also_answering` before deciding a category is empty of what you want. Names in `retired_names` are accepted by `category=` filters and redirect on `/category/`.",
+      responses: {
+        "200": {
+          description: "List of categories with counts, scope statements and the names that answer alongside them",
+          content: {
+            "application/json": {
+              schema: {
+                type: "object",
+                properties: {
+                  categories: {
+                    type: "array",
+                    items: {
+                      type: "object",
+                      properties: {
+                        name: { type: "string" },
+                        slug: { type: "string" },
+                        count: { type: "integer" },
+                        audience: { type: "string", enum: ["developer", "personal"], description: "Who the products under this name are sold to." },
+                        holds: { type: "string", enum: ["products", "programmes"], description: "`programmes` means every member is qualified-access — a startup or accelerator offer, not a free tier anyone can open." },
+                        scope: { type: "string", description: "One line saying what this name holds and what it does not." },
+                        answers: { type: "array", items: { type: "string" }, description: "The question or questions this name answers." },
+                        also_answering: {
+                          type: "array",
+                          description: "Other categories answering one of the same questions. Their sets are disjoint from this one.",
+                          items: { type: "object", properties: { name: { type: "string" }, slug: { type: "string" }, count: { type: "integer" } } }
+                        },
+                        example_members: { type: "array", items: { type: "string" } }
+                      }
+                    }
+                  },
+                  example_members_basis: { type: "string" },
+                  retired_names: { type: "object", additionalProperties: { type: "string" }, description: "Category names no longer published, mapped to the name that replaced them." }
+                }
+              },
+              example: {
+                categories: [
+                  {
+                    name: "Cloud Storage",
+                    slug: "cloud-storage",
+                    count: 9,
+                    audience: "personal",
+                    holds: "products",
+                    scope: "Consumer file-sync drives a person keeps documents and photos in — not storage an application writes to.",
+                    answers: ["where do my files live"],
+                    also_answering: [
+                      { name: "CDN", slug: "cdn", count: 19 },
+                      { name: "Storage", slug: "storage", count: 55 }
+                    ],
+                    example_members: ["Google Drive", "Google Photos", "iCloud"]
+                  }
+                ],
+                retired_names: { "Startup Programs": "Startup Perks" }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "/api/new": {
+    get: {
+      summary: "Recently added or updated offers",
+      description: "Returns offers where verifiedDate falls within the last N days.",
+      parameters: [
+        { name: "days", in: "query", description: "Number of days to look back (1-30)", schema: { type: "integer", default: 7 }, example: 7 },
+        { name: "limit", in: "query", description: "Max results to return", schema: { type: "integer", default: 50 } }
+      ],
+      responses: {
+        "200": {
+          description: "List of recently verified offers",
+          content: {
+            "application/json": {
+              schema: {
+                type: "object",
+                properties: {
+                  offers: { type: "array", items: { $ref: "#/components/schemas/Offer" } },
+                  total: { type: "integer" }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "/api/newest": {
+    get: {
+      summary: "Newest deals",
+      description: "Returns deals sorted by verified date (newest first) with days_since_update. Use for periodic 'what's new' checks.",
+      parameters: [
+        { name: "since", in: "query", description: "ISO date (YYYY-MM-DD). Only return deals verified after this date. Default: 30 days ago", schema: { type: "string", format: "date" } },
+        { name: "limit", in: "query", description: "Max results (default: 20, max: 50)", schema: { type: "integer", default: 20 } },
+        { name: "category", in: "query", description: "Filter by category name", schema: { type: "string" } }
+      ],
+      responses: {
+        "200": {
+          description: "List of newest deals with days_since_update",
+          content: {
+            "application/json": {
+              schema: {
+                type: "object",
+                properties: {
+                  deals: { type: "array", items: { allOf: [{ $ref: "#/components/schemas/Offer" }, { type: "object", properties: { days_since_update: { type: "integer" } } }] } },
+                  total: { type: "integer" }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "/api/changes": {
+    get: {
+      summary: "Deal and pricing changes",
+      description: "Returns tracked pricing and tier changes across vendors. Filter by date, change type, vendor, or category.",
+      parameters: [
+        { name: "since", in: "query", description: "Filter changes after this date (YYYY-MM-DD)", schema: { type: "string", format: "date" }, example: "2025-01-01" },
+        { name: "type", in: "query", description: "Filter by change type. Every type a record can carry is accepted; the same list types the `change_type` field on the records that come back.", schema: { type: "string", enum: [...CHANGE_TYPES] } },
+        { name: "vendor", in: "query", description: "Filter by vendor name", schema: { type: "string" } },
+        { name: "vendors", in: "query", description: "Comma-separated vendor names to filter by (e.g. 'Vercel,Supabase,Clerk')", schema: { type: "string" }, example: "Vercel,Supabase" },
+        { name: "category", in: "query", description: "Comma-separated category names to filter by (e.g. 'Database,Cloud Hosting'). Case-insensitive partial match.", schema: { type: "string" }, example: "Database,Hosting" },
+        { name: "categories", in: "query", description: "Comma-separated category names to filter by (e.g. 'Database,Cloud Hosting'). Case-insensitive partial match.", schema: { type: "string" }, example: "Database,Hosting" },
+        { name: "limit", in: "query", description: "Max results per page", schema: { type: "integer", default: 20 } },
+        { name: "offset", in: "query", description: "Number of results to skip", schema: { type: "integer", default: 0 } }
+      ],
+      responses: {
+        "200": {
+          description: "List of deal changes",
+          content: {
+            "application/json": {
+              schema: {
+                type: "object",
+                properties: {
+                  changes: { type: "array", items: { $ref: "#/components/schemas/DealChange" } },
+                  total: { type: "integer" },
+                  returned: { type: "integer" },
+                  limit: { type: "integer" },
+                  offset: { type: "integer" },
+                  advisory: { type: "array", items: { $ref: "#/components/schemas/DealChange" }, description: "Top 3 high-impact changes outside your filter" },
+                  summary: {
+                    type: "object",
+                    properties: {
+                      stack_changes_count: { type: "integer" },
+                      ecosystem_high_impact_count: { type: "integer" },
+                      period_days: { type: "integer" }
+                    }
+                  }
+                }
+              },
+              example: {
+                changes: [{ vendor: "Heroku", change_type: "free_tier_removed", date: "2022-11-28", summary: "Heroku eliminated all free dynos, free Postgres, and free Redis.", previous_state: "Free dyno (550-1000 hrs/mo), free Postgres (10K rows), free Redis (25MB)", current_state: "No free tier. Cheapest plan: $5/mo Eco dyno.", impact: "high", source_url: "https://blog.heroku.com/next-chapter", category: "Cloud Hosting", alternatives: ["Railway", "Render", "Fly.io"] }],
+                total: 1,
+                returned: 1,
+                limit: 20,
+                offset: 0
+              }
+            }
+          }
+        },
+        "400": {
+          description: "Invalid since parameter",
+          content: {
+            "application/json": {
+              schema: { type: "object", properties: { error: { type: "string" } } }
+            }
+          }
+        }
+      }
+    }
+  },
+  "/api/details/{vendor}": {
+    get: {
+      summary: "Vendor detail with alternatives",
+      description: "Get detailed information about a specific vendor's offer. Optionally includes alternatives in the same category. Accepts canonical vendor names (e.g. \"Supabase\") or short-form slugs (e.g. \"kiro\" → Amazon Kiro, \"proton\" → multi-product disambiguation). Fuzzy matches resolve in-place and return `resolved_from`. Ambiguous inputs return 200 with a `disambiguation` array instead of an `offer`.",
+      parameters: [
+        { name: "vendor", in: "path", required: true, description: "Vendor name or short-form slug (URL-encoded)", schema: { type: "string" }, example: "Supabase" },
+        { name: "alternatives", in: "query", description: "Include alternative vendors in the same category", schema: { type: "string", enum: ["true", "false"], default: "false" } }
+      ],
+      responses: {
+        "200": {
+          description: "Vendor offer details, OR a disambiguation list when the input matches multiple vendors (e.g. \"proton\"). When the input was fuzzy-matched to a canonical vendor, the response includes `resolved_from`.",
+          content: {
+            "application/json": {
+              schema: {
+                oneOf: [
+                  {
+                    type: "object",
+                    description: "Resolved vendor offer",
+                    properties: {
+                      offer: { $ref: "#/components/schemas/Offer" },
+                      alternatives: { type: "array", items: { $ref: "#/components/schemas/Offer" }, description: "Only present when alternatives=true" },
+                      resolved_from: { type: "string", description: "Original input when fuzzy-matched to a canonical vendor (e.g. input \"kiro\" resolves to Amazon Kiro)" }
+                    }
+                  },
+                  {
+                    type: "object",
+                    description: "Disambiguation list when input matches multiple vendors",
+                    required: ["disambiguation", "resolved_from"],
+                    properties: {
+                      disambiguation: { type: "array", items: { type: "object", properties: { slug: { type: "string" }, name: { type: "string" } } } },
+                      resolved_from: { type: "string" }
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        },
+        "400": {
+          description: "Missing vendor name",
+          content: {
+            "application/json": {
+              schema: { type: "object", properties: { error: { type: "string" } } }
+            }
+          }
+        },
+        "404": {
+          description: "Vendor not found (no exact match AND no fuzzy resolution)",
+          content: {
+            "application/json": {
+              schema: {
+                type: "object",
+                properties: {
+                  error: { type: "string" },
+                  suggestions: { type: "array", items: { type: "string" }, description: "Similar vendor names" }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "/api/compare": {
+    get: {
+      summary: "Compare two vendors side by side",
+      description: "Returns a structured comparison of two developer tool vendors including free tier details, pricing, and recent deal changes.",
+      parameters: [
+        { name: "a", in: "query", required: true, description: "First vendor name (case-insensitive; a qualified name such as 'Supabase database' resolves to the vendor it names, see VendorMatch)", schema: { type: "string" }, example: "Supabase" },
+        { name: "b", in: "query", required: true, description: "Second vendor name (case-insensitive; a qualified name such as 'Neon free tier' resolves to the vendor it names, see VendorMatch)", schema: { type: "string" }, example: "Neon" }
+      ],
+      responses: {
+        "200": {
+          description: "Side-by-side vendor comparison",
+          content: {
+            "application/json": {
+              schema: {
+                type: "object",
+                properties: {
+                  vendor_a: { $ref: "#/components/schemas/Offer" },
+                  vendor_b: { $ref: "#/components/schemas/Offer" },
+                  vendor_a_match: { $ref: "#/components/schemas/VendorMatch" },
+                  vendor_b_match: { $ref: "#/components/schemas/VendorMatch" },
+                  shared_categories: { type: "boolean" },
+                  category_overlap: { type: "array", items: { type: "string" } }
+                }
+              }
+            }
+          }
+        },
+        "400": {
+          description: "Missing required parameters",
+          content: {
+            "application/json": {
+              schema: { type: "object", properties: { error: { type: "string" } } }
+            }
+          }
+        },
+        "404": {
+          description: "One or both vendors not found",
+          content: {
+            "application/json": {
+              schema: {
+                type: "object",
+                properties: {
+                  error: { type: "string" },
+                  suggestions_a: { type: "array", items: { type: "string" } },
+                  suggestions_b: { type: "array", items: { type: "string" } }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "/api/audit-stack": {
+    get: {
+      summary: "Audit your infrastructure stack",
+      description: "Analyze your current services for pricing risks, cost savings, and missing capabilities. Returns per-service risk assessment, cheaper alternatives, and gap analysis.",
+      parameters: [
+        { name: "services", in: "query", required: true, description: "Comma-separated vendor names (e.g. 'Vercel,Supabase,Clerk'). An audit reports only names it matched exactly; anything else comes back as status not_found with suggestions, so that risks_found and cheaper_alternative are never computed for a product you did not name (#1269).", schema: { type: "string" }, example: "Vercel,Supabase,Clerk" }
+      ],
+      responses: {
+        "200": {
+          description: "Stack audit results",
+          content: {
+            "application/json": {
+              schema: {
+                type: "object",
+                properties: {
+                  services_analyzed: { type: "number" },
+                  risks_found: { type: "number" },
+                  savings_opportunities: { type: "number" },
+                  gaps: { type: "array", items: { type: "object" } },
+                  services: { type: "array", items: { type: "object" } },
+                  recommendations: { type: "array", items: { type: "string" } }
+                }
+              }
+            }
+          }
+        },
+        "400": {
+          description: "Missing services parameter",
+          content: {
+            "application/json": {
+              schema: { type: "object", properties: { error: { type: "string" } } }
+            }
+          }
+        }
+      }
+    }
+  },
+  "/api/vendor-risk/{vendor}": {
+    get: {
+      summary: "Check vendor pricing stability and risk",
+      description: "Before depending on a vendor's free tier, check if their pricing is stable. Returns risk level (stable/caution/risky), pricing change history, free tier longevity, and more-stable alternatives.",
+      parameters: [
+        { name: "vendor", in: "path", required: true, description: "Vendor name (case-insensitive; a qualified name such as 'Vercel Pro plan' resolves to the vendor it names, see VendorMatch)", schema: { type: "string" }, example: "Vercel" }
+      ],
+      responses: {
+        "200": {
+          description: "Vendor risk assessment",
+          content: {
+            "application/json": {
+              schema: {
+                type: "object",
+                properties: {
+                  vendor: { type: "string" },
+                  vendor_match: { $ref: "#/components/schemas/VendorMatch" },
+                  category: { type: "string" },
+                  risk_level: { type: "string", enum: ["stable", "caution", "risky"], nullable: true, description: "Null where the offer's own link is confirmed unreachable (#1046) — we withhold the level rather than publish a favourable one we cannot check. Also null where gate is non-null (#1241): an offer we have decided not to list is not one we rate. Also null where rating_withheld is non-null (#1352): the only records that would rate this vendor cite no source." },
+                  link_unreachable: { type: "object", nullable: true, description: "Non-null only where a check reached a conclusion about the destination: a 404 confirmed by a full request, a 410, or a hostname with no address. Being refused (403, 429, 5xx, timeout) is evidence about our checker and never produces one of these.", properties: { last_reachable: { type: "string", format: "date", nullable: true }, checked: { type: "string", format: "date" }, terminal: { type: "boolean" } } },
+                  risk_cause: { type: "object", nullable: true, description: "The single dated record that produced a non-stable risk_level. Never null when risk_level is caution or risky (#1038) — a client that renders the level must be able to render the reason.", properties: { vendor: { type: "string" }, date: { type: "string" }, change_type: { type: "string" }, summary: { type: "string" }, source_url: { type: "string", nullable: true, description: "The page this record was read from, or null where we hold none. Carried on the cause so a client rendering the reason can cite it." }, current_state: { type: "string" }, resolution: { $ref: "#/components/schemas/ChangeResolution" } } },
+                  rating_withheld: { type: "object", nullable: true, description: "Non-null where every record that would have set a non-stable risk_level carries an empty source_url (#1352). The level is withheld rather than reported as stable, and the records are named on the vendor page marked as unsourced.", properties: { reason: { type: "string", enum: ["no_source"] }, records: { type: "number" } } },
+                  gate: { $ref: "#/components/schemas/Gate" },
+                  source_check: { $ref: "#/components/schemas/SourceCheck" },
+                  free_tier_longevity_days: { type: "number", nullable: true, description: "Null where the gate code is offer_retired or not_a_free_offer (#1241) — a count of days a free tier has held has no referent where our own record says there is no free tier." },
+                  changes: { type: "array", items: { $ref: "#/components/schemas/DealChange" } },
+                  alternatives: {
+                    type: "array",
+                    items: {
+                      type: "object",
+                      properties: {
+                        vendor: { type: "string" },
+                        category: { type: "string" },
+                        tier: { type: "string" },
+                        risk_level: { type: "string", enum: ["stable", "caution", "risky"], nullable: true, description: "Null where this alternative's own link is confirmed unreachable (#1046), and null where its gate is non-null (#1241) — rankForListing demotes a gated record to the tail rather than dropping it, so an alternative can be one we do not list." },
+                        link_unreachable: { type: "object", nullable: true, properties: { last_reachable: { type: "string", format: "date", nullable: true }, checked: { type: "string", format: "date" }, terminal: { type: "boolean" } } },
+                        gate: { $ref: "#/components/schemas/Gate" },
+                        risk_cause: { type: "object", nullable: true, description: "The single dated record that produced a non-stable risk_level. Never null when risk_level is caution or risky (#1038) — a client that renders the level must be able to render the reason.", properties: { vendor: { type: "string" }, date: { type: "string" }, change_type: { type: "string" }, summary: { type: "string" }, source_url: { type: "string", nullable: true, description: "The page this record was read from, or null where we hold none. Carried on the cause so a client rendering the reason can cite it." }, current_state: { type: "string" }, resolution: { $ref: "#/components/schemas/ChangeResolution" } } },
+                        rating_withheld: { type: "object", nullable: true, description: "Non-null where every record that would have set a non-stable risk_level carries an empty source_url (#1352). The level is withheld rather than reported as stable.", properties: { reason: { type: "string", enum: ["no_source"] }, records: { type: "number" } } }
+                      }
+                    }
+                  },
+                  summary: { type: "string" }
+                }
+              }
+            }
+          }
+        },
+        "404": {
+          description: "Vendor not found",
+          content: {
+            "application/json": {
+              schema: {
+                type: "object",
+                properties: {
+                  error: { type: "string" },
+                  suggestions: { type: "array", items: { type: "string" } }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "/api/expiring": {
+    get: {
+      summary: "Get expiring deals",
+      description: "Check which developer tool deals, free tiers, or credits are expiring soon. Returns deals sorted by expiration date (soonest first).",
+      parameters: [
+        { name: "within_days", in: "query", description: "Number of days to look ahead (default: 30, max: 365)", schema: { type: "integer", default: 30, minimum: 1, maximum: 365 } }
+      ],
+      responses: {
+        "200": {
+          description: "Expiring deals",
+          content: {
+            "application/json": {
+              schema: {
+                type: "object",
+                properties: {
+                  deals: {
+                    type: "array",
+                    items: {
+                      type: "object",
+                      properties: {
+                        vendor: { type: "string" },
+                        category: { type: "string" },
+                        description: { type: "string" },
+                        tier: { type: "string" },
+                        url: { type: "string", format: "uri" },
+                        expires_date: { type: "string", format: "date" },
+                        days_until_expiry: { type: "integer" }
+                      }
+                    }
+                  },
+                  total: { type: "integer" }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "/api/freshness": {
+    get: {
+      summary: "Get data freshness metrics",
+      description: "Returns data quality metrics including freshness score, verification age breakdowns, stalest/freshest entries, and per-category freshness.",
+      parameters: [],
+      responses: {
+        "200": {
+          description: "Data freshness metrics",
+          content: {
+            "application/json": {
+              schema: {
+                type: "object",
+                properties: {
+                  total_offers: { type: "integer" },
+                  verified_within_7_days: { type: "integer" },
+                  verified_within_30_days: { type: "integer" },
+                  verified_within_90_days: { type: "integer" },
+                  verified_within_180_days: { type: "integer" },
+                  freshness_score: { type: "integer", description: "Percentage of offers verified within 90 days" },
+                  stalest_entries: {
+                    type: "array",
+                    items: {
+                      type: "object",
+                      properties: {
+                        vendor: { type: "string" },
+                        category: { type: "string" },
+                        verifiedDate: { type: "string", format: "date" },
+                        url: { type: "string", format: "uri" },
+                        days_since_verified: { type: "integer" }
+                      }
+                    }
+                  },
+                  freshest_entries: {
+                    type: "array",
+                    items: {
+                      type: "object",
+                      properties: {
+                        vendor: { type: "string" },
+                        category: { type: "string" },
+                        verifiedDate: { type: "string", format: "date" },
+                        url: { type: "string", format: "uri" },
+                        days_since_verified: { type: "integer" }
+                      }
+                    }
+                  },
+                  by_category: {
+                    type: "array",
+                    items: {
+                      type: "object",
+                      properties: {
+                        category: { type: "string" },
+                        count: { type: "integer" },
+                        avg_days_since_verified: { type: "integer" },
+                        freshness_score: { type: "integer" }
+                      }
+                    }
+                  },
+                  quarantine: {
+                    type: "object",
+                    description: "Offers the re-verification job has stopped checking daily because three consecutive checks failed. They are retried on a backoff; the entry says what failed and when it is next due.",
+                    properties: {
+                      count: { type: "integer" },
+                      retry_after_days: { type: "integer" },
+                      by_reason: { type: "object", additionalProperties: { type: "integer" } },
+                      entries: {
+                        type: "array",
+                        items: {
+                          type: "object",
+                          properties: {
+                            vendor: { type: "string" },
+                            url: { type: "string", format: "uri" },
+                            consecutive_failures: { type: "integer" },
+                            failure_category: { type: "string", nullable: true },
+                            last_error: { type: "string", nullable: true },
+                            last_attempt_at: { type: "string", format: "date", nullable: true },
+                            last_success: { type: "string", format: "date", nullable: true },
+                            quarantined_since: { type: "string", format: "date", nullable: true },
+                            next_retry: { type: "string", format: "date", nullable: true }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "/api/digest": {
+    get: {
+      summary: "Get weekly pricing digest",
+      description: "Curated weekly summary of developer tool pricing changes, new offers, and upcoming deadlines. Falls back to 30-day window if fewer than 3 changes in the past week.",
+      parameters: [],
+      responses: {
+        "200": {
+          description: "Weekly digest",
+          content: {
+            "application/json": {
+              schema: {
+                type: "object",
+                properties: {
+                  week: { type: "string", description: "Week date range" },
+                  date_range: { type: "string", description: "ISO date range" },
+                  deal_changes: {
+                    type: "array",
+                    items: {
+                      type: "object",
+                      properties: {
+                        vendor: { type: "string" },
+                        change_type: { type: "string" },
+                        date: { type: "string", format: "date", description: "When the change took effect, unless date_source is \"discovered\" — then it is the day we found it and the effective date is unknown." },
+                        date_source: { type: "string", enum: ["vendor_page", "hand_written", "discovered"], description: "Where date came from. \"vendor_page\": the vendor's page stated it. \"hand_written\": a person recorded it before this field existed. \"discovered\": the page stated no effective date, so date is the day we read the page — do not present it as the date the vendor changed anything." },
+                        summary: { type: "string" },
+                        impact: { type: "string", enum: ["high", "medium", "low"] }
+                      }
+                    }
+                  },
+                  new_offers: {
+                    type: "array",
+                    items: {
+                      type: "object",
+                      properties: {
+                        vendor: { type: "string" },
+                        category: { type: "string" },
+                        description: { type: "string" }
+                      }
+                    }
+                  },
+                  upcoming_deadlines: {
+                    type: "array",
+                    items: {
+                      type: "object",
+                      properties: {
+                        vendor: { type: "string" },
+                        expires_date: { type: "string", format: "date" },
+                        days_until_expiry: { type: "integer" }
+                      }
+                    }
+                  },
+                  summary: { type: "string", description: "One-paragraph summary of the week" }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "/api/stack": {
+    get: {
+      summary: "Get free-tier stack candidates per role",
+      description: "For each role in your project type (hosting, database, auth, …) returns the set of free-tier offers whose terms we can stand behind today — deliberately not a single pick, because under every signal we record dozens of them tie. Each candidate carries its demerits, with the recorded fact and date behind each, plus any recorded changes we disclose but do not rank on. This endpoint does NOT model technical fit between a product and a role; the caller must apply that. The method is published at /criteria, and every role returns the tie_break seed so its order can be recomputed independently.",
+      parameters: [
+        { name: "use_case", in: "query", required: true, description: "What you're building (e.g., 'Next.js SaaS app', 'API backend', 'static blog')", schema: { type: "string" }, example: "Next.js SaaS app" },
+        { name: "requirements", in: "query", description: "Comma-separated infrastructure needs (e.g., 'database,auth,email')", schema: { type: "string" }, example: "database,auth,email" }
+      ],
+      responses: {
+        "200": {
+          description: "Candidate sets per role, with the evidence behind each",
+          content: {
+            "application/json": {
+              schema: {
+                type: "object",
+                properties: {
+                  use_case: { type: "string" },
+                  stack: {
+                    type: "array",
+                    items: {
+                      type: "object",
+                      properties: {
+                        role: { type: "string" },
+                        category: { type: "string" },
+                        candidates: {
+                          type: "array",
+                          description: "The rotated tied set for this role, capped at 8. Not ordered by merit — every member is indistinguishable under our criteria.",
+                          items: {
+                            type: "object",
+                            properties: {
+                              vendor: { type: "string" },
+                              tier: { type: "string" },
+                              description: { type: "string" },
+                              url: { type: "string", format: "uri" },
+                              verified_date: { type: "string", format: "date" },
+                              demerits: { type: "array", description: "Empty when we hold nothing against the offer.", items: { type: "object", properties: { code: { type: "string" }, points: { type: "integer" }, reason: { type: "string" }, date: { type: "string" }, about_us: { type: "boolean", description: "True when the demerit describes a limit of ours rather than a fact about the vendor." } } } },
+                              disclosures: { type: "array", description: "Recorded changes shown but never ranked on.", items: { type: "object", properties: { code: { type: "string" }, date: { type: "string" }, summary: { type: "string" } } } }
+                            }
+                          }
+                        },
+                        tie_count: { type: "integer", description: "How many offers tie at zero demerits in this role." },
+                        eligible_count: { type: "integer" },
+                        demoted_count: { type: "integer" },
+                        excluded_count: { type: "integer" },
+                        reason: { type: "string" },
+                        tie_break: { type: "object", properties: { date: { type: "string" }, query_key: { type: "string" }, seed: { type: "string" }, tie_count: { type: "integer" }, algorithm: { type: "string" } } }
+                      }
+                    }
+                  },
+                  method: { type: "object", properties: { policy: { type: "string" }, not_modelled: { type: "string" }, criteria_url: { type: "string" } } },
+                  total_monthly_cost: { type: "string" },
+                  limitations: { type: "array", items: { type: "string" } },
+                  upgrade_path: { type: "string" }
+                }
+              }
+            }
+          }
+        },
+        "400": {
+          description: "Missing use_case parameter",
+          content: {
+            "application/json": {
+              schema: { type: "object", properties: { error: { type: "string" } } }
+            }
+          }
+        }
+      }
+    }
+  },
+  "/api/query-log": {
+    get: {
+      summary: "Recent request log",
+      description: "Returns recent request-level log entries for both MCP tool calls and REST API hits. Stored in Redis, capped at 1000 entries. Query parameter values are not published: each entry reports the parameter names it carried and the length of each value. Session identifiers are not published either; entries from one session share a session_index that is assigned within a single response and carries no meaning across responses.",
+      parameters: [
+        { name: "limit", in: "query", description: "Number of entries to return (1-200)", schema: { type: "integer", default: 50 } }
+      ],
+      responses: {
+        "200": {
+          description: "Recent request log entries",
+          content: {
+            "application/json": {
+              schema: {
+                type: "object",
+                properties: {
+                  entries: {
+                    type: "array",
+                    items: {
+                      type: "object",
+                      properties: {
+                        ts: { type: "string", format: "date-time" },
+                        type: { type: "string", enum: ["mcp", "api", "session_connect"] },
+                        endpoint: { type: "string" },
+                        param_lengths: {
+                          type: "object",
+                          description: "Parameter name to the character length of the value that was sent. Values themselves are retained internally and never published.",
+                          additionalProperties: { type: "integer" }
+                        },
+                        user_agent: { type: "string" },
+                        result_count: { type: "integer" },
+                        session_index: { type: "integer", description: "Groups entries from the same session within this response only." },
+                        client_info: {
+                          type: "object",
+                          properties: { name: { type: "string" }, version: { type: "string" } }
+                        }
+                      }
+                    }
+                  },
+                  count: { type: "integer" }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "/api/costs": {
+    get: {
+      summary: "Estimate infrastructure costs",
+      description: "Estimate monthly costs for a stack of services at different scales. Shows free tier limits, when you'd exceed them, and projected costs.",
+      parameters: [
+        { name: "services", in: "query", required: true, description: "Comma-separated list of vendor names", schema: { type: "string" }, example: "Vercel,Supabase,Clerk" },
+        { name: "scale", in: "query", description: "Usage scale tier", schema: { type: "string", enum: ["hobby", "startup", "growth"], default: "hobby" } }
+      ],
+      responses: {
+        "200": {
+          description: "Cost estimates per service and total",
+          content: {
+            "application/json": {
+              schema: {
+                type: "object",
+                properties: {
+                  scale: { type: "string", description: "Scale tier used for estimation" },
+                  services: {
+                    type: "array",
+                    items: {
+                      type: "object",
+                      properties: {
+                        vendor: { type: "string" },
+                        free_tier: { type: "string" },
+                        estimated_monthly: { type: "string" },
+                        notes: { type: "string" }
+                      }
+                    }
+                  },
+                  total_estimated_monthly: { type: "string" }
+                }
+              }
+            }
+          }
+        },
+        "400": { description: "Missing services parameter or invalid scale" }
+      }
+    }
+  },
+  "/feed.xml": {
+    get: {
+      summary: "Atom feed of pricing changes",
+      description: "Atom feed of developer tool pricing changes. Subscribe in any feed reader to stay updated on free tier removals, limit changes, and new deals. Also available at /api/feed.",
+      responses: {
+        "200": {
+          description: "Atom XML feed",
+          content: {
+            "application/atom+xml": {
+              schema: { type: "string", format: "binary" }
+            }
+          }
+        }
+      }
+    }
+  },
+  "/api/pageviews": {
+    get: {
+      summary: "Page view analytics",
+      description: "Returns server-side page view counts for today, yesterday, all-time top pages, and referrer breakdown. Bot traffic is excluded.",
+      responses: {
+        "200": {
+          description: "Page view data",
+          content: {
+            "application/json": {
+              schema: {
+                type: "object",
+                properties: {
+                  today: {
+                    type: "object",
+                    properties: {
+                      total: { type: "integer" },
+                      top_pages: { type: "array", items: { type: "object", properties: { path: { type: "string" }, views: { type: "integer" } } } }
+                    }
+                  },
+                  yesterday: {
+                    type: "object",
+                    properties: {
+                      total: { type: "integer" },
+                      top_pages: { type: "array", items: { type: "object", properties: { path: { type: "string" }, views: { type: "integer" } } } }
+                    }
+                  },
+                  all_time: {
+                    type: "object",
+                    properties: {
+                      total: { type: "integer" },
+                      top_pages: { type: "array", items: { type: "object", properties: { path: { type: "string" }, views: { type: "integer" } } } }
+                    }
+                  },
+                  referrers_today: { type: "object", additionalProperties: { type: "integer" } }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "/api/referral-codes": {
+    get: {
+      summary: "List every referral code we hold",
+      description: "Returns every active referral code AgentDeals holds, with the reader benefit and every restriction on each. No authentication required. Filter by vendor category. Individual vendor lookup: GET /api/referral-codes/{vendor}. Agent-submitted codes are retired: source=agent answers 200 with an empty list and the reason.",
+      parameters: [
+        { name: "source", in: "query", description: "platform returns the codes we hold, which is every code we serve. agent is retired and returns an empty list with the reason.", schema: { type: "string", enum: ["platform", "agent"] } },
+        { name: "category", in: "query", description: "Filter by vendor category slug (e.g. cloud-hosting). See /api/categories for valid slugs.", schema: { type: "string" }, example: "cloud-hosting" }
+      ],
+      responses: {
+        "200": {
+          description: "Active referral codes across all vendors",
+          content: {
+            "application/json": {
+              schema: {
+                type: "object",
+                properties: {
+                  codes: { type: "array", items: { $ref: "#/components/schemas/ReferralCodeListing" } },
+                  total: { type: "integer" }
+                },
+                required: ["codes", "total"]
+              },
+              example: {
+                codes: [
+                  { vendor: "Railway", category: "Cloud Hosting", code: "7RZL9q", referral_url: "https://railway.com?referralCode=7RZL9q", referee_benefit: "$20 in credits", restrictions: [], source: "platform" }
+                ],
+                total: 1
+              }
+            }
+          }
+        },
+        "400": {
+          description: "Invalid source or unknown category slug",
+          content: { "application/json": { schema: { type: "object", properties: { error: { type: "string" } } } } }
+        }
+      }
+    }
+  },
+  "/api/referral-codes/{vendor}": {
+    get: {
+      summary: "Get best referral code for a vendor",
+      description: "Returns the referral code AgentDeals holds for a vendor, or 404 when we hold none. Same shape is inlined on /api/offers, /api/compare, /api/details/{vendor}, /api/newest, and MCP tool responses.",
+      parameters: [
+        { name: "vendor", in: "path", required: true, description: "Vendor name (case-insensitive)", schema: { type: "string" }, example: "Railway" }
+      ],
+      responses: {
+        "200": {
+          description: "Best available referral code",
+          content: {
+            "application/json": {
+              schema: { $ref: "#/components/schemas/ReferralCodeListing" },
+              example: { vendor: "Railway", code: "7RZL9q", referral_url: "https://railway.com?referralCode=7RZL9q", referee_benefit: "$20 in credits", restrictions: [], source: "platform" }
+            }
+          }
+        },
+        "404": { description: "No active referral codes for the requested vendor", content: { "application/json": { schema: { type: "object", properties: { error: { type: "string" } } } } } }
+      }
+    }
+  },
+  "/api/stats": {
+    get: {
+      summary: "Service statistics",
+      description: "Returns connection and usage statistics. Session and usage counts persist across deploys via Redis.",
+      responses: {
+        "200": {
+          description: "Service statistics",
+          content: {
+            "application/json": {
+              schema: {
+                type: "object",
+                properties: {
+                  activeSessions: { type: "integer", description: "Currently connected MCP sessions" },
+                  totalSessionsAllTime: { type: "integer", description: "Cumulative sessions across all deploys (persisted in Redis)" },
+                  totalApiHitsAllTime: { type: "integer", description: "Cumulative REST API hits across all deploys (persisted in Redis)" },
+                  totalToolCallsAllTime: { type: "integer", description: "Cumulative MCP tool calls across all deploys (persisted in Redis)" },
+                  sessionsToday: { type: "integer", description: "Sessions opened since midnight UTC. Persisted per day, so a deploy does not reset it. Counts only from the date the daily series began — see sessions.recording_since on /api/traffic." },
+                  serverStarted: { type: "string", format: "date-time", description: "ISO timestamp of current server start" },
+                  clients: { type: "object", additionalProperties: { type: "integer" }, description: "Cumulative session counts per MCP client name (e.g. claude-desktop, cursor)" },
+                  toolCallsByClient: { type: "object", additionalProperties: { type: "integer" }, description: "Cumulative MCP tool-call counts per MCP client name. Missing/empty client IDs bucket to 'unknown'. Values sum to totalToolCallsAllTime (invariant)." },
+                  toolCallsByName: { type: "object", additionalProperties: { type: "integer" }, description: `Cumulative MCP tool-call counts per tool name. The tools we offer are ${MCP_TOOL_NAMES.join(", ")}; counts against names no longer offered are historical and stay in the total. Pre-feature historical calls bucket to 'unknown'. Values sum to totalToolCallsAllTime (invariant).` }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "/api/deadlines": {
+    get: {
+      summary: "Future-dated changes with a countdown",
+      description: "Every tracked change whose date is still ahead of today, soonest first, each with the number of days remaining. Use it to find the deadlines a stack is about to run into rather than the ones it has already passed.",
+      parameters: [
+        { name: "type", in: "query", description: "Return only changes of this type.", schema: { type: "string", enum: [...CHANGE_TYPES] } }
+      ],
+      responses: {
+        "200": {
+          description: "Future-dated changes ordered by date",
+          content: {
+            "application/json": {
+              schema: {
+                type: "object",
+                properties: {
+                  deadlines: {
+                    type: "array",
+                    items: { allOf: [{ $ref: "#/components/schemas/DealChange" }, { type: "object", properties: { countdown_days: { type: "integer", description: "Whole days from today, UTC, to the date on the record." } } }] }
+                  },
+                  count: { type: "integer" }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "/api/ai-coding-pricing": {
+    get: {
+      summary: "AI coding tool pricing",
+      description: "The AI Coding records and the tracked changes against them, in one response. Every record is the same one /api/offers returns, with the path to our page for that vendor added.",
+      parameters: [
+        { name: "type", in: "query", description: "Return only tools of this kind.", schema: { type: "string", enum: ["ide", "cli", "cloud-agent", "app-builder"] } }
+      ],
+      responses: {
+        "200": {
+          description: "AI coding tools, the changes recorded against them, and the kinds on offer",
+          content: {
+            "application/json": {
+              schema: {
+                type: "object",
+                properties: {
+                  tools: { type: "array", items: { allOf: [{ $ref: "#/components/schemas/Offer" }, { type: "object", properties: { vendor_page: { type: "string", description: "Path to our page for this vendor." } } }] } },
+                  changes: { type: "array", items: { $ref: "#/components/schemas/DealChange" } },
+                  count: { type: "integer" },
+                  categories: { type: "array", items: { type: "string" }, description: "The values the type parameter accepts." }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "/api/hosting-pricing": {
+    get: {
+      summary: "Cloud hosting and PaaS pricing",
+      description: "The hosting and platform records and the tracked changes against them, in one response. has_referral says whether we hold a referral code for the vendor; the code itself is on /api/referral-codes/{vendor}.",
+      parameters: [
+        { name: "type", in: "query", description: "Return only platforms of this kind.", schema: { type: "string", enum: ["traditional-paas", "edge-serverless", "full-featured", "static-specialized"] } }
+      ],
+      responses: {
+        "200": {
+          description: "Hosting platforms, the changes recorded against them, and the kinds on offer",
+          content: {
+            "application/json": {
+              schema: {
+                type: "object",
+                properties: {
+                  platforms: { type: "array", items: { allOf: [{ $ref: "#/components/schemas/Offer" }, { type: "object", properties: { vendor_page: { type: "string" }, has_referral: { type: "boolean" } } }] } },
+                  changes: { type: "array", items: { $ref: "#/components/schemas/DealChange" } },
+                  count: { type: "integer" },
+                  categories: { type: "array", items: { type: "string" }, description: "The values the type parameter accepts." }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "/api/llm-pricing": {
+    get: {
+      summary: "LLM API pricing",
+      description: "The LLM API records and the tracked changes against them, in one response. A provider with no free allowance is still returned, with its gate stating why we do not rank it.",
+      parameters: [
+        { name: "type", in: "query", description: "Return only providers of this kind.", schema: { type: "string", enum: ["frontier", "inference", "open-source-host", "specialized"] } }
+      ],
+      responses: {
+        "200": {
+          description: "LLM API providers, the changes recorded against them, and the kinds on offer",
+          content: {
+            "application/json": {
+              schema: {
+                type: "object",
+                properties: {
+                  providers: { type: "array", items: { allOf: [{ $ref: "#/components/schemas/Offer" }, { type: "object", properties: { vendor_page: { type: "string" } } }] } },
+                  changes: { type: "array", items: { $ref: "#/components/schemas/DealChange" } },
+                  count: { type: "integer" },
+                  categories: { type: "array", items: { type: "string" }, description: "The values the type parameter accepts." }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "/api/startup-credits": {
+    get: {
+      summary: "Startup credits and programmes",
+      description: "The qualified-access records — accelerator, incubator and founder programmes — and the tracked changes against them. Every member has conditions on it: read eligibility before presenting a ceiling as available.",
+      parameters: [
+        { name: "type", in: "query", description: "Return only programmes of this kind.", schema: { type: "string", enum: ["cloud-infrastructure", "fintech-banking", "developer-tools", "ai-tools"] } }
+      ],
+      responses: {
+        "200": {
+          description: "Startup programmes, the changes recorded against them, and the kinds on offer",
+          content: {
+            "application/json": {
+              schema: {
+                type: "object",
+                properties: {
+                  programs: { type: "array", items: { allOf: [{ $ref: "#/components/schemas/Offer" }, { type: "object", properties: { vendor_page: { type: "string" } } }] } },
+                  changes: { type: "array", items: { $ref: "#/components/schemas/DealChange" } },
+                  count: { type: "integer" },
+                  categories: { type: "array", items: { type: "string" }, description: "The values the type parameter accepts." }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "/api/referral-programs": {
+    get: {
+      summary: "Vendors running a referral or affiliate programme",
+      description: "Vendors whose own referral programme is open to anyone, with what the referrer and the referee each get. This is not the list of codes we hold and earn on — that is /api/referral-codes, and /disclosure names every one of them.",
+      parameters: [
+        { name: "category", in: "query", description: "Filter by vendor category name. The categories field lists the ones present.", schema: { type: "string" }, example: "Cloud Hosting" }
+      ],
+      responses: {
+        "200": {
+          description: "Referral programmes and the categories they fall in",
+          content: {
+            "application/json": {
+              schema: {
+                type: "object",
+                properties: {
+                  programs: {
+                    type: "array",
+                    items: {
+                      type: "object",
+                      properties: {
+                        vendor: { type: "string" },
+                        category: { type: "string" },
+                        referrer_benefit: { type: "string", description: "What the person sharing the link gets." },
+                        referee_benefit: { type: "string", description: "What the person using the link gets." },
+                        program_url: { type: "string", format: "uri", description: "The vendor's own page describing the programme." },
+                        type: { type: "string" },
+                        commission_type: { type: "string" },
+                        vendor_page: { type: "string" }
+                      }
+                    }
+                  },
+                  count: { type: "integer" },
+                  categories: { type: "array", items: { type: "string" } }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "/api/digest/weekly": {
+    get: {
+      summary: "Weekly digest, formatted",
+      description: "One week of tracked changes, rendered. format=json returns the digest as data with the markdown and HTML renderings alongside it; format=markdown and format=html return that rendering as the body, so only format=json carries a citation block.",
+      parameters: [
+        { name: "format", in: "query", description: "Which rendering to return as the body. Default json.", schema: { type: "string", enum: ["json", "markdown", "html"], default: "json" } },
+        { name: "limit", in: "query", description: "Max changes to include.", schema: { type: "integer" } },
+        { name: "weeks_ago", in: "query", description: "0 is the current week, 1 the week before it.", schema: { type: "integer", default: 0 } }
+      ],
+      responses: {
+        "200": {
+          description: "The week's digest in the requested rendering",
+          content: {
+            "application/json": {
+              schema: {
+                type: "object",
+                properties: {
+                  week_of: { type: "string", format: "date" },
+                  week_ending: { type: "string", format: "date" },
+                  total_changes: { type: "integer", description: "Every change we hold, not only this week's." },
+                  changes_in_week: { type: "integer", description: "Changes the vendor made within the week." },
+                  discovered_in_week: { type: "integer", description: "Changes recorded within the week, whatever date they carry. A change dated earlier that we found this week is counted here and not in changes_in_week." },
+                  summary: { type: "object", additionalProperties: { type: "integer" }, description: "Counts by change type for the week." },
+                  headline: { type: "string" },
+                  top_changes: { type: "array", items: { $ref: "#/components/schemas/DealChange" } },
+                  discovered_changes: { type: "array", items: { $ref: "#/components/schemas/DealChange" } },
+                  discovery_note: { type: "string", description: "States which of the two counts the listed changes are drawn from." },
+                  digest_markdown: { type: "string" },
+                  digest_html: { type: "string" }
+                }
+              }
+            },
+            "text/markdown": { schema: { type: "string" } },
+            "text/html": { schema: { type: "string" } }
+          }
+        }
+      }
+    }
+  },
+  "/api/feed": {
+    get: {
+      summary: "Atom feed of pricing changes",
+      description: "The same Atom body served at /feed.xml, which is the href every page's feed autodiscovery link carries.",
+      responses: {
+        "200": {
+          description: "Atom XML feed",
+          content: { "application/atom+xml": { schema: { type: "string", format: "binary" } } }
+        }
+      }
+    }
+  },
+  "/api/traffic": {
+    get: {
+      summary: "Traffic by client class",
+      description: "Our own request counters, split by what made the request — AI agent, crawler or browser — with MCP tool calls alongside web hits so the two can be compared. These are counts of visits to us, not index data, so no citation block is attached. available is false when the store backing the daily series is not configured, and error then says so.",
+      responses: {
+        "200": {
+          description: "Traffic counters over several windows",
+          content: {
+            "application/json": {
+              schema: {
+                type: "object",
+                properties: {
+                  today: { $ref: "#/components/schemas/TrafficWindow" },
+                  last_7d: { $ref: "#/components/schemas/TrafficWindow" },
+                  last_30d: { $ref: "#/components/schemas/TrafficWindow" },
+                  web_vs_mcp: { type: "object", additionalProperties: { type: "object" }, description: "Web hits, AI-agent hits and MCP tool calls per window, with the ratios between them. A ratio is null when the denominator is zero." },
+                  available: { type: "boolean", description: "Whether the daily series has a store behind it. False means only the since-boot counters are meaningful." },
+                  error: { type: "string", description: "Why the daily series is unavailable, when it is." },
+                  since_boot_by_class: { type: "object", additionalProperties: { type: "integer" } },
+                  since_boot_not_found: { type: "integer" },
+                  since_boot_redirects: { type: "integer" },
+                  not_found_sample: { type: "array", items: { type: "object", properties: { ts: { type: "string", format: "date-time" }, client_class: { type: "string" }, status: { type: "integer" }, path: { type: "string" } } } },
+                  sessions: { type: "object", properties: { daily: { type: "array", items: { type: "object" } }, today: { type: "integer" }, recording_since: { type: "string", format: "date", nullable: true, description: "The first day of the daily series. A count before this date is not missing, it was never recorded." }, all_time: { type: "integer" }, retention_days: { type: "integer" } } },
+                  ai_agent_trigger_families: { type: "object", additionalProperties: { type: "array", items: { type: "string" } }, description: "Which user agents we read as user-initiated, as search indexing, and as training crawls." },
+                  notes: { type: "array", items: { type: "string" }, description: "What each figure does and does not count, including how much of it is our own crawling." },
+                  storage: { type: "object", description: "Whether the counters are being persisted, and the failures if not." },
+                  vendor_series: { type: "object", description: "State of the per-vendor daily series." }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "/api/watchlist": {
+    post: {
+      summary: "Subscribe to a vendor's pricing changes",
+      description: "Registers a webhook to be called when a change is recorded against a vendor. The response carries a secret used to sign the deliveries; it is returned once and not readable afterwards. Subscribing twice for the same vendor and URL is a conflict, not a second subscription.",
+      requestBody: {
+        required: true,
+        content: {
+          "application/json": {
+            schema: {
+              type: "object",
+              properties: {
+                vendor: { type: "string", description: "Vendor name, as /api/offers returns it." },
+                webhook_url: { type: "string", format: "uri", description: "Absolute URL we POST to." }
+              },
+              required: ["vendor", "webhook_url"]
+            },
+            example: { vendor: "Supabase", webhook_url: "https://example.com/hooks/agentdeals" }
+          }
+        }
+      },
+      responses: {
+        "201": {
+          description: "Subscription created",
+          content: {
+            "application/json": {
+              schema: {
+                type: "object",
+                properties: {
+                  id: { type: "string" },
+                  vendor: { type: "string" },
+                  webhook_url: { type: "string", format: "uri" },
+                  secret: { type: "string", description: "Signs the delivery. Returned only here." },
+                  created_at: { type: "string", format: "date-time" }
+                }
+              }
+            }
+          }
+        },
+        "400": { description: "Body is not JSON, or vendor or webhook_url is missing or not a URL", content: { "application/json": { schema: { type: "object", properties: { error: { type: "string" } } } } } },
+        "409": { description: "The subscription was refused: this vendor and URL are already subscribed, or this URL has reached the cap on vendors it may watch. The error says which.", content: { "application/json": { schema: { type: "object", properties: { error: { type: "string" } } } } } },
+        "503": { description: "The subscription could not be persisted, so it was not created", content: { "application/json": { schema: { type: "object", properties: { error: { type: "string" } } } } } }
+      }
+    },
+    get: {
+      summary: "List watchlist subscriptions",
+      description: "Subscriptions we hold, without their secrets. Pass the webhook URL to see only the subscriptions pointing at it.",
+      parameters: [
+        { name: "webhook_url", in: "query", description: "Return only subscriptions delivering to this URL.", schema: { type: "string", format: "uri" } }
+      ],
+      responses: {
+        "200": {
+          description: "Subscriptions and their count",
+          content: {
+            "application/json": {
+              schema: {
+                type: "object",
+                properties: {
+                  subscriptions: { type: "array", items: { $ref: "#/components/schemas/WatchlistSubscription" } },
+                  total: { type: "integer" }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "/api/watchlist/{id}": {
+    get: {
+      summary: "Read one subscription",
+      description: "The subscription's state, including the last change delivered against it. The secret is not returned.",
+      parameters: [
+        { name: "id", in: "path", required: true, description: "Subscription id, as returned when it was created.", schema: { type: "string" } }
+      ],
+      responses: {
+        "200": {
+          description: "The subscription",
+          content: {
+            "application/json": {
+              schema: {
+                allOf: [
+                  { $ref: "#/components/schemas/WatchlistSubscription" },
+                  { type: "object", properties: { last_notified_change: { type: "string", nullable: true, description: "The last change we delivered on this subscription, or null if none has been." } } }
+                ]
+              }
+            }
+          }
+        },
+        "404": { description: "No subscription with this id", content: { "application/json": { schema: { type: "object", properties: { error: { type: "string" } } } } } }
+      }
+    },
+    delete: {
+      summary: "Unsubscribe",
+      description: "Removes the subscription. Deleting one that is already gone is a 404, not a success.",
+      parameters: [
+        { name: "id", in: "path", required: true, description: "Subscription id.", schema: { type: "string" } }
+      ],
+      responses: {
+        "200": { description: "Removed", content: { "application/json": { schema: { type: "object", properties: { ok: { type: "boolean" } } } } } },
+        "404": { description: "No subscription with this id", content: { "application/json": { schema: { type: "object", properties: { error: { type: "string" } } } } } },
+        "503": { description: "The removal could not be persisted, so it did not take effect", content: { "application/json": { schema: { type: "object", properties: { error: { type: "string" } } } } } }
+      }
+    }
+  },
+  "/api/signal": {
+    post: {
+      summary: "Report a vendor you recommended",
+      description: "The attribution beacon. Tell us which vendor from one of our responses you named in your answer, and whether your user went on to sign up. No authentication. What we record is the vendor slug, the event, and an optional note — notes may be shared verbatim with the vendor named, so send nothing about your user. Counts collected here are published as self-reported and never affect any order we publish. A caller that cannot issue a POST may send the same fields as a query string on a GET to this path with ack=1, which is described at /signal.",
+      requestBody: {
+        required: true,
+        content: {
+          "application/json": {
+            schema: {
+              type: "object",
+              properties: {
+                event: { type: "string", enum: [...SIGNAL_EVENTS], description: "recommended when you named the vendor in an answer; converted when your user signed up. An unrecognised value is still recorded, and the response says it was not recognised." },
+                vendor: { type: "string", description: "The vendor slug, as a response of ours carries it. A name we cannot resolve is recorded unresolved rather than refused." },
+                source: { type: "string" },
+                agent: { type: "string" },
+                agent_id: { type: "string" },
+                note: { type: "string", description: "Optional, and may be shared verbatim with the vendor named." }
+              },
+              required: ["event", "vendor"]
+            },
+            example: { event: "recommended", vendor: "supabase" }
+          },
+          "application/x-www-form-urlencoded": {
+            schema: { type: "object", properties: { event: { type: "string" }, vendor: { type: "string" }, note: { type: "string" } } }
+          }
+        }
+      },
+      responses: {
+        "202": {
+          description: "Recorded",
+          content: {
+            "application/json": {
+              schema: {
+                type: "object",
+                properties: {
+                  ok: { type: "boolean" },
+                  recorded: { type: "string", description: "The event as we stored it." },
+                  vendor: { type: "string", nullable: true },
+                  vendor_resolved: { type: "boolean", description: "Present and false when the name did not resolve to a vendor we hold." },
+                  unresolved_name: { type: "string", description: "Present with vendor_resolved, carrying the name as sent." },
+                  event_recognized: { type: "boolean", description: "Present and false when the event is not one we know." },
+                  valid_events: { type: "array", items: { type: "string" } },
+                  note_received: { type: "boolean" },
+                  note_redacted: { type: "boolean" },
+                  note_published: { type: "boolean" },
+                  agent_id_reserved: { type: "boolean" },
+                  self_reported: { type: "boolean", description: "Always true. Every count here is the caller's own claim and is published as one." },
+                  affects_ranking: { type: "boolean", description: "Always false." },
+                  docs: { type: "string" }
+                }
+              }
+            }
+          }
+        },
+        "400": { description: "event or vendor is missing", content: { "application/json": { schema: { type: "object", properties: { ok: { type: "boolean" }, error: { type: "string" }, hint: { type: "string" }, valid_events: { type: "array", items: { type: "string" } } } } } } },
+        "405": { description: "A method other than POST, or a GET without ack=1", content: { "application/json": { schema: { type: "object", properties: { ok: { type: "boolean" }, error: { type: "string" }, docs: { type: "string" } } } } } },
+        "413": { description: `A body over ${SIGNAL_BODY_MAX} bytes`, content: { "application/json": { schema: { type: "object", properties: { ok: { type: "boolean" }, error: { type: "string" }, max_bytes: { type: "integer" }, docs: { type: "string" } } } } } },
+        "429": { description: `Over ${RATE_LIMIT_PER_MINUTE} requests a minute from one caller. Retry-After carries the wait.`, content: { "application/json": { schema: { type: "object", properties: { ok: { type: "boolean" }, error: { type: "string" }, retry_after_seconds: { type: "integer" }, docs: { type: "string" } } } } } }
+      }
+    }
+  },
+  "/api/openapi.json": {
+    get: {
+      summary: "This document",
+      description: "The OpenAPI 3.0 description of this API. Its path list is built from the same endpoint inventory that renders /developers and the request block on the home page, so a route reachable from either is described here.",
+      responses: {
+        "200": {
+          description: "OpenAPI 3.0 document",
+          content: { "application/json": { schema: { type: "object" } } }
+        }
+      }
+    }
+  },
+  "/api/docs": {
+    get: {
+      summary: "Browsable API reference",
+      description: "Renders this document as a page you can issue requests from.",
+      responses: {
+        "200": {
+          description: "HTML page",
+          content: { "text/html": { schema: { type: "string" } } }
+        }
+      }
+    }
+  }
+};
+
 export const openapiSpec = {
   openapi: "3.0.3",
   info: {
     title: "AgentDeals API",
-    description: "Aggregated free tiers, discounts, and startup programs for developer infrastructure. No authentication required.",
+    description: [
+      "Aggregated free tiers, discounts, and startup programs for developer infrastructure. No authentication is required on any path described here.",
+      `This document's path list is built from the same endpoint inventory that renders /developers and the request block on the home page, so every route either of those offers is described here, read and write alike. The write paths in it are ${writePaths().join(", ")}.`,
+      "Three classes of route answer and are deliberately absent. Routes serving one caller's own state — a registration, a submission, a subscription belonging to whoever created it. Routes serving our own operational counters and editorial registers. And POST /api/agents/register, which mints a key read by features this document does not describe; it is not offered as a public capability.",
+      "Every response carrying index data includes a `_provenance` object, described by the Provenance schema, so a figure can be attributed without parsing a sentence."
+    ].join("\n\n"),
     version: "0.1.0",
     contact: {
       name: "AgentDeals",
@@ -20,927 +1412,54 @@ export const openapiSpec = {
     }
   ],
   security: [],
-  paths: {
-    "/api/offers": {
-      get: {
-        summary: "Search and browse offers",
-        description: "Search vendor offers by keyword and/or category. Returns paginated results.",
-        parameters: [
-          { name: "q", in: "query", description: "Search keyword (matches vendor name, description, category, tags)", schema: { type: "string" }, example: "database" },
-          { name: "category", in: "query", description: "Filter by category name", schema: { type: "string" }, example: "Cloud Hosting" },
-          { name: "limit", in: "query", description: "Max results per page", schema: { type: "integer", default: 20 } },
-          { name: "offset", in: "query", description: "Number of results to skip", schema: { type: "integer", default: 0 } }
-        ],
-        responses: {
-          "200": {
-            description: "Paginated list of offers",
-            content: {
-              "application/json": {
-                schema: {
-                  type: "object",
-                  properties: {
-                    offers: { type: "array", items: { $ref: "#/components/schemas/Offer" } },
-                    total: { type: "integer", description: "Total matching offers (before pagination)" },
-                    gated: { type: "integer", description: "How many of the `total` matching offers carry a non-null `gate` — counted over the whole match, not the returned page (#1241)." },
-                    gate_summary: { type: "string", description: "One line stating how many of the matching offers are not on our ranked list and why. Absent when `gated` is 0." }
-                  }
-                },
-                example: {
-                  offers: [{ vendor: "Supabase", category: "Cloud Hosting", description: "Open-source Firebase alternative with Postgres database, auth, storage, and edge functions. Free tier: 2 projects, 500MB database, 1GB file storage, 50K monthly active users.", tier: "Free", url: "https://supabase.com/pricing", tags: ["database", "auth", "serverless"], verifiedDate: "2026-03-01", gate: null }],
-                  total: 1,
-                  gated: 0
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/categories": {
-      get: {
-        summary: "List all categories",
-        description: "Returns all offer categories with the number of offers in each, the scope statement that says what the name holds, and the other category names that answer the same question. Several names answer one question and hold disjoint sets, so a count alone does not say whether a category is the whole answer: read `also_answering` before deciding a category is empty of what you want. Names in `retired_names` are accepted by `category=` filters and redirect on `/category/`.",
-        responses: {
-          "200": {
-            description: "List of categories with counts, scope statements and the names that answer alongside them",
-            content: {
-              "application/json": {
-                schema: {
-                  type: "object",
-                  properties: {
-                    categories: {
-                      type: "array",
-                      items: {
-                        type: "object",
-                        properties: {
-                          name: { type: "string" },
-                          slug: { type: "string" },
-                          count: { type: "integer" },
-                          audience: { type: "string", enum: ["developer", "personal"], description: "Who the products under this name are sold to." },
-                          holds: { type: "string", enum: ["products", "programmes"], description: "`programmes` means every member is qualified-access — a startup or accelerator offer, not a free tier anyone can open." },
-                          scope: { type: "string", description: "One line saying what this name holds and what it does not." },
-                          answers: { type: "array", items: { type: "string" }, description: "The question or questions this name answers." },
-                          also_answering: {
-                            type: "array",
-                            description: "Other categories answering one of the same questions. Their sets are disjoint from this one.",
-                            items: { type: "object", properties: { name: { type: "string" }, slug: { type: "string" }, count: { type: "integer" } } }
-                          },
-                          example_members: { type: "array", items: { type: "string" } }
-                        }
-                      }
-                    },
-                    example_members_basis: { type: "string" },
-                    retired_names: { type: "object", additionalProperties: { type: "string" }, description: "Category names no longer published, mapped to the name that replaced them." }
-                  }
-                },
-                example: {
-                  categories: [
-                    {
-                      name: "Cloud Storage",
-                      slug: "cloud-storage",
-                      count: 9,
-                      audience: "personal",
-                      holds: "products",
-                      scope: "Consumer file-sync drives a person keeps documents and photos in — not storage an application writes to.",
-                      answers: ["where do my files live"],
-                      also_answering: [
-                        { name: "CDN", slug: "cdn", count: 19 },
-                        { name: "Storage", slug: "storage", count: 55 }
-                      ],
-                      example_members: ["Google Drive", "Google Photos", "iCloud"]
-                    }
-                  ],
-                  retired_names: { "Startup Programs": "Startup Perks" }
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/new": {
-      get: {
-        summary: "Recently added or updated offers",
-        description: "Returns offers where verifiedDate falls within the last N days.",
-        parameters: [
-          { name: "days", in: "query", description: "Number of days to look back (1-30)", schema: { type: "integer", default: 7 }, example: 7 },
-          { name: "limit", in: "query", description: "Max results to return", schema: { type: "integer", default: 50 } }
-        ],
-        responses: {
-          "200": {
-            description: "List of recently verified offers",
-            content: {
-              "application/json": {
-                schema: {
-                  type: "object",
-                  properties: {
-                    offers: { type: "array", items: { $ref: "#/components/schemas/Offer" } },
-                    total: { type: "integer" }
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/newest": {
-      get: {
-        summary: "Newest deals",
-        description: "Returns deals sorted by verified date (newest first) with days_since_update. Use for periodic 'what's new' checks.",
-        parameters: [
-          { name: "since", in: "query", description: "ISO date (YYYY-MM-DD). Only return deals verified after this date. Default: 30 days ago", schema: { type: "string", format: "date" } },
-          { name: "limit", in: "query", description: "Max results (default: 20, max: 50)", schema: { type: "integer", default: 20 } },
-          { name: "category", in: "query", description: "Filter by category name", schema: { type: "string" } }
-        ],
-        responses: {
-          "200": {
-            description: "List of newest deals with days_since_update",
-            content: {
-              "application/json": {
-                schema: {
-                  type: "object",
-                  properties: {
-                    deals: { type: "array", items: { allOf: [{ $ref: "#/components/schemas/Offer" }, { type: "object", properties: { days_since_update: { type: "integer" } } }] } },
-                    total: { type: "integer" }
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/changes": {
-      get: {
-        summary: "Deal and pricing changes",
-        description: "Returns tracked pricing and tier changes across vendors. Filter by date, change type, vendor, or category.",
-        parameters: [
-          { name: "since", in: "query", description: "Filter changes after this date (YYYY-MM-DD)", schema: { type: "string", format: "date" }, example: "2025-01-01" },
-          { name: "type", in: "query", description: "Filter by change type", schema: { type: "string", enum: ["free_tier_removed", "limits_reduced", "restriction", "limits_increased", "new_free_tier", "new_tier", "pricing_restructured", "open_source_killed", "pricing_model_change", "startup_program_expanded", "pricing_postponed", "product_deprecated", "record_corrected"] } },
-          { name: "vendor", in: "query", description: "Filter by vendor name", schema: { type: "string" } },
-          { name: "vendors", in: "query", description: "Comma-separated vendor names to filter by (e.g. 'Vercel,Supabase,Clerk')", schema: { type: "string" }, example: "Vercel,Supabase" },
-          { name: "category", in: "query", description: "Comma-separated category names to filter by (e.g. 'Database,Cloud Hosting'). Case-insensitive partial match.", schema: { type: "string" }, example: "Database,Hosting" },
-          { name: "categories", in: "query", description: "Comma-separated category names to filter by (e.g. 'Database,Cloud Hosting'). Case-insensitive partial match.", schema: { type: "string" }, example: "Database,Hosting" },
-          { name: "limit", in: "query", description: "Max results per page", schema: { type: "integer", default: 20 } },
-          { name: "offset", in: "query", description: "Number of results to skip", schema: { type: "integer", default: 0 } }
-        ],
-        responses: {
-          "200": {
-            description: "List of deal changes",
-            content: {
-              "application/json": {
-                schema: {
-                  type: "object",
-                  properties: {
-                    changes: { type: "array", items: { $ref: "#/components/schemas/DealChange" } },
-                    total: { type: "integer" },
-                    returned: { type: "integer" },
-                    limit: { type: "integer" },
-                    offset: { type: "integer" },
-                    advisory: { type: "array", items: { $ref: "#/components/schemas/DealChange" }, description: "Top 3 high-impact changes outside your filter" },
-                    summary: {
-                      type: "object",
-                      properties: {
-                        stack_changes_count: { type: "integer" },
-                        ecosystem_high_impact_count: { type: "integer" },
-                        period_days: { type: "integer" }
-                      }
-                    }
-                  }
-                },
-                example: {
-                  changes: [{ vendor: "Heroku", change_type: "free_tier_removed", date: "2022-11-28", summary: "Heroku eliminated all free dynos, free Postgres, and free Redis.", previous_state: "Free dyno (550-1000 hrs/mo), free Postgres (10K rows), free Redis (25MB)", current_state: "No free tier. Cheapest plan: $5/mo Eco dyno.", impact: "high", source_url: "https://blog.heroku.com/next-chapter", category: "Cloud Hosting", alternatives: ["Railway", "Render", "Fly.io"] }],
-                  total: 1,
-                  returned: 1,
-                  limit: 20,
-                  offset: 0
-                }
-              }
-            }
-          },
-          "400": {
-            description: "Invalid since parameter",
-            content: {
-              "application/json": {
-                schema: { type: "object", properties: { error: { type: "string" } } }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/details/{vendor}": {
-      get: {
-        summary: "Vendor detail with alternatives",
-        description: "Get detailed information about a specific vendor's offer. Optionally includes alternatives in the same category. Accepts canonical vendor names (e.g. \"Supabase\") or short-form slugs (e.g. \"kiro\" → Amazon Kiro, \"proton\" → multi-product disambiguation). Fuzzy matches resolve in-place and return `resolved_from`. Ambiguous inputs return 200 with a `disambiguation` array instead of an `offer`.",
-        parameters: [
-          { name: "vendor", in: "path", required: true, description: "Vendor name or short-form slug (URL-encoded)", schema: { type: "string" }, example: "Supabase" },
-          { name: "alternatives", in: "query", description: "Include alternative vendors in the same category", schema: { type: "string", enum: ["true", "false"], default: "false" } }
-        ],
-        responses: {
-          "200": {
-            description: "Vendor offer details, OR a disambiguation list when the input matches multiple vendors (e.g. \"proton\"). When the input was fuzzy-matched to a canonical vendor, the response includes `resolved_from`.",
-            content: {
-              "application/json": {
-                schema: {
-                  oneOf: [
-                    {
-                      type: "object",
-                      description: "Resolved vendor offer",
-                      properties: {
-                        offer: { $ref: "#/components/schemas/Offer" },
-                        alternatives: { type: "array", items: { $ref: "#/components/schemas/Offer" }, description: "Only present when alternatives=true" },
-                        resolved_from: { type: "string", description: "Original input when fuzzy-matched to a canonical vendor (e.g. input \"kiro\" resolves to Amazon Kiro)" }
-                      }
-                    },
-                    {
-                      type: "object",
-                      description: "Disambiguation list when input matches multiple vendors",
-                      required: ["disambiguation", "resolved_from"],
-                      properties: {
-                        disambiguation: { type: "array", items: { type: "object", properties: { slug: { type: "string" }, name: { type: "string" } } } },
-                        resolved_from: { type: "string" }
-                      }
-                    }
-                  ]
-                }
-              }
-            }
-          },
-          "400": {
-            description: "Missing vendor name",
-            content: {
-              "application/json": {
-                schema: { type: "object", properties: { error: { type: "string" } } }
-              }
-            }
-          },
-          "404": {
-            description: "Vendor not found (no exact match AND no fuzzy resolution)",
-            content: {
-              "application/json": {
-                schema: {
-                  type: "object",
-                  properties: {
-                    error: { type: "string" },
-                    suggestions: { type: "array", items: { type: "string" }, description: "Similar vendor names" }
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/compare": {
-      get: {
-        summary: "Compare two vendors side by side",
-        description: "Returns a structured comparison of two developer tool vendors including free tier details, pricing, and recent deal changes.",
-        parameters: [
-          { name: "a", in: "query", required: true, description: "First vendor name (case-insensitive; a qualified name such as 'Supabase database' resolves to the vendor it names, see VendorMatch)", schema: { type: "string" }, example: "Supabase" },
-          { name: "b", in: "query", required: true, description: "Second vendor name (case-insensitive; a qualified name such as 'Neon free tier' resolves to the vendor it names, see VendorMatch)", schema: { type: "string" }, example: "Neon" }
-        ],
-        responses: {
-          "200": {
-            description: "Side-by-side vendor comparison",
-            content: {
-              "application/json": {
-                schema: {
-                  type: "object",
-                  properties: {
-                    vendor_a: { $ref: "#/components/schemas/Offer" },
-                    vendor_b: { $ref: "#/components/schemas/Offer" },
-                    vendor_a_match: { $ref: "#/components/schemas/VendorMatch" },
-                    vendor_b_match: { $ref: "#/components/schemas/VendorMatch" },
-                    shared_categories: { type: "boolean" },
-                    category_overlap: { type: "array", items: { type: "string" } }
-                  }
-                }
-              }
-            }
-          },
-          "400": {
-            description: "Missing required parameters",
-            content: {
-              "application/json": {
-                schema: { type: "object", properties: { error: { type: "string" } } }
-              }
-            }
-          },
-          "404": {
-            description: "One or both vendors not found",
-            content: {
-              "application/json": {
-                schema: {
-                  type: "object",
-                  properties: {
-                    error: { type: "string" },
-                    suggestions_a: { type: "array", items: { type: "string" } },
-                    suggestions_b: { type: "array", items: { type: "string" } }
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/audit-stack": {
-      get: {
-        summary: "Audit your infrastructure stack",
-        description: "Analyze your current services for pricing risks, cost savings, and missing capabilities. Returns per-service risk assessment, cheaper alternatives, and gap analysis.",
-        parameters: [
-          { name: "services", in: "query", required: true, description: "Comma-separated vendor names (e.g. 'Vercel,Supabase,Clerk'). An audit reports only names it matched exactly; anything else comes back as status not_found with suggestions, so that risks_found and cheaper_alternative are never computed for a product you did not name (#1269).", schema: { type: "string" }, example: "Vercel,Supabase,Clerk" }
-        ],
-        responses: {
-          "200": {
-            description: "Stack audit results",
-            content: {
-              "application/json": {
-                schema: {
-                  type: "object",
-                  properties: {
-                    services_analyzed: { type: "number" },
-                    risks_found: { type: "number" },
-                    savings_opportunities: { type: "number" },
-                    gaps: { type: "array", items: { type: "object" } },
-                    services: { type: "array", items: { type: "object" } },
-                    recommendations: { type: "array", items: { type: "string" } }
-                  }
-                }
-              }
-            }
-          },
-          "400": {
-            description: "Missing services parameter",
-            content: {
-              "application/json": {
-                schema: { type: "object", properties: { error: { type: "string" } } }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/vendor-risk/{vendor}": {
-      get: {
-        summary: "Check vendor pricing stability and risk",
-        description: "Before depending on a vendor's free tier, check if their pricing is stable. Returns risk level (stable/caution/risky), pricing change history, free tier longevity, and more-stable alternatives.",
-        parameters: [
-          { name: "vendor", in: "path", required: true, description: "Vendor name (case-insensitive; a qualified name such as 'Vercel Pro plan' resolves to the vendor it names, see VendorMatch)", schema: { type: "string" }, example: "Vercel" }
-        ],
-        responses: {
-          "200": {
-            description: "Vendor risk assessment",
-            content: {
-              "application/json": {
-                schema: {
-                  type: "object",
-                  properties: {
-                    vendor: { type: "string" },
-                    vendor_match: { $ref: "#/components/schemas/VendorMatch" },
-                    category: { type: "string" },
-                    risk_level: { type: "string", enum: ["stable", "caution", "risky"], nullable: true, description: "Null where the offer's own link is confirmed unreachable (#1046) — we withhold the level rather than publish a favourable one we cannot check. Also null where gate is non-null (#1241): an offer we have decided not to list is not one we rate. Also null where rating_withheld is non-null (#1352): the only records that would rate this vendor cite no source." },
-                    link_unreachable: { type: "object", nullable: true, description: "Non-null only where a check reached a conclusion about the destination: a 404 confirmed by a full request, a 410, or a hostname with no address. Being refused (403, 429, 5xx, timeout) is evidence about our checker and never produces one of these.", properties: { last_reachable: { type: "string", format: "date", nullable: true }, checked: { type: "string", format: "date" }, terminal: { type: "boolean" } } },
-                    risk_cause: { type: "object", nullable: true, description: "The single dated record that produced a non-stable risk_level. Never null when risk_level is caution or risky (#1038) — a client that renders the level must be able to render the reason.", properties: { vendor: { type: "string" }, date: { type: "string" }, change_type: { type: "string" }, summary: { type: "string" }, source_url: { type: "string", nullable: true, description: "The page this record was read from, or null where we hold none. Carried on the cause so a client rendering the reason can cite it." }, current_state: { type: "string" }, resolution: { $ref: "#/components/schemas/ChangeResolution" } } },
-                    rating_withheld: { type: "object", nullable: true, description: "Non-null where every record that would have set a non-stable risk_level carries an empty source_url (#1352). The level is withheld rather than reported as stable, and the records are named on the vendor page marked as unsourced.", properties: { reason: { type: "string", enum: ["no_source"] }, records: { type: "number" } } },
-                    gate: { $ref: "#/components/schemas/Gate" },
-                    source_check: { $ref: "#/components/schemas/SourceCheck" },
-                    free_tier_longevity_days: { type: "number", nullable: true, description: "Null where the gate code is offer_retired or not_a_free_offer (#1241) — a count of days a free tier has held has no referent where our own record says there is no free tier." },
-                    changes: { type: "array", items: { $ref: "#/components/schemas/DealChange" } },
-                    alternatives: {
-                      type: "array",
-                      items: {
-                        type: "object",
-                        properties: {
-                          vendor: { type: "string" },
-                          category: { type: "string" },
-                          tier: { type: "string" },
-                          risk_level: { type: "string", enum: ["stable", "caution", "risky"], nullable: true, description: "Null where this alternative's own link is confirmed unreachable (#1046), and null where its gate is non-null (#1241) — rankForListing demotes a gated record to the tail rather than dropping it, so an alternative can be one we do not list." },
-                          link_unreachable: { type: "object", nullable: true, properties: { last_reachable: { type: "string", format: "date", nullable: true }, checked: { type: "string", format: "date" }, terminal: { type: "boolean" } } },
-                          gate: { $ref: "#/components/schemas/Gate" },
-                          risk_cause: { type: "object", nullable: true, description: "The single dated record that produced a non-stable risk_level. Never null when risk_level is caution or risky (#1038) — a client that renders the level must be able to render the reason.", properties: { vendor: { type: "string" }, date: { type: "string" }, change_type: { type: "string" }, summary: { type: "string" }, source_url: { type: "string", nullable: true, description: "The page this record was read from, or null where we hold none. Carried on the cause so a client rendering the reason can cite it." }, current_state: { type: "string" }, resolution: { $ref: "#/components/schemas/ChangeResolution" } } },
-                          rating_withheld: { type: "object", nullable: true, description: "Non-null where every record that would have set a non-stable risk_level carries an empty source_url (#1352). The level is withheld rather than reported as stable.", properties: { reason: { type: "string", enum: ["no_source"] }, records: { type: "number" } } }
-                        }
-                      }
-                    },
-                    summary: { type: "string" }
-                  }
-                }
-              }
-            }
-          },
-          "404": {
-            description: "Vendor not found",
-            content: {
-              "application/json": {
-                schema: {
-                  type: "object",
-                  properties: {
-                    error: { type: "string" },
-                    suggestions: { type: "array", items: { type: "string" } }
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/expiring": {
-      get: {
-        summary: "Get expiring deals",
-        description: "Check which developer tool deals, free tiers, or credits are expiring soon. Returns deals sorted by expiration date (soonest first).",
-        parameters: [
-          { name: "within_days", in: "query", description: "Number of days to look ahead (default: 30, max: 365)", schema: { type: "integer", default: 30, minimum: 1, maximum: 365 } }
-        ],
-        responses: {
-          "200": {
-            description: "Expiring deals",
-            content: {
-              "application/json": {
-                schema: {
-                  type: "object",
-                  properties: {
-                    deals: {
-                      type: "array",
-                      items: {
-                        type: "object",
-                        properties: {
-                          vendor: { type: "string" },
-                          category: { type: "string" },
-                          description: { type: "string" },
-                          tier: { type: "string" },
-                          url: { type: "string", format: "uri" },
-                          expires_date: { type: "string", format: "date" },
-                          days_until_expiry: { type: "integer" }
-                        }
-                      }
-                    },
-                    total: { type: "integer" }
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/freshness": {
-      get: {
-        summary: "Get data freshness metrics",
-        description: "Returns data quality metrics including freshness score, verification age breakdowns, stalest/freshest entries, and per-category freshness.",
-        parameters: [],
-        responses: {
-          "200": {
-            description: "Data freshness metrics",
-            content: {
-              "application/json": {
-                schema: {
-                  type: "object",
-                  properties: {
-                    total_offers: { type: "integer" },
-                    verified_within_7_days: { type: "integer" },
-                    verified_within_30_days: { type: "integer" },
-                    verified_within_90_days: { type: "integer" },
-                    verified_within_180_days: { type: "integer" },
-                    freshness_score: { type: "integer", description: "Percentage of offers verified within 90 days" },
-                    stalest_entries: {
-                      type: "array",
-                      items: {
-                        type: "object",
-                        properties: {
-                          vendor: { type: "string" },
-                          category: { type: "string" },
-                          verifiedDate: { type: "string", format: "date" },
-                          url: { type: "string", format: "uri" },
-                          days_since_verified: { type: "integer" }
-                        }
-                      }
-                    },
-                    freshest_entries: {
-                      type: "array",
-                      items: {
-                        type: "object",
-                        properties: {
-                          vendor: { type: "string" },
-                          category: { type: "string" },
-                          verifiedDate: { type: "string", format: "date" },
-                          url: { type: "string", format: "uri" },
-                          days_since_verified: { type: "integer" }
-                        }
-                      }
-                    },
-                    by_category: {
-                      type: "array",
-                      items: {
-                        type: "object",
-                        properties: {
-                          category: { type: "string" },
-                          count: { type: "integer" },
-                          avg_days_since_verified: { type: "integer" },
-                          freshness_score: { type: "integer" }
-                        }
-                      }
-                    },
-                    quarantine: {
-                      type: "object",
-                      description: "Offers the re-verification job has stopped checking daily because three consecutive checks failed. They are retried on a backoff; the entry says what failed and when it is next due.",
-                      properties: {
-                        count: { type: "integer" },
-                        retry_after_days: { type: "integer" },
-                        by_reason: { type: "object", additionalProperties: { type: "integer" } },
-                        entries: {
-                          type: "array",
-                          items: {
-                            type: "object",
-                            properties: {
-                              vendor: { type: "string" },
-                              url: { type: "string", format: "uri" },
-                              consecutive_failures: { type: "integer" },
-                              failure_category: { type: "string", nullable: true },
-                              last_error: { type: "string", nullable: true },
-                              last_attempt_at: { type: "string", format: "date", nullable: true },
-                              last_success: { type: "string", format: "date", nullable: true },
-                              quarantined_since: { type: "string", format: "date", nullable: true },
-                              next_retry: { type: "string", format: "date", nullable: true }
-                            }
-                          }
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/digest": {
-      get: {
-        summary: "Get weekly pricing digest",
-        description: "Curated weekly summary of developer tool pricing changes, new offers, and upcoming deadlines. Falls back to 30-day window if fewer than 3 changes in the past week.",
-        parameters: [],
-        responses: {
-          "200": {
-            description: "Weekly digest",
-            content: {
-              "application/json": {
-                schema: {
-                  type: "object",
-                  properties: {
-                    week: { type: "string", description: "Week date range" },
-                    date_range: { type: "string", description: "ISO date range" },
-                    deal_changes: {
-                      type: "array",
-                      items: {
-                        type: "object",
-                        properties: {
-                          vendor: { type: "string" },
-                          change_type: { type: "string" },
-                          date: { type: "string", format: "date", description: "When the change took effect, unless date_source is \"discovered\" — then it is the day we found it and the effective date is unknown." },
-                          date_source: { type: "string", enum: ["vendor_page", "hand_written", "discovered"], description: "Where date came from. \"vendor_page\": the vendor's page stated it. \"hand_written\": a person recorded it before this field existed. \"discovered\": the page stated no effective date, so date is the day we read the page — do not present it as the date the vendor changed anything." },
-                          summary: { type: "string" },
-                          impact: { type: "string", enum: ["high", "medium", "low"] }
-                        }
-                      }
-                    },
-                    new_offers: {
-                      type: "array",
-                      items: {
-                        type: "object",
-                        properties: {
-                          vendor: { type: "string" },
-                          category: { type: "string" },
-                          description: { type: "string" }
-                        }
-                      }
-                    },
-                    upcoming_deadlines: {
-                      type: "array",
-                      items: {
-                        type: "object",
-                        properties: {
-                          vendor: { type: "string" },
-                          expires_date: { type: "string", format: "date" },
-                          days_until_expiry: { type: "integer" }
-                        }
-                      }
-                    },
-                    summary: { type: "string", description: "One-paragraph summary of the week" }
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/stack": {
-      get: {
-        summary: "Get free-tier stack candidates per role",
-        description: "For each role in your project type (hosting, database, auth, …) returns the set of free-tier offers whose terms we can stand behind today — deliberately not a single pick, because under every signal we record dozens of them tie. Each candidate carries its demerits, with the recorded fact and date behind each, plus any recorded changes we disclose but do not rank on. This endpoint does NOT model technical fit between a product and a role; the caller must apply that. The method is published at /criteria, and every role returns the tie_break seed so its order can be recomputed independently.",
-        parameters: [
-          { name: "use_case", in: "query", required: true, description: "What you're building (e.g., 'Next.js SaaS app', 'API backend', 'static blog')", schema: { type: "string" }, example: "Next.js SaaS app" },
-          { name: "requirements", in: "query", description: "Comma-separated infrastructure needs (e.g., 'database,auth,email')", schema: { type: "string" }, example: "database,auth,email" }
-        ],
-        responses: {
-          "200": {
-            description: "Candidate sets per role, with the evidence behind each",
-            content: {
-              "application/json": {
-                schema: {
-                  type: "object",
-                  properties: {
-                    use_case: { type: "string" },
-                    stack: {
-                      type: "array",
-                      items: {
-                        type: "object",
-                        properties: {
-                          role: { type: "string" },
-                          category: { type: "string" },
-                          candidates: {
-                            type: "array",
-                            description: "The rotated tied set for this role, capped at 8. Not ordered by merit — every member is indistinguishable under our criteria.",
-                            items: {
-                              type: "object",
-                              properties: {
-                                vendor: { type: "string" },
-                                tier: { type: "string" },
-                                description: { type: "string" },
-                                url: { type: "string", format: "uri" },
-                                verified_date: { type: "string", format: "date" },
-                                demerits: { type: "array", description: "Empty when we hold nothing against the offer.", items: { type: "object", properties: { code: { type: "string" }, points: { type: "integer" }, reason: { type: "string" }, date: { type: "string" }, about_us: { type: "boolean", description: "True when the demerit describes a limit of ours rather than a fact about the vendor." } } } },
-                                disclosures: { type: "array", description: "Recorded changes shown but never ranked on.", items: { type: "object", properties: { code: { type: "string" }, date: { type: "string" }, summary: { type: "string" } } } }
-                              }
-                            }
-                          },
-                          tie_count: { type: "integer", description: "How many offers tie at zero demerits in this role." },
-                          eligible_count: { type: "integer" },
-                          demoted_count: { type: "integer" },
-                          excluded_count: { type: "integer" },
-                          reason: { type: "string" },
-                          tie_break: { type: "object", properties: { date: { type: "string" }, query_key: { type: "string" }, seed: { type: "string" }, tie_count: { type: "integer" }, algorithm: { type: "string" } } }
-                        }
-                      }
-                    },
-                    method: { type: "object", properties: { policy: { type: "string" }, not_modelled: { type: "string" }, criteria_url: { type: "string" } } },
-                    total_monthly_cost: { type: "string" },
-                    limitations: { type: "array", items: { type: "string" } },
-                    upgrade_path: { type: "string" }
-                  }
-                }
-              }
-            }
-          },
-          "400": {
-            description: "Missing use_case parameter",
-            content: {
-              "application/json": {
-                schema: { type: "object", properties: { error: { type: "string" } } }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/query-log": {
-      get: {
-        summary: "Recent request log",
-        description: "Returns recent request-level log entries for both MCP tool calls and REST API hits. Stored in Redis, capped at 1000 entries. Query parameter values are not published: each entry reports the parameter names it carried and the length of each value. Session identifiers are not published either; entries from one session share a session_index that is assigned within a single response and carries no meaning across responses.",
-        parameters: [
-          { name: "limit", in: "query", description: "Number of entries to return (1-200)", schema: { type: "integer", default: 50 } }
-        ],
-        responses: {
-          "200": {
-            description: "Recent request log entries",
-            content: {
-              "application/json": {
-                schema: {
-                  type: "object",
-                  properties: {
-                    entries: {
-                      type: "array",
-                      items: {
-                        type: "object",
-                        properties: {
-                          ts: { type: "string", format: "date-time" },
-                          type: { type: "string", enum: ["mcp", "api", "session_connect"] },
-                          endpoint: { type: "string" },
-                          param_lengths: {
-                            type: "object",
-                            description: "Parameter name to the character length of the value that was sent. Values themselves are retained internally and never published.",
-                            additionalProperties: { type: "integer" }
-                          },
-                          user_agent: { type: "string" },
-                          result_count: { type: "integer" },
-                          session_index: { type: "integer", description: "Groups entries from the same session within this response only." },
-                          client_info: {
-                            type: "object",
-                            properties: { name: { type: "string" }, version: { type: "string" } }
-                          }
-                        }
-                      }
-                    },
-                    count: { type: "integer" }
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/costs": {
-      get: {
-        summary: "Estimate infrastructure costs",
-        description: "Estimate monthly costs for a stack of services at different scales. Shows free tier limits, when you'd exceed them, and projected costs.",
-        parameters: [
-          { name: "services", in: "query", required: true, description: "Comma-separated list of vendor names", schema: { type: "string" }, example: "Vercel,Supabase,Clerk" },
-          { name: "scale", in: "query", description: "Usage scale tier", schema: { type: "string", enum: ["hobby", "startup", "growth"], default: "hobby" } }
-        ],
-        responses: {
-          "200": {
-            description: "Cost estimates per service and total",
-            content: {
-              "application/json": {
-                schema: {
-                  type: "object",
-                  properties: {
-                    scale: { type: "string", description: "Scale tier used for estimation" },
-                    services: {
-                      type: "array",
-                      items: {
-                        type: "object",
-                        properties: {
-                          vendor: { type: "string" },
-                          free_tier: { type: "string" },
-                          estimated_monthly: { type: "string" },
-                          notes: { type: "string" }
-                        }
-                      }
-                    },
-                    total_estimated_monthly: { type: "string" }
-                  }
-                }
-              }
-            }
-          },
-          "400": { description: "Missing services parameter or invalid scale" }
-        }
-      }
-    },
-    "/feed.xml": {
-      get: {
-        summary: "Atom feed of pricing changes",
-        description: "Atom feed of developer tool pricing changes. Subscribe in any feed reader to stay updated on free tier removals, limit changes, and new deals. Also available at /api/feed.",
-        responses: {
-          "200": {
-            description: "Atom XML feed",
-            content: {
-              "application/atom+xml": {
-                schema: { type: "string", format: "binary" }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/pageviews": {
-      get: {
-        summary: "Page view analytics",
-        description: "Returns server-side page view counts for today, yesterday, all-time top pages, and referrer breakdown. Bot traffic is excluded.",
-        responses: {
-          "200": {
-            description: "Page view data",
-            content: {
-              "application/json": {
-                schema: {
-                  type: "object",
-                  properties: {
-                    today: {
-                      type: "object",
-                      properties: {
-                        total: { type: "integer" },
-                        top_pages: { type: "array", items: { type: "object", properties: { path: { type: "string" }, views: { type: "integer" } } } }
-                      }
-                    },
-                    yesterday: {
-                      type: "object",
-                      properties: {
-                        total: { type: "integer" },
-                        top_pages: { type: "array", items: { type: "object", properties: { path: { type: "string" }, views: { type: "integer" } } } }
-                      }
-                    },
-                    all_time: {
-                      type: "object",
-                      properties: {
-                        total: { type: "integer" },
-                        top_pages: { type: "array", items: { type: "object", properties: { path: { type: "string" }, views: { type: "integer" } } } }
-                      }
-                    },
-                    referrers_today: { type: "object", additionalProperties: { type: "integer" } }
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/referral-codes": {
-      get: {
-        summary: "List every referral code we hold",
-        description: "Returns every active referral code AgentDeals holds, with the reader benefit and every restriction on each. No authentication required. Filter by vendor category. Individual vendor lookup: GET /api/referral-codes/{vendor}. Agent-submitted codes are retired: source=agent answers 200 with an empty list and the reason.",
-        parameters: [
-          { name: "source", in: "query", description: "platform returns the codes we hold, which is every code we serve. agent is retired and returns an empty list with the reason.", schema: { type: "string", enum: ["platform", "agent"] } },
-          { name: "category", in: "query", description: "Filter by vendor category slug (e.g. cloud-hosting). See /api/categories for valid slugs.", schema: { type: "string" }, example: "cloud-hosting" }
-        ],
-        responses: {
-          "200": {
-            description: "Active referral codes across all vendors",
-            content: {
-              "application/json": {
-                schema: {
-                  type: "object",
-                  properties: {
-                    codes: { type: "array", items: { $ref: "#/components/schemas/ReferralCodeListing" } },
-                    total: { type: "integer" }
-                  },
-                  required: ["codes", "total"]
-                },
-                example: {
-                  codes: [
-                    { vendor: "Railway", category: "Cloud Hosting", code: "7RZL9q", referral_url: "https://railway.com?referralCode=7RZL9q", referee_benefit: "$20 in credits", restrictions: [], source: "platform" }
-                  ],
-                  total: 1
-                }
-              }
-            }
-          },
-          "400": {
-            description: "Invalid source or unknown category slug",
-            content: { "application/json": { schema: { type: "object", properties: { error: { type: "string" } } } } }
-          }
-        }
-      }
-    },
-    "/api/referral-codes/{vendor}": {
-      get: {
-        summary: "Get best referral code for a vendor",
-        description: "Returns the referral code AgentDeals holds for a vendor, or 404 when we hold none. Same shape is inlined on /api/offers, /api/compare, /api/details/{vendor}, /api/newest, and MCP tool responses.",
-        parameters: [
-          { name: "vendor", in: "path", required: true, description: "Vendor name (case-insensitive)", schema: { type: "string" }, example: "Railway" }
-        ],
-        responses: {
-          "200": {
-            description: "Best available referral code",
-            content: {
-              "application/json": {
-                schema: { $ref: "#/components/schemas/ReferralCodeListing" },
-                example: { vendor: "Railway", code: "7RZL9q", referral_url: "https://railway.com?referralCode=7RZL9q", referee_benefit: "$20 in credits", restrictions: [], source: "platform" }
-              }
-            }
-          },
-          "404": { description: "No active referral codes for the requested vendor", content: { "application/json": { schema: { type: "object", properties: { error: { type: "string" } } } } } }
-        }
-      }
-    },
-    "/api/stats": {
-      get: {
-        summary: "Service statistics",
-        description: "Returns connection and usage statistics. Session and usage counts persist across deploys via Redis.",
-        responses: {
-          "200": {
-            description: "Service statistics",
-            content: {
-              "application/json": {
-                schema: {
-                  type: "object",
-                  properties: {
-                    activeSessions: { type: "integer", description: "Currently connected MCP sessions" },
-                    totalSessionsAllTime: { type: "integer", description: "Cumulative sessions across all deploys (persisted in Redis)" },
-                    totalApiHitsAllTime: { type: "integer", description: "Cumulative REST API hits across all deploys (persisted in Redis)" },
-                    totalToolCallsAllTime: { type: "integer", description: "Cumulative MCP tool calls across all deploys (persisted in Redis)" },
-                    sessionsToday: { type: "integer", description: "Sessions opened since midnight UTC. Persisted per day, so a deploy does not reset it. Counts only from the date the daily series began — see sessions.recording_since on /api/traffic." },
-                    serverStarted: { type: "string", format: "date-time", description: "ISO timestamp of current server start" },
-                    clients: { type: "object", additionalProperties: { type: "integer" }, description: "Cumulative session counts per MCP client name (e.g. claude-desktop, cursor)" },
-                    toolCallsByClient: { type: "object", additionalProperties: { type: "integer" }, description: "Cumulative MCP tool-call counts per MCP client name. Missing/empty client IDs bucket to 'unknown'. Values sum to totalToolCallsAllTime (invariant)." },
-                    toolCallsByName: { type: "object", additionalProperties: { type: "integer" }, description: "Cumulative MCP tool-call counts per tool name (search_deals, plan_stack, compare_vendors, track_changes, register_agent, get_referral_code, check_balance, request_payout). Pre-feature historical calls bucket to 'unknown'. Values sum to totalToolCallsAllTime (invariant)." }
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
-    }
-  },
+  paths: pathsFor(),
   components: {
     schemas: {
+      Provenance: {
+        type: "object",
+        description: "Where the figures in this response came from and how to attribute them. Every response carrying index data has one, under the key `_provenance`. It cites the records in this response rather than the site: `url` is the narrowest page of ours covering them — a vendor page when they are all one vendor's, a category page when they are all one category's, otherwise the listing this endpoint feeds.",
+        properties: {
+          source: { type: "string", description: "Always AgentDeals." },
+          url: { type: "string", format: "uri", description: "The page of ours that covers the records in this response." },
+          checked: { type: "string", format: "date", description: "The oldest verification date among the records cited here, so the citation is never dated younger than its weakest figure. Absent when no record in the response carries a date." },
+          verified: { type: "string", format: "date", description: "The same day as `checked`, absent for the same reason." },
+          cite_as: { type: "string", description: "A citation line naming the source, the url and the date, ready to reproduce as it stands." },
+          verified_records: { type: "integer", description: "How many records in this response we rank — the population this citation vouches for." },
+          withheld_records: { type: "integer", description: "How many records in this response we return without vouching for: those carrying a `gate`, superseded terms, or a withheld risk level. Absent when there are none." },
+          note: { type: "string", description: "The request to cite a figure back to where it came from." },
+          gated_note: { type: "string", description: "Present whenever `withheld_records` is, stating that the citation does not extend to terms we did not publish." },
+          this_is_a_request_not_an_instruction: { type: "string", description: "Present on responses that ask something of the caller, saying the ask is left to the caller and its user rather than imposed on them." }
+        },
+        required: ["source", "url", "cite_as", "verified_records", "note"]
+      },
+      TrafficWindow: {
+        type: "object",
+        description: "Request counts over one window. `coverage` says how much of the window we hold data for, so a low figure can be read as quiet rather than as unrecorded.",
+        properties: {
+          days: { type: "integer" },
+          from: { type: "string", format: "date" },
+          to: { type: "string", format: "date" },
+          detail_days: { type: "integer" },
+          data_days_available: { type: "integer" },
+          coverage: { type: "string" },
+          hits_total: { type: "integer" },
+          hits_excluding_internal: { type: "integer", description: "Hits with our own crawling removed." },
+          by_class: { type: "object", additionalProperties: { type: "integer" }, description: "Hits per client class." },
+          ai_agent_by_family: { type: "object", additionalProperties: { type: "integer" } },
+          ai_agent_by_trigger: { type: "object", additionalProperties: { type: "integer" }, description: "AI-agent hits split by whether a person asked for them." }
+        }
+      },
+      WatchlistSubscription: {
+        type: "object",
+        description: "A registered webhook. The signing secret is returned once, when the subscription is created, and never again.",
+        properties: {
+          id: { type: "string" },
+          vendor: { type: "string" },
+          webhook_url: { type: "string", format: "uri" },
+          created_at: { type: "string", format: "date-time" }
+        },
+        required: ["id", "vendor", "webhook_url", "created_at"]
+      },
       Offer: {
         type: "object",
         properties: {
@@ -1032,7 +1551,7 @@ export const openapiSpec = {
         type: "object",
         properties: {
           vendor: { type: "string" },
-          change_type: { type: "string", enum: ["free_tier_removed", "limits_reduced", "restriction", "limits_increased", "new_free_tier", "new_tier", "pricing_restructured", "open_source_killed", "pricing_model_change", "startup_program_expanded", "pricing_postponed", "product_deprecated", "rebranded", "record_corrected"] },
+          change_type: { type: "string", enum: [...CHANGE_TYPES] },
           reports: { type: "string", enum: ["vendor_offer", "our_index"], description: "What the record is about. 'vendor_offer' — the vendor changed its own offer, and a vendor page is where that can be read. 'our_index' — we changed what we list while the vendor's offer stood still, so no vendor page evidences it and the record carries no source_url. Absent means vendor_offer. Filter these out of any figure you present as vendor market activity." },
           date: { type: "string", format: "date" },
           summary: { type: "string" },
@@ -1062,3 +1581,112 @@ export const openapiSpec = {
     }
   }
 };
+
+function specPathFor(path: string): string {
+  return path.replace(/:([A-Za-z_]+)/g, "{$1}");
+}
+
+function operationKey(endpoint: ApiEndpoint): string {
+  return `${endpoint.method} ${specPathFor(endpoint.path)}`;
+}
+
+function writePaths(): string[] {
+  return API_ENDPOINTS.filter((endpoint) => endpoint.method !== "GET").map(operationKey);
+}
+
+function namedParams(spec: string): { name: string; note: string | null }[] {
+  const pieces: string[] = [];
+  let depth = 0;
+  let current = "";
+  for (const ch of spec) {
+    if (ch === "(") depth += 1;
+    if (ch === ")") depth -= 1;
+    if (ch === "," && depth === 0) { pieces.push(current); current = ""; continue; }
+    current += ch;
+  }
+  pieces.push(current);
+  return pieces
+    .map((piece) => piece.trim().match(/^([A-Za-z_][A-Za-z0-9_]*)\s*(?:\(([^)]*)\))?$/))
+    .filter((match): match is RegExpMatchArray => match !== null)
+    .map((match) => ({ name: match[1], note: match[2] ?? null }));
+}
+
+function derivedOperation(endpoint: ApiEndpoint): Record<string, any> {
+  const params = endpoint.params.trim() ? namedParams(endpoint.params) : [];
+  const query = endpoint.method === "GET" ? params.filter((p) => p.note !== "body") : [];
+  const body = params.filter((p) => p.note === "body");
+  const operation: Record<string, any> = {
+    summary: endpoint.desc,
+    description: `${endpoint.desc}. This route is served and carried in our endpoint inventory; its response has not been described here yet, so treat the shape as undocumented rather than empty.`,
+    responses: { "200": { description: endpoint.desc } },
+  };
+  if (query.length > 0) {
+    operation.parameters = query.map((p) => ({
+      name: p.name,
+      in: "query",
+      ...(p.note ? { description: p.note } : {}),
+      schema: { type: "string" },
+    }));
+  }
+  if (body.length > 0) {
+    operation.requestBody = {
+      required: true,
+      content: { "application/json": { schema: { type: "object", properties: Object.fromEntries(body.map((p) => [p.name, { type: "string" }])) } } },
+    };
+  }
+  return operation;
+}
+
+function citedSchema(schema: Record<string, any>): Record<string, any> {
+  const citation = { type: "object", properties: { _provenance: { $ref: PROVENANCE_REF } }, required: ["_provenance"] };
+  if (Array.isArray(schema.allOf)) return { ...schema, allOf: [...schema.allOf, citation] };
+  if (schema.properties) return { ...schema, properties: { ...schema.properties, _provenance: { $ref: PROVENANCE_REF } } };
+  return { allOf: [schema, citation] };
+}
+
+function withCitation(operation: Record<string, any>): Record<string, any> {
+  const json = operation.responses?.["200"]?.content?.["application/json"];
+  if (!json?.schema) return operation;
+  return {
+    ...operation,
+    responses: {
+      ...operation.responses,
+      "200": {
+        ...operation.responses["200"],
+        content: { ...operation.responses["200"].content, "application/json": { ...json, schema: citedSchema(json.schema) } },
+      },
+    },
+  };
+}
+
+export function endpointsDescribedFromTheInventoryAlone(endpoints: readonly ApiEndpoint[] = API_ENDPOINTS): string[] {
+  return endpoints
+    .filter((endpoint) => DOCUMENTED_OPERATIONS[specPathFor(endpoint.path)]?.[endpoint.method.toLowerCase()] === undefined)
+    .map(operationKey);
+}
+
+export function documentedOperationsNoEndpointServes(endpoints: readonly ApiEndpoint[] = API_ENDPOINTS): string[] {
+  const served = new Set(endpoints.map(operationKey));
+  const alias = new Set(Object.keys(PATHS_OUTSIDE_THE_ENDPOINT_INVENTORY));
+  return Object.entries(DOCUMENTED_OPERATIONS)
+    .filter(([path]) => !alias.has(path))
+    .flatMap(([path, methods]) => Object.keys(methods).map((method) => `${method.toUpperCase()} ${path}`))
+    .filter((key) => !served.has(key));
+}
+
+export function pathsFor(endpoints: readonly ApiEndpoint[] = API_ENDPOINTS): Record<string, Record<string, any>> {
+  const paths: Record<string, Record<string, any>> = {};
+  for (const endpoint of endpoints) {
+    const path = specPathFor(endpoint.path);
+    const method = endpoint.method.toLowerCase();
+    const written = DOCUMENTED_OPERATIONS[path]?.[method];
+    const operation = written ? structuredClone(written) : derivedOperation(endpoint);
+    paths[path] = paths[path] ?? {};
+    paths[path][method] = endpoint.cites ? withCitation(operation) : operation;
+  }
+  for (const path of Object.keys(PATHS_OUTSIDE_THE_ENDPOINT_INVENTORY)) {
+    const written = DOCUMENTED_OPERATIONS[path];
+    if (written) paths[path] = structuredClone(written);
+  }
+  return paths;
+}

--- a/src/serve.ts
+++ b/src/serve.ts
@@ -49293,6 +49293,12 @@ function buildDeveloperHubPage(): string {
 
   const endpointRows = endpointTable.map(endpointRow).join("\n");
 
+  const writeEndpoints = endpointTable.concat(referralEndpointTable).filter(e => e.method !== "GET");
+  const writeMethods = [...new Set(writeEndpoints.map(e => e.method))];
+  const methodSentence = writeEndpoints.length === 0
+    ? "Every endpoint below is read-only (GET)."
+    : "Every endpoint below is read-only (GET) except the " + writeEndpoints.length + " marked " + writeMethods.join(" and ") + " in the Method column.";
+
   return "<!DOCTYPE html>\n"
     + "<html lang=\"en\">\n"
     + "<head>\n"
@@ -49472,7 +49478,7 @@ function buildDeveloperHubPage(): string {
     + "    </div>\n"
     + "\n"
     + "    <h2>Endpoint Reference</h2>\n"
-    + "    <p>All endpoints are read-only (GET). Responses are JSON. For full request/response schemas, see the <a href=\"/api/docs\">interactive Swagger documentation</a>.</p>\n"
+    + "    <p>" + methodSentence + " Responses are JSON. Every one of them is described in our <a href=\"/api/openapi.json\">OpenAPI document</a>, browsable as <a href=\"/api/docs\">interactive Swagger documentation</a>.</p>\n"
     + "    <div style=\"overflow-x:auto\">\n"
     + "    <table class=\"endpoint-table\">\n"
     + "      <thead><tr><th>Method</th><th>Endpoint</th><th>Description</th><th>Parameters</th></tr></thead>\n"

--- a/test/homepage-cites-what-it-serves.test.ts
+++ b/test/homepage-cites-what-it-serves.test.ts
@@ -7,6 +7,9 @@ import { fileURLToPath } from "node:url";
 import { API_ENDPOINTS, DOCUMENTED_GROUPS, HOMEPAGE_GROUPS, endpointHref, endpointsInGroups, exampleSubjects, readableEndpoints } from "../dist/api-inventory.js";
 import { ACCELERATOR_CREDIT_PROGRAM, ACCELERATOR_CREDIT_VENDOR, figureIsHeldBy, figuresIn, normaliseFigure, programCeiling } from "../dist/homepage-claims.js";
 import { loadDealChanges, loadOffers } from "../dist/data.js";
+import { SIGNAL_DOC_PATH, SIGNAL_PATH } from "../dist/signal.js";
+import { CRITERIA_PATH } from "../dist/ranking.js";
+import { VENDOR_SERIES_PATH } from "../dist/vendor-series.js";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -18,6 +21,7 @@ const ROUTES_WE_DO_NOT_PUBLISH = new Map<string, string>([
   ["/api/page-reviews", "our editorial review register"],
   ["/api/analytics/history", "our own analytics"],
   ["/api/analytics/daily", "our own analytics"],
+  ["/api/analytics/vendors", "our own analytics — the per-vendor daily series, whose state /api/traffic publishes"],
   ["/api/agent-payments", "the retired marketplace ledger"],
   ["/api/agents/register", "agent registration, not a read endpoint"],
   ["/api/agents/me", "one caller's own registration"],
@@ -41,11 +45,21 @@ const NAMES_A_CLIENT_NOT_A_CLAIM = ["Cursor", "Cline", "Windsurf", "Claude Deskt
 
 const NAMES_AN_EXAMPLE_QUERY = ["Firebase"];
 
+const ROUTES_NAMED_BY_A_CONSTANT: Record<string, string> = { SIGNAL_PATH, SIGNAL_DOC_PATH, CRITERIA_PATH, VENDOR_SERIES_PATH };
+
+function constantsRoutingAPath(): string[] {
+  const source = readFileSync(SERVE_SOURCE, "utf8");
+  return [...new Set([...source.matchAll(/url\.pathname === ([A-Z][A-Z0-9_]*)\b/g)].map(([, name]) => name))].sort();
+}
+
 function servedApiRoutes(): string[] {
   const source = readFileSync(SERVE_SOURCE, "utf8");
   const exact = [...source.matchAll(/url\.pathname === "(\/api\/[^"]+)"/g)].map(([, route]) => route);
   const prefixed = [...source.matchAll(/url\.pathname\.startsWith\("(\/api\/[^"]+)"\)/g)].map(([, route]) => route);
-  return [...new Set([...exact, ...prefixed])].sort();
+  const named = constantsRoutingAPath()
+    .map((name) => ROUTES_NAMED_BY_A_CONSTANT[name])
+    .filter((route): route is string => typeof route === "string" && route.startsWith("/api/"));
+  return [...new Set([...exact, ...prefixed, ...named])].sort();
 }
 
 function requestsPrintedOnHome(html: string): string[] {
@@ -135,6 +149,11 @@ describe("the homepage publishes only what it can serve", () => {
     const known = new Set(API_ENDPOINTS.map((e) => e.path.replace(/:[a-z]+$/i, "")));
     const stray = servedApiRoutes().filter((route) => !known.has(route) && !ROUTES_WE_DO_NOT_PUBLISH.has(route));
     assert.deepStrictEqual(stray, [], `served /api routes in neither the inventory nor the unpublished register: ${stray.join(", ")}`);
+  });
+
+  it("resolves every constant the router matches a path against, so none can hide from that scan", () => {
+    const unresolved = constantsRoutingAPath().filter((name) => ROUTES_NAMED_BY_A_CONSTANT[name] === undefined);
+    assert.deepStrictEqual(unresolved, [], `constants the router keys on that this scan cannot resolve to a path: ${unresolved.join(", ")}`);
   });
 
   it("issues every API link the developer hub offers and gets an answer", async () => {

--- a/test/http.test.ts
+++ b/test/http.test.ts
@@ -6,6 +6,8 @@ import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { MCP_TOOL_COUNT, MCP_TOOL_NAMES } from "../dist/mcp-tool-inventory.js";
+import { API_ENDPOINTS } from "../dist/api-inventory.js";
+import { PATHS_OUTSIDE_THE_ENDPOINT_INVENTORY } from "../dist/openapi.js";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 let serverPort = 0;
@@ -964,7 +966,7 @@ describe("HTTP transport", () => {
     const body = await response.json() as any;
     assert.strictEqual(body.openapi, "3.0.3");
     assert.strictEqual(body.info.title, "AgentDeals API");
-    assert.ok(body.info.description.includes("No authentication required"));
+    assert.match(body.info.description, /no authentication is required/i);
     assert.ok(body.paths["/api/offers"]);
     assert.ok(body.paths["/api/categories"]);
     assert.ok(body.paths["/api/new"]);
@@ -985,7 +987,9 @@ describe("HTTP transport", () => {
     assert.ok(body.paths["/api/freshness"]);
     assert.ok(body.paths["/api/referral-codes"]);
     assert.ok(body.paths["/api/referral-codes/{vendor}"]);
-    assert.strictEqual(Object.keys(body.paths).length, 20);
+    const servedPaths = new Set(API_ENDPOINTS.map((e) => e.path.replace(/:([A-Za-z_]+)/g, "{$1}")));
+    for (const alias of Object.keys(PATHS_OUTSIDE_THE_ENDPOINT_INVENTORY)) servedPaths.add(alias);
+    assert.deepStrictEqual(Object.keys(body.paths).sort(), [...servedPaths].sort());
     assert.ok(body.components.schemas.Offer);
     assert.ok(body.components.schemas.DealChange);
     assert.ok(body.components.schemas.Eligibility);

--- a/test/openapi-covers-what-we-serve.test.ts
+++ b/test/openapi-covers-what-we-serve.test.ts
@@ -1,0 +1,317 @@
+import { describe, it, before, after } from "node:test";
+import assert from "node:assert";
+import { spawn, type ChildProcess } from "node:child_process";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  API_ENDPOINTS,
+  DOCUMENTED_GROUPS,
+  HOMEPAGE_GROUPS,
+  endpointHref,
+  exampleRequest,
+  exampleSubjects,
+  readableEndpoints,
+  type ApiEndpoint,
+} from "../dist/api-inventory.js";
+import {
+  CHANGE_TYPES,
+  PATHS_OUTSIDE_THE_ENDPOINT_INVENTORY,
+  documentedOperationsNoEndpointServes,
+  endpointsDescribedFromTheInventoryAlone,
+  openapiSpec,
+  pathsFor,
+} from "../dist/openapi.js";
+import { MCP_TOOLS_WITHDRAWN } from "../dist/mcp-tool-inventory.js";
+import { CHANGE_DIRECTION } from "../dist/change-direction.js";
+import { loadOffers } from "../dist/data.js";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+const JSON_REPRESENTATION = new Map<string, string>([
+  ["/api/digest/weekly", "/api/digest/weekly?format=json"],
+]);
+
+const spec = openapiSpec as unknown as {
+  info: { description: string };
+  paths: Record<string, Record<string, { responses: Record<string, { content?: Record<string, { schema: unknown }> }> }>>;
+  components: { schemas: Record<string, { properties?: Record<string, unknown>; required?: string[] }> };
+};
+
+function specPath(route: string): string {
+  return route.replace(/:([A-Za-z_]+)/g, "{$1}");
+}
+
+function operationFor(endpoint: ApiEndpoint) {
+  return spec.paths[specPath(endpoint.path)]?.[endpoint.method.toLowerCase()];
+}
+
+function citesInTheSpec(endpoint: ApiEndpoint): boolean {
+  const json = operationFor(endpoint)?.responses?.["200"]?.content?.["application/json"];
+  return json ? JSON.stringify(json.schema).includes("#/components/schemas/Provenance") : false;
+}
+
+function probeRequest(endpoint: ApiEndpoint, subjects: ReturnType<typeof exampleSubjects>): string | null {
+  const override = JSON_REPRESENTATION.get(endpoint.path);
+  if (override) return override;
+  return endpointHref(endpoint, subjects);
+}
+
+describe("the machine-readable spec describes what the API serves", () => {
+  let proc: ChildProcess;
+  let base: string;
+  let subjects: ReturnType<typeof exampleSubjects>;
+  let bodies: Map<string, unknown>;
+
+  before(async () => {
+    const started = await new Promise<{ proc: ChildProcess; port: number }>((resolve, reject) => {
+      const child = spawn("node", [path.join(__dirname, "..", "dist", "serve.js")], {
+        stdio: ["pipe", "pipe", "pipe"],
+        env: { ...process.env, PORT: "0", BASE_URL: "http://127.0.0.1" },
+      });
+      const timer = setTimeout(() => { child.kill("SIGKILL"); reject(new Error("startup timeout")); }, 60000);
+      child.stderr?.on("data", (b: Buffer) => {
+        const m = b.toString().match(/running on http:\/\/localhost:(\d+)/);
+        if (m) { clearTimeout(timer); resolve({ proc: child, port: parseInt(m[1], 10) }); }
+      });
+      child.on("error", (e) => { clearTimeout(timer); reject(e); });
+    });
+    proc = started.proc;
+    base = `http://127.0.0.1:${started.port}`;
+    const codes = await (await fetch(`${base}/api/referral-codes`, { redirect: "error" })).json() as { codes: { vendor: string }[] };
+    subjects = exampleSubjects(loadOffers().map((o) => o.vendor), codes.codes.map((c) => c.vendor));
+    bodies = new Map();
+    for (const endpoint of API_ENDPOINTS) {
+      if (endpoint.method !== "GET") continue;
+      const request = probeRequest(endpoint, subjects);
+      if (!request) continue;
+      const res = await fetch(`${base}${request}`, { redirect: "error" });
+      const text = await res.text();
+      try { bodies.set(endpoint.path, JSON.parse(text)); } catch { bodies.set(endpoint.path, null); }
+    }
+  });
+
+  after(() => { proc?.kill("SIGKILL"); });
+
+  it("describes every endpoint the inventory both surfaces are built from", () => {
+    const missing = API_ENDPOINTS
+      .filter((endpoint) => operationFor(endpoint) === undefined)
+      .map((endpoint) => `${endpoint.method} ${endpoint.path}`);
+    assert.deepStrictEqual(missing, [], `endpoints served and listed but absent from the spec: ${missing.join(", ")}`);
+  });
+
+  it("describes no operation that no endpoint serves, beyond the aliases it registers", () => {
+    assert.deepStrictEqual(documentedOperationsNoEndpointServes(), []);
+    const served = new Set(API_ENDPOINTS.map((e) => `${e.method.toLowerCase()} ${specPath(e.path)}`));
+    const alias = new Set(Object.keys(PATHS_OUTSIDE_THE_ENDPOINT_INVENTORY));
+    const stray = Object.entries(spec.paths)
+      .filter(([route]) => !alias.has(route))
+      .flatMap(([route, methods]) => Object.keys(methods).map((method) => `${method} ${route}`))
+      .filter((key) => !served.has(key));
+    assert.deepStrictEqual(stray, [], `paths in the spec that no served endpoint backs: ${stray.join(", ")}`);
+  });
+
+  it("writes a description for every endpoint rather than falling back to the inventory's line", () => {
+    assert.deepStrictEqual(endpointsDescribedFromTheInventoryAlone(), []);
+  });
+
+  it("puts a route added to the inventory alone into the spec, and reports it as undescribed", () => {
+    const invented: ApiEndpoint = { method: "GET", path: "/api/pressure-test", desc: "A route the spec has never been told about", params: "limit", group: "product" };
+    const perturbed = [...API_ENDPOINTS, invented];
+    assert.ok(pathsFor(perturbed)["/api/pressure-test"]?.get, "a route added to the inventory did not reach the spec");
+    assert.deepStrictEqual(endpointsDescribedFromTheInventoryAlone(perturbed), ["GET /api/pressure-test"]);
+  });
+
+  it("reports an operation left in the spec after its endpoint is withdrawn", () => {
+    const withdrawn = API_ENDPOINTS.filter((e) => e.path !== "/api/deadlines");
+    assert.deepStrictEqual(documentedOperationsNoEndpointServes(withdrawn), ["GET /api/deadlines"]);
+  });
+
+  it("answers on every path it publishes", async () => {
+    const refused: string[] = [];
+    for (const endpoint of API_ENDPOINTS) {
+      if (endpoint.method !== "GET") continue;
+      const request = probeRequest(endpoint, subjects);
+      if (!request) continue;
+      const res = await fetch(`${base}${request}`, { redirect: "error" });
+      if (res.status >= 400) refused.push(`${request} -> ${res.status}`);
+    }
+    for (const alias of Object.keys(PATHS_OUTSIDE_THE_ENDPOINT_INVENTORY)) {
+      const res = await fetch(`${base}${alias}`, { redirect: "error" });
+      if (res.status >= 400) refused.push(`${alias} -> ${res.status}`);
+    }
+    assert.deepStrictEqual(refused, [], `paths the spec describes that the server refuses:\n${refused.join("\n")}`);
+  });
+
+  it("reaches a described path from every API link the developer hub offers", async () => {
+    const hub = await (await fetch(`${base}/developers`, { redirect: "error" })).text();
+    const links = [...new Set([...hub.matchAll(/<td><a href="([^"]*?)(\/api\/[^"?]*)[^"]*">/g)].map(([, , route]) => route))];
+    assert.ok(links.length >= 25, `the developer hub offers ${links.length} API links`);
+    const described = new Set(Object.keys(spec.paths));
+    const undescribed = links.filter((route) => {
+      if (described.has(route)) return false;
+      const template = API_ENDPOINTS.find((e) => e.method === "GET" && new RegExp(`^${specPath(e.path).replace(/\{[A-Za-z_]+\}/g, "[^/]+")}$`).test(route));
+      return template === undefined || !described.has(specPath(template.path));
+    });
+    assert.deepStrictEqual(undescribed, [], `API links on /developers reaching no described path: ${undescribed.join(", ")}`);
+  });
+
+  it("reaches a described path from every request the home page prints", async () => {
+    const home = await (await fetch(`${base}/`, { redirect: "error" })).text();
+    const printed = [...home.matchAll(/<pre><code>([\s\S]*?)<\/code><\/pre>/g)]
+      .flatMap(([, block]) => block.split("\n"))
+      .filter((line) => line.startsWith("GET /api/"))
+      .map((line) => line.slice(4).replace(/&amp;/g, "&").split("?")[0]);
+    assert.ok(printed.length >= readableEndpoints(HOMEPAGE_GROUPS).length - 2, `the home page printed ${printed.length} API requests`);
+    const described = new Set(Object.keys(spec.paths));
+    const undescribed = printed.filter((route) => {
+      if (described.has(route)) return false;
+      return !API_ENDPOINTS.some((e) => e.method === "GET" && described.has(specPath(e.path)) && new RegExp(`^${specPath(e.path).replace(/\{[A-Za-z_]+\}/g, "[^/]+")}$`).test(route));
+    });
+    assert.deepStrictEqual([...new Set(undescribed)], [], `requests printed on / reaching no described path: ${undescribed.join(", ")}`);
+  });
+
+  it("counts the same endpoints the developer hub counts", () => {
+    const documented = API_ENDPOINTS.filter((e) => DOCUMENTED_GROUPS.includes(e.group));
+    const inSpec = documented.filter((e) => operationFor(e) !== undefined);
+    assert.strictEqual(inSpec.length, documented.length);
+  });
+
+  it("says which methods the developer hub's own table holds", async () => {
+    const hub = await (await fetch(`${base}/developers`, { redirect: "error" })).text();
+    const table = hub.slice(hub.indexOf("<table class=\"endpoint-table\">"));
+    const inTable = [...new Set([...table.matchAll(/<td><code>(GET|POST|DELETE|PUT|PATCH)<\/code><\/td>/g)].map(([, method]) => method))];
+    const claim = hub.match(/<p>(Every endpoint below[^<]*)/);
+    assert.ok(claim, "/developers states nothing about the methods its table holds");
+    const writes = inTable.filter((method) => method !== "GET");
+    const unstated = writes.filter((method) => !claim[1].includes(method));
+    assert.deepStrictEqual(unstated, [], `methods in the endpoint table that the sentence above it does not admit: ${unstated.join(", ")}`);
+    if (writes.length === 0) assert.ok(/^Every endpoint below is read-only \(GET\)\.$/.test(claim[1].trim()));
+  });
+});
+
+describe("the citation block an agent reads is the one the spec describes", () => {
+  let proc: ChildProcess;
+  let base: string;
+  let subjects: ReturnType<typeof exampleSubjects>;
+  let carried: Map<string, Record<string, unknown> | null>;
+
+  before(async () => {
+    const started = await new Promise<{ proc: ChildProcess; port: number }>((resolve, reject) => {
+      const child = spawn("node", [path.join(__dirname, "..", "dist", "serve.js")], {
+        stdio: ["pipe", "pipe", "pipe"],
+        env: { ...process.env, PORT: "0", BASE_URL: "http://127.0.0.1" },
+      });
+      const timer = setTimeout(() => { child.kill("SIGKILL"); reject(new Error("startup timeout")); }, 60000);
+      child.stderr?.on("data", (b: Buffer) => {
+        const m = b.toString().match(/running on http:\/\/localhost:(\d+)/);
+        if (m) { clearTimeout(timer); resolve({ proc: child, port: parseInt(m[1], 10) }); }
+      });
+      child.on("error", (e) => { clearTimeout(timer); reject(e); });
+    });
+    proc = started.proc;
+    base = `http://127.0.0.1:${started.port}`;
+    const codes = await (await fetch(`${base}/api/referral-codes`, { redirect: "error" })).json() as { codes: { vendor: string }[] };
+    subjects = exampleSubjects(loadOffers().map((o) => o.vendor), codes.codes.map((c) => c.vendor));
+    carried = new Map();
+    for (const endpoint of API_ENDPOINTS) {
+      if (endpoint.method !== "GET") continue;
+      const request = probeRequest(endpoint, subjects);
+      if (!request) continue;
+      const res = await fetch(`${base}${request}`, { redirect: "error" });
+      const text = await res.text();
+      let block: Record<string, unknown> | null = null;
+      try {
+        const body = JSON.parse(text) as Record<string, unknown>;
+        block = (body._provenance as Record<string, unknown>) ?? null;
+      } catch { block = null; }
+      carried.set(endpoint.path, block);
+    }
+  });
+
+  after(() => { proc?.kill("SIGKILL"); });
+
+  it("describes the citation on every response that carries one, and on no response that does not", () => {
+    const disagreeing: string[] = [];
+    for (const endpoint of API_ENDPOINTS) {
+      if (endpoint.method !== "GET") continue;
+      if (!carried.has(endpoint.path)) continue;
+      const served = carried.get(endpoint.path) !== null;
+      const described = citesInTheSpec(endpoint);
+      if (served !== described) disagreeing.push(`${endpoint.path}: served=${served} described=${described}`);
+    }
+    assert.deepStrictEqual(disagreeing, [], `routes whose citation block and spec disagree:\n${disagreeing.join("\n")}`);
+  });
+
+  it("cites on more than half of the endpoints it describes", () => {
+    const citing = [...carried.values()].filter((block) => block !== null);
+    assert.ok(citing.length > carried.size / 2, `${citing.length} of ${carried.size} readable endpoints carry a citation`);
+  });
+
+  it("names every field the block carries", () => {
+    const documented = new Set(Object.keys(spec.components.schemas.Provenance.properties ?? {}));
+    const undocumented = new Set<string>();
+    for (const block of carried.values()) {
+      if (!block) continue;
+      for (const field of Object.keys(block)) if (!documented.has(field)) undocumented.add(field);
+    }
+    assert.deepStrictEqual([...undocumented], [], `fields the citation block carries that the Provenance schema does not name: ${[...undocumented].join(", ")}`);
+  });
+
+  it("requires only the fields every block actually carries", () => {
+    const required = spec.components.schemas.Provenance.required ?? [];
+    const blocks = [...carried.values()].filter((block): block is Record<string, unknown> => block !== null);
+    assert.ok(blocks.length > 0, "no endpoint carried a citation block");
+    const absent = required.filter((field) => blocks.some((block) => !(field in block)));
+    assert.deepStrictEqual(absent, [], `fields the Provenance schema requires that some block omits: ${absent.join(", ")}`);
+  });
+
+  it("describes each optional field as optional", () => {
+    const properties = Object.keys(spec.components.schemas.Provenance.properties ?? {});
+    const required = new Set(spec.components.schemas.Provenance.required ?? []);
+    const blocks = [...carried.values()].filter((block): block is Record<string, unknown> => block !== null);
+    const alwaysPresent = properties.filter((field) => !required.has(field) && blocks.every((block) => field in block));
+    assert.deepStrictEqual(alwaysPresent, [], `fields every block carries that the schema leaves optional: ${alwaysPresent.join(", ")}`);
+  });
+});
+
+describe("the spec's own vocabulary matches the code's", () => {
+  it("offers every change type a record can hold as a filter value", () => {
+    const filter = (spec.paths["/api/changes"].get as unknown as { parameters: { name: string; schema: { enum?: string[] } }[] })
+      .parameters.find((p) => p.name === "type");
+    assert.ok(filter?.schema.enum, "/api/changes documents no type filter");
+    assert.deepStrictEqual([...filter.schema.enum].sort(), Object.keys(CHANGE_DIRECTION).sort());
+  });
+
+  it("types the change record with the same list it offers as a filter", () => {
+    const onTheRecord = (spec.components.schemas.DealChange.properties!.change_type as { enum: string[] }).enum;
+    const filter = (spec.paths["/api/changes"].get as unknown as { parameters: { name: string; schema: { enum?: string[] } }[] })
+      .parameters.find((p) => p.name === "type")!;
+    assert.deepStrictEqual([...onTheRecord].sort(), [...filter.schema.enum!].sort());
+    assert.deepStrictEqual([...onTheRecord].sort(), [...CHANGE_TYPES].sort());
+  });
+
+  it("describes no capability we have withdrawn", () => {
+    const published = JSON.stringify(openapiSpec);
+    const residue = MCP_TOOLS_WITHDRAWN.map((tool) => tool.name).filter((name) => published.includes(name));
+    assert.deepStrictEqual(residue, [], `the spec names withdrawn capabilities: ${residue.join(", ")}`);
+  });
+
+  it("says which served routes it leaves out rather than leaving them out in silence", () => {
+    const stated = spec.info.description;
+    assert.ok(/deliberately absent/.test(stated), "the spec does not say that any route is deliberately undescribed");
+    assert.ok(stated.includes("POST /api/agents/register"), "the spec does not name the write path it leaves out");
+    for (const write of API_ENDPOINTS.filter((e) => e.method !== "GET")) {
+      assert.ok(
+        spec.paths[specPath(write.path)]?.[write.method.toLowerCase()],
+        `${write.method} ${write.path} is neither described nor declared out of scope`,
+      );
+    }
+  });
+
+  it("names every alias it describes and why the endpoint inventory does not hold it", () => {
+    for (const [route, reason] of Object.entries(PATHS_OUTSIDE_THE_ENDPOINT_INVENTORY)) {
+      assert.ok(spec.paths[route], `${route} is registered as an alias and not described`);
+      assert.ok(reason.length > 30, `${route} is registered with no reason`);
+    }
+  });
+});


### PR DESCRIPTION
Refs #1318

`/api/openapi.json` described 20 paths against an endpoint inventory of 34, and `/developers` counted 32. Fifteen served operations were absent from the spec, including the four carrying the deepest pricing data — `/api/llm-pricing`, `/api/startup-credits`, `/api/hosting-pricing`, `/api/ai-coding-pricing`. Since #1464 the home page has asserted completeness and linked, six words later, to the inventory that was not complete.

**The spec's path list is now built from the endpoint inventory rather than written beside it.** `src/openapi.ts` holds a map of hand-written operations keyed by path and method; `pathsFor()` walks `API_ENDPOINTS` and emits an operation for every one, falling back to a description derived from the inventory's own line where none is written. A route added to `/developers` or the home page cannot be missing from the spec, because both surfaces and the spec are now built from the same list.

**34 paths, 36 operations, up from 20.** All ten GET routes named in the issue, all three write paths, `/api/openapi.json` and `/api/docs`. Every one of the 34 answers; Swagger UI renders the document without a parse error.

## The citation contract

`_provenance` and `cite_as` appeared zero times in the spec. There is now a `Provenance` component schema describing `source`, `url`, `checked`, `verified`, `cite_as`, `verified_records`, `withheld_records`, `note`, `gated_note` and the deference line.

Which endpoints carry it is a fact about the server, so it is recorded on the endpoint — `cites: true` — and the spec attaches the `$ref` from that flag. 22 responses reference it. The flag is held to the running server in both directions: a route that carries a citation block the spec does not describe fails, and so does a route the spec says cites when it does not.

## The third write path

The issue names `POST /api/signal` among the missing. It was missing from more than the spec: it is routed through the `SIGNAL_PATH` constant, and `test/homepage-cites-what-it-serves.test.ts` scans `src/serve.ts` for `url.pathname === "/api/..."` **string literals**, so the guard that is supposed to hold every served route to an inventory could not see it. `/developers` documents its rate limit in prose below a table it is not in.

It is now in the inventory and in the spec, and the scan resolves constants — with a test that fails on any routing constant it cannot resolve, so the next one cannot hide the same way. That test found a second route the scan had never seen: `VENDOR_SERIES_PATH`, which is `/api/analytics/vendors`. It is our own analytics and belongs in `ROUTES_WE_DO_NOT_PUBLISH`, where it now is with its reason.

## Two vocabularies that had drifted

- The `type` filter on `/api/changes` enumerated 13 change types; the `change_type` schema 855 lines below enumerated 14. `rebranded` was legal and undiscoverable. Both now derive from `CHANGE_DIRECTION`, which TypeScript refuses to compile incomplete.
- `/api/stats` still advertised `register_agent`, `check_balance` and `request_payout` in its `toolCallsByName` description. The list derives from `MCP_TOOLS`, and a test fails on any withdrawn tool named anywhere in the spec.

## What the spec now says it leaves out

Its own description names the three classes of served route deliberately absent — one caller's own state, our operational counters, and `POST /api/agents/register` — rather than omitting them in silence. The write paths it does describe are listed from the inventory, so that sentence cannot go stale either.

`/developers` said "All endpoints are read-only (GET)" directly above a table holding `POST` and `DELETE`. The sentence is derived from the table now.

## Tests

`test/openapi-covers-what-we-serve.test.ts`, 21 tests. The drift detector's own sensitivity is asserted rather than seeded by hand: adding a route to a copy of the inventory must put it in the spec and report it as undescribed, and withdrawing one must report the operation left behind. The reachability tests measure the rendered `/developers` and `/` rather than the inventory, so a path dropped from the spec fails on the page a reader sees.

Two assertions in `test/http.test.ts` pinned the superseded state — 20 paths exactly, and the old description wording. Inverted rather than deleted: the path set must now equal what the inventory serves plus the registered aliases.

13 mutants, 13 killed.

Two tests fail on this branch and fail identically on `main` with this branch stashed — `plan_stack recommend mode returns risk_level/stability per component and risk_warnings` and `candidates include risk_level and stability fields`. Both are in the stack-candidate risk family and neither touches anything this change reaches.
