### PR TITLE
Resolve two labels for one function to one page, and name what each page lists (#1479)

### DIFF
--- a/scripts/mutate-1479.mjs
+++ b/scripts/mutate-1479.mjs
@@ -1,0 +1,100 @@
+import { readFileSync, writeFileSync } from "node:fs";
+import { execFileSync } from "node:child_process";
+
+const SUITE = ["test/function-naming.test.ts", "test/product-function-pages.test.ts"];
+
+const MUTANTS = [
+  ["two-labels-for-one-function-split-back-into-two-pages", "src/product-role.ts",
+    "export function canonicalEntryFor(entry: TaxonomyEntryRef): TaxonomyEntryRef {\n  for (const ruling of CROSS_TAXONOMY_RULINGS) {",
+    "export function canonicalEntryFor(entry: TaxonomyEntryRef): TaxonomyEntryRef {\n  if (entry.subtype.length > 0) return entry;\n  for (const ruling of CROSS_TAXONOMY_RULINGS) {"],
+
+  ["the-page-namespace-keys-on-the-raw-label-again", "src/product-function.ts",
+    "      const canonical = canonicalEntryFor({ taxonomy, subtype });\n      const key = functionKey(toSlug(canonical.subtype));",
+    "      const canonical = canonicalEntryFor({ taxonomy, subtype });\n      const key = functionKey(toSlug(subtype));"],
+
+  ["a-record-reaches-the-page-only-under-the-governing-label", "src/product-function.ts",
+    "  const labels = (offer.product_subtypes?.labels ?? []).filter(l => fn.subtypes.includes(l.subtype));",
+    "  const labels = (offer.product_subtypes?.labels ?? []).filter(l => toSlug(l.subtype) === fn.slug);"],
+
+  ["the-register-loses-the-pair-it-was-filed-for", "src/product-role.ts",
+    "    a: { taxonomy: \"Databases\", subtype: \"vector\" },\n    b: { taxonomy: \"AI / ML\", subtype: \"vector_store\" },",
+    "    a: { taxonomy: \"Databases\", subtype: \"vector\" },\n    b: { taxonomy: \"AI / ML\", subtype: \"kv_cache\" },"],
+
+  ["the-taxonomies-stop-being-read-against-each-other", "src/product-role.ts",
+    "      if (!byDefinition && !byLabel) continue;",
+    "      if (!byDefinition || !byLabel || overlap > 0.9) continue;"],
+
+  ["a-merged-function-publishes-one-definition-per-parent", "src/product-function.ts",
+    "      const governing = governingDefinition(taxonomy, subtype);\n      if (governing) definitions.add(governing);",
+    "      const governing = subtypeDefinition(taxonomy, subtype);\n      if (governing) definitions.add(governing);"],
+
+  ["the-definition-goes-back-behind-a-subject-pronoun", "src/product-function.ts",
+    "  return definitions.length === 0 ? \"\" : `Our membership test: ${definitions.join(\"; or \")}.`;",
+    "  return definitions.length === 0 ? \"\" : `We list a product here when it ${definitions.join(\"; or when it \")}.`;"],
+
+  ["the-count-sentence-stops-agreeing-in-number", "src/serve.ts",
+    "function countedNoun(count: number, noun: string): string {\n  return `${count} ${noun}${count === 1 ? \"\" : \"s\"}`;\n}",
+    "function countedNoun(count: number, noun: string): string {\n  return `${count} ${noun}s`;\n}"],
+
+  ["a-declared-class-name-is-ignored-for-the-title", "src/product-function.ts",
+    "  const declared = subtypeEntry(canonical.taxonomy, canonical.subtype)?.name;",
+    "  const declared = undefined as string | undefined;"],
+
+  ["a-declared-name-borrows-a-noun-its-parent-does-not-supply", "src/product-role.ts",
+    "{ subtype: \"vector\", name: \"Vector Databases\", definition:",
+    "{ subtype: \"vector\", name: \"Vector Search\", definition:"],
+
+  ["a-declared-name-is-published-with-the-generic-noun-appended", "src/product-function.ts",
+    "  return { title, listNoun: declared ?? `${title} Tools` };",
+    "  return { title, listNoun: `${title} Tools` };"],
+
+  ["the-page-threshold-counts-what-the-function-could-reach", "src/serve.ts",
+    "    if (rankFunction(fn, date).qualified.length >= BEST_OF_MIN_PICKS) publishing.set(slug, fn);",
+    "    if (functionMembers(offers, fn).length >= BEST_OF_MIN_PICKS) publishing.set(slug, fn);"],
+
+  ["a-page-with-one-pick-is-published-again", "src/serve.ts",
+    "const BEST_OF_MIN_PICKS = 2;",
+    "const BEST_OF_MIN_PICKS = 1;"],
+
+  ["a-withheld-page-stays-in-the-sitemap", "src/serve.ts",
+    "    for (const [s, fn] of publishedBestOf().entries()) {",
+    "    for (const [s, fn] of bestOfSlugMap.entries()) {"],
+
+  ["a-category-page-loses-the-title-its-category-gave-it", "src/product-function.ts",
+    "    byKey.set(key, { slug, title: name, listNoun: `${name} Tools`,",
+    "    byKey.set(key, { slug, title: name, listNoun: `${name} Free Tools`,"],
+];
+
+function run(cmd, args) {
+  try {
+    execFileSync(cmd, args, { stdio: "pipe", encoding: "utf-8" });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+const survivors = [];
+const uncompiled = [];
+const skipped = [];
+for (const [name, file, from, to] of MUTANTS) {
+  const original = readFileSync(file, "utf-8");
+  if (!original.includes(from)) {
+    console.log(`SKIP  ${name} — the line it mutates is not in ${file}`);
+    skipped.push(name);
+    continue;
+  }
+  writeFileSync(file, original.replace(from, to));
+  const built = run("npm", ["run", "build"]);
+  const green = built && run("node", ["--test", "--test-concurrency", "1", ...SUITE]);
+  writeFileSync(file, original);
+  if (!built) uncompiled.push(name);
+  console.log(`${green ? "SURVIVED" : built ? "killed  " : "DID NOT COMPILE"}  ${name}`);
+  if (green) survivors.push(name);
+}
+run("npm", ["run", "build"]);
+const killed = MUTANTS.length - survivors.length - uncompiled.length - skipped.length;
+console.log(`\n${killed}/${MUTANTS.length} killed`);
+if (survivors.length > 0) console.log("survivors:", survivors.join(", "));
+if (uncompiled.length > 0) console.log("did not compile:", uncompiled.join(", "));
+if (skipped.length > 0) console.log("skipped — target string moved, so these scored nothing:", skipped.join(", "));

--- a/src/product-function.ts
+++ b/src/product-function.ts
@@ -1,10 +1,11 @@
-import { SUBTYPE_TAXONOMIES, subtypeDefinition } from "./product-role.js";
+import { SUBTYPE_TAXONOMIES, subtypeDefinition, canonicalEntryFor, governingDefinition, subtypeEntry } from "./product-role.js";
 import { toSlug } from "./slug.js";
 import type { SubtypeLabel } from "./types.js";
 
 export interface ProductFunction {
   slug: string;
   title: string;
+  listNoun: string;
   categories: string[];
   subtypes: string[];
   taxonomies: string[];
@@ -16,7 +17,13 @@ export interface FunctionCarrier {
 }
 
 export const FUNCTION_NAMING_RULE =
-  "A page is named after a product function. A function is named by a category, by a subtype label, or by both — two names are the same function when their slugs match once a trailing plural is dropped, and by nothing weaker. Substring overlap is not a match: container_app is not the container registry category, host_metrics is not cloud hosting, and the document database subtype is not documentation.";
+  "A page is named after a product function. A function is named by a category, by a subtype label, or by both — two names are the same function when their slugs match once a trailing plural is dropped, or when a published ruling says two labels under different parents name one thing, and by nothing weaker. Substring overlap is not a match: container_app is not the container registry category, host_metrics is not cloud hosting, and the document database subtype is not documentation.";
+
+export const FUNCTION_TITLE_RULE =
+  "A page's title names a class of product. A category already names one, so the category name is the title. A subtype names an attribute of the class its parent names, so where the attribute alone would not name a product the title is declared beside the definition instead of derived from the label.";
+
+export const FUNCTION_PICK_RULE =
+  "A page is published when the function reaches enough records to compare and the list it will publish holds more than one of them. A page carrying a single pick is not a comparison, so the threshold counts what the page shows rather than what it could reach.";
 
 export const FUNCTION_MEMBERSHIP_RULE =
   "A record reaches a function page when its category names the function or when it carries a subtype label that names the function. Adding a label to a record publishes it here; removing one withdraws it. No page holds a list of vendors.";
@@ -41,6 +48,13 @@ export function subtypeTitle(subtype: string): string {
     .join(" ");
 }
 
+export function functionNaming(taxonomy: string, subtype: string): { title: string; listNoun: string } {
+  const canonical = canonicalEntryFor({ taxonomy, subtype });
+  const declared = subtypeEntry(canonical.taxonomy, canonical.subtype)?.name;
+  const title = declared ?? subtypeTitle(canonical.subtype);
+  return { title, listNoun: declared ?? `${title} Tools` };
+}
+
 export function buildProductFunctions(categoryNames: readonly string[]): ProductFunction[] {
   const byKey = new Map<string, ProductFunction>();
 
@@ -52,20 +66,31 @@ export function buildProductFunctions(categoryNames: readonly string[]): Product
       if (!held.categories.includes(name)) held.categories.push(name);
       continue;
     }
-    byKey.set(key, { slug, title: name, categories: [name], subtypes: [], taxonomies: [] });
+    byKey.set(key, { slug, title: name, listNoun: `${name} Tools`, categories: [name], subtypes: [], taxonomies: [] });
   }
 
   for (const [taxonomy, entries] of Object.entries(SUBTYPE_TAXONOMIES)) {
     for (const { subtype } of entries) {
-      const key = functionKey(toSlug(subtype));
+      const canonical = canonicalEntryFor({ taxonomy, subtype });
+      const key = functionKey(toSlug(canonical.subtype));
       const held = byKey.get(key);
       if (held) {
         if (!held.subtypes.includes(subtype)) held.subtypes.push(subtype);
         if (!held.taxonomies.includes(taxonomy)) held.taxonomies.push(taxonomy);
         continue;
       }
-      byKey.set(key, { slug: toSlug(subtype), title: subtypeTitle(subtype), categories: [], subtypes: [subtype], taxonomies: [taxonomy] });
+      byKey.set(key, {
+        slug: toSlug(canonical.subtype),
+        ...functionNaming(taxonomy, subtype),
+        categories: [],
+        subtypes: [subtype],
+        taxonomies: [taxonomy],
+      });
     }
+  }
+
+  for (const fn of byKey.values()) {
+    fn.subtypes.sort((a, b) => Number(toSlug(b) === fn.slug) - Number(toSlug(a) === fn.slug));
   }
 
   return [...byKey.values()];
@@ -75,11 +100,16 @@ export function functionDefinitions(fn: ProductFunction): string[] {
   const definitions = new Set<string>();
   for (const taxonomy of fn.taxonomies) {
     for (const subtype of fn.subtypes) {
-      const definition = subtypeDefinition(taxonomy, subtype);
-      if (definition) definitions.add(definition);
+      if (!subtypeDefinition(taxonomy, subtype)) continue;
+      const governing = governingDefinition(taxonomy, subtype);
+      if (governing) definitions.add(governing);
     }
   }
   return [...definitions];
+}
+
+export function functionMeaningSentence(definitions: readonly string[]): string {
+  return definitions.length === 0 ? "" : `Our membership test: ${definitions.join("; or ")}.`;
 }
 
 export interface FunctionAdmission {

--- a/src/product-role.ts
+++ b/src/product-role.ts
@@ -29,11 +29,17 @@ export const MEMBERSHIP_GATE_RULES: Record<MembershipGate, { label: string; rule
   },
 };
 
-export const SUBTYPE_TAXONOMIES: Record<string, Array<{ subtype: string; definition: string }>> = {
+export interface SubtypeTaxonomyEntry {
+  subtype: string;
+  definition: string;
+  name?: string;
+}
+
+export const SUBTYPE_TAXONOMIES: Record<string, SubtypeTaxonomyEntry[]> = {
   Databases: [
-    { subtype: "relational", definition: "tables, rows and joins under SQL — Postgres, MySQL, SQLite family" },
-    { subtype: "document", definition: "schemaless JSON/BSON documents as the stored unit" },
-    { subtype: "vector", definition: "stores embeddings and answers similarity queries as its primary access path" },
+    { subtype: "relational", name: "Relational Databases", definition: "tables, rows and joins under SQL — Postgres, MySQL, SQLite family" },
+    { subtype: "document", name: "Document Databases", definition: "schemaless JSON/BSON documents as the stored unit" },
+    { subtype: "vector", name: "Vector Databases", definition: "stores embeddings and answers similarity queries as its primary access path" },
     { subtype: "kv_cache", definition: "key to value, no query language over the value" },
     { subtype: "graph", definition: "nodes and edges are the primary model, with a traversal query language" },
     { subtype: "timeseries", definition: "rows are time-indexed measurements, retention is a first-class setting" },
@@ -84,6 +90,136 @@ export const SUBTYPE_TAXONOMIES: Record<string, Array<{ subtype: string; definit
     { subtype: "agent_tool_access", definition: "supplies an agent with authenticated connections to third-party applications it can call as tools" },
   ],
 };
+
+export interface TaxonomyEntryRef {
+  taxonomy: string;
+  subtype: string;
+}
+
+export interface CrossTaxonomyRuling {
+  a: TaxonomyEntryRef;
+  b: TaxonomyEntryRef;
+  same: boolean;
+  canonical?: TaxonomyEntryRef;
+  reason: string;
+}
+
+export const CROSS_TAXONOMY_RULE =
+  "The taxonomies are read against each other, not only within a parent. Two entries under different parents are flagged as candidates for one function when their definitions describe the same thing or when one label contains the other, and every flagged pair is ruled on here rather than left to the slug. A pair ruled the same is one function: whichever label a record carries, it reaches the page named after that function, and one definition governs.";
+
+export const CROSS_TAXONOMY_RULINGS: CrossTaxonomyRuling[] = [
+  {
+    a: { taxonomy: "Databases", subtype: "vector" },
+    b: { taxonomy: "AI / ML", subtype: "vector_store" },
+    same: true,
+    canonical: { taxonomy: "Databases", subtype: "vector" },
+    reason: "Similarity search and nearest-neighbour search are one operation under two names, so these two labels are one function. Records carrying either reach the page named after it, whichever parent they are filed under.",
+  },
+  {
+    a: { taxonomy: "Cloud Hosting", subtype: "agent_sandbox" },
+    b: { taxonomy: "AI / ML", subtype: "agent_sandbox" },
+    same: true,
+    canonical: { taxonomy: "Cloud Hosting", subtype: "agent_sandbox" },
+    reason: "One label declared under two parents. The Cloud Hosting wording governs because it does not restrict the workload to code an agent wrote.",
+  },
+  {
+    a: { taxonomy: "Databases", subtype: "document" },
+    b: { taxonomy: "AI / ML", subtype: "document_extraction" },
+    same: false,
+    reason: "A document database stores a document as its unit; document extraction reads one and returns text or fields. They share a word and no function.",
+  },
+];
+
+const CROSS_TAXONOMY_DEFINITION_OVERLAP = 0.5;
+
+const DEFINITION_STOPWORDS = new Set(
+  "a an the and or of to in on for with as its it is are be by that this you your we our from not no there them their than rather so per own one two three what which when where how".split(" "),
+);
+
+function definitionTokens(definition: string): Set<string> {
+  return new Set(
+    definition
+      .toLowerCase()
+      .replace(/[^a-z0-9\s-]/g, " ")
+      .split(/\s+/)
+      .filter(word => word.length > 0 && !DEFINITION_STOPWORDS.has(word))
+      .map(word => word.replace(/ies$/, "y").replace(/es$/, "e").replace(/s$/, "")),
+  );
+}
+
+function definitionOverlap(one: string, other: string): number {
+  const left = definitionTokens(one);
+  const right = definitionTokens(other);
+  const shared = [...left].filter(token => right.has(token)).length;
+  const union = new Set([...left, ...right]).size;
+  return union === 0 ? 0 : shared / union;
+}
+
+function labelContains(one: string, other: string): boolean {
+  return one === other || one.startsWith(`${other}_`) || one.endsWith(`_${other}`);
+}
+
+export type CrossTaxonomySignal = "definition" | "label" | "definition and label";
+
+export interface CrossTaxonomyCandidate {
+  a: TaxonomyEntryRef;
+  b: TaxonomyEntryRef;
+  overlap: number;
+  signal: CrossTaxonomySignal;
+}
+
+export function crossTaxonomyCandidates(taxonomies: Record<string, SubtypeTaxonomyEntry[]> = SUBTYPE_TAXONOMIES): CrossTaxonomyCandidate[] {
+  const flat = Object.entries(taxonomies).flatMap(([taxonomy, entries]) => entries.map(entry => ({ taxonomy, ...entry })));
+  const found: CrossTaxonomyCandidate[] = [];
+  for (let i = 0; i < flat.length; i++) {
+    for (let j = i + 1; j < flat.length; j++) {
+      const one = flat[i];
+      const other = flat[j];
+      if (one.taxonomy === other.taxonomy) continue;
+      const overlap = definitionOverlap(one.definition, other.definition);
+      const byDefinition = overlap >= CROSS_TAXONOMY_DEFINITION_OVERLAP;
+      const byLabel = labelContains(one.subtype, other.subtype) || labelContains(other.subtype, one.subtype);
+      if (!byDefinition && !byLabel) continue;
+      found.push({
+        a: { taxonomy: one.taxonomy, subtype: one.subtype },
+        b: { taxonomy: other.taxonomy, subtype: other.subtype },
+        overlap,
+        signal: byDefinition && byLabel ? "definition and label" : byDefinition ? "definition" : "label",
+      });
+    }
+  }
+  return found;
+}
+
+function sameRef(one: TaxonomyEntryRef, other: TaxonomyEntryRef): boolean {
+  return one.taxonomy === other.taxonomy && one.subtype === other.subtype;
+}
+
+export function crossTaxonomyRulingFor(one: TaxonomyEntryRef, other: TaxonomyEntryRef): CrossTaxonomyRuling | null {
+  return (
+    CROSS_TAXONOMY_RULINGS.find(
+      ruling =>
+        (sameRef(ruling.a, one) && sameRef(ruling.b, other)) || (sameRef(ruling.a, other) && sameRef(ruling.b, one)),
+    ) ?? null
+  );
+}
+
+export function canonicalEntryFor(entry: TaxonomyEntryRef): TaxonomyEntryRef {
+  for (const ruling of CROSS_TAXONOMY_RULINGS) {
+    if (!ruling.same || !ruling.canonical) continue;
+    if (sameRef(ruling.a, entry) || sameRef(ruling.b, entry)) return ruling.canonical;
+  }
+  return entry;
+}
+
+export function subtypeEntry(taxonomy: string, subtype: string): SubtypeTaxonomyEntry | null {
+  return SUBTYPE_TAXONOMIES[taxonomy]?.find(entry => entry.subtype === subtype) ?? null;
+}
+
+export function governingDefinition(taxonomy: string, subtype: string): string | null {
+  const canonical = canonicalEntryFor({ taxonomy, subtype });
+  return subtypeEntry(canonical.taxonomy, canonical.subtype)?.definition ?? null;
+}
 
 export interface SubtypeMembershipGroup {
   subtypes: string[];

--- a/src/serve.ts
+++ b/src/serve.ts
@@ -75,8 +75,8 @@ import type { RankedEntry, RankingResult } from "./ranking.js";
 import { eligibilityGateAsPublished, gatedShareDescriptionClause, gatedShareLede, publishableEligibilityConditions } from "./eligibility.js";
 import { gateDisclosureFor } from "./gate-disclosure.js";
 import { verificationLedger, QUARANTINE_AFTER_FAILURES } from "./verification-state.js";
-import { partitionAlternatives, partitionSubstitutes, type SubstitutesPartition, productRoleSentence, MEMBERSHIP_GATE_RULES, MEMBERSHIP_GATE_ORDER, MEMBERSHIP_GATE_SYMMETRY, MEMBERSHIP_GATE_SCOPE, MEMBERSHIP_GATE_CORRECTIONS, SUBTYPE_TAXONOMIES, SUBTYPE_MEMBERSHIP_RULE, SUBTYPE_MEMBERSHIP_GROUP_SCOPE, CURATED_SUBTYPE_EXEMPTION, membershipGroupsFor, subtypeDefinition } from "./product-role.js";
-import { buildProductFunctions, functionMembers, functionDefinitions, admissionFor, splitByFunction, labelsNaming, FUNCTION_RESIDUE_COPY, type ProductFunction, FUNCTION_MEMBERSHIP_RULE, FUNCTION_SPLIT_RULE, FUNCTION_NAMING_RULE } from "./product-function.js";
+import { partitionAlternatives, partitionSubstitutes, type SubstitutesPartition, productRoleSentence, MEMBERSHIP_GATE_RULES, MEMBERSHIP_GATE_ORDER, MEMBERSHIP_GATE_SYMMETRY, MEMBERSHIP_GATE_SCOPE, MEMBERSHIP_GATE_CORRECTIONS, SUBTYPE_TAXONOMIES, SUBTYPE_MEMBERSHIP_RULE, SUBTYPE_MEMBERSHIP_GROUP_SCOPE, CURATED_SUBTYPE_EXEMPTION, membershipGroupsFor, subtypeDefinition, CROSS_TAXONOMY_RULE, CROSS_TAXONOMY_RULINGS } from "./product-role.js";
+import { buildProductFunctions, functionMembers, functionDefinitions, functionMeaningSentence, admissionFor, splitByFunction, labelsNaming, FUNCTION_RESIDUE_COPY, type ProductFunction, FUNCTION_MEMBERSHIP_RULE, FUNCTION_SPLIT_RULE, FUNCTION_NAMING_RULE, FUNCTION_TITLE_RULE, FUNCTION_PICK_RULE } from "./product-function.js";
 import { resolveCuratedAlternatives, curatedAlternativesFor, addCuratedToPool } from "./curated-alternatives.js";
 import type { Agent, ChangeDateSource, DealChange, RiskCause, RatingWithheld, LinkUnreachable, Offer, StabilityClass, SubtypeLabel } from "./types.js";
 import { changeDateLabel, changeEntryDateLabel, changeEntryLongDateLabel, changeDateClause, changeDatePublished, changeEventStartDate, capListSections, latestEventDate, offerExpiryAfter, feedEntryUpdated, undatedGroupHeading, UNDATED_TILE_LABEL, firstReadHeading, discoveryBatchNote, isoWeekOf, monthlyChangeSeries, changesInWindow, discoveryMonthSeriesHeading, periodComparisonSentence, DISCOVERED_DATE_PREFIX, EFFECTIVE_DATE_PREFIX, EVENT_DATED_SOURCES, UNDATED_GROUP_NOTE, UNKNOWN_EFFECTIVE_DATE_MARKER, EFFECTIVE_MONTH_SERIES_NOTE, DISCOVERY_MONTH_SERIES_NOTE, weekRangeLabel } from "./change-dates.js";
@@ -2221,6 +2221,11 @@ ${globalNavCss()}
 }
 
 const BEST_OF_MIN_VENDORS = 5;
+const BEST_OF_MIN_PICKS = 2;
+
+function countedNoun(count: number, noun: string): string {
+  return `${count} ${noun}${count === 1 ? "" : "s"}`;
+}
 
 const productFunctions = buildProductFunctions(categories.map(c => c.name));
 
@@ -2245,6 +2250,20 @@ function rankFunction(fn: ProductFunction, date = utcDate()): RankingResult<Enri
     date,
     verificationLedger: verificationLedger(),
   });
+}
+
+const bestOfPublishedByDate = new Map<string, Map<string, ProductFunction>>();
+
+function publishedBestOf(date = utcDate()): Map<string, ProductFunction> {
+  const held = bestOfPublishedByDate.get(date);
+  if (held) return held;
+  const publishing = new Map<string, ProductFunction>();
+  for (const [slug, fn] of bestOfSlugMap) {
+    if (rankFunction(fn, date).qualified.length >= BEST_OF_MIN_PICKS) publishing.set(slug, fn);
+  }
+  bestOfPublishedByDate.clear();
+  bestOfPublishedByDate.set(date, publishing);
+  return publishing;
 }
 
 function buildBestOfMiniReview(offer: ReturnType<typeof enrichOffers>[number]): string {
@@ -2326,21 +2345,24 @@ function functionEvidenceHtml(offer: EnrichedOfferRow, labels: SubtypeLabel[], f
 }
 
 function buildBestOfPage(slug: string): string | null {
-  const fn = bestOfSlugMap.get(slug);
+  const date = utcDate();
+  const fn = publishedBestOf(date).get(slug);
   if (!fn) return null;
   const categoryName = fn.title;
-  const ranking = rankFunction(fn);
+  const ranking = rankFunction(fn, date);
   const qualified = ranking.qualified;
   const demoted = ranking.demoted;
   const tie = ranking.tie_break;
   const year = new Date().getFullYear();
   const pickCount = qualified.length;
   const groups = splitByFunction(qualified.map(e => e.offer), fn);
-  const definition = fn.categories.length === 0 ? functionDefinitions(fn).join("; or when it ") || null : null;
-  const title = `Best Free ${categoryName} Tools (${year}) — AgentDeals`;
-  const metaDesc = definition
-    ? `Every free ${categoryName.toLowerCase()} tier that clears our bar in ${year}: ${pickCount} offers meet the criteria and ${demoted.length} are demoted with a named reason. We list a product here when it ${definition}.`
-    : `Every free ${categoryName.toLowerCase()} tier that clears our bar in ${year}: ${pickCount} offers meet the criteria and ${demoted.length} are demoted with a named reason. Verified pricing, recorded changes, and a published ranking method.`;
+  const meaning = fn.categories.length === 0 ? functionMeaningSentence(functionDefinitions(fn)) : "";
+  const listNoun = fn.listNoun;
+  const title = `Best Free ${listNoun} (${year}) — AgentDeals`;
+  const clearOurBar = `Every free ${categoryName.toLowerCase()} tier that clears our bar in ${year}: ${countedNoun(pickCount, "offer")} ${pickCount === 1 ? "meets" : "meet"} the criteria and ${countedNoun(demoted.length, "offer")} ${demoted.length === 1 ? "is" : "are"} demoted with a named reason.`;
+  const metaDesc = meaning
+    ? `${clearOurBar} ${meaning}`
+    : `${clearOurBar} Verified pricing, recorded changes, and a published ranking method.`;
 
   const riskColors: Record<string, string> = { stable: "#3fb950", caution: "#d29922", risky: "#f85149" };
   const pageScope = fn.categories.length === 1 && fn.subtypes.length === 0 ? "for this category" : "on this page";
@@ -2434,7 +2456,7 @@ ${cards}`;
     ? {
         "@context": "https://schema.org",
         "@type": "ItemList",
-        name: `Best Free ${categoryName} Tools`,
+        name: `Best Free ${listNoun}`,
         description: metaDesc,
         numberOfItems: renderedGroups.length,
         itemListElement: renderedGroups.map((group, i) => ({
@@ -2452,7 +2474,7 @@ ${cards}`;
     : {
         "@context": "https://schema.org",
         "@type": "ItemList",
-        name: `Best Free ${categoryName} Tools`,
+        name: `Best Free ${listNoun}`,
         description: metaDesc,
         numberOfItems: pickCount,
         itemListElement: listOf(qualified.map(e => e.offer)),
@@ -2463,7 +2485,7 @@ ${cards}`;
     .map(c => `<a href="/category/${toSlug(c)}">See all ${offers.filter(o => o.category === c).length} ${escHtmlServer(c.toLowerCase())} offers &rarr;</a>`)
     .join(" ");
 
-  const otherBestOf = Array.from(bestOfSlugMap.entries())
+  const otherBestOf = Array.from(publishedBestOf(date).entries())
     .filter(([s]) => s !== slug)
     .sort((a, b) => functionMembers(offers, b[1]).length - functionMembers(offers, a[1]).length)
     .slice(0, 10)
@@ -2544,8 +2566,8 @@ ${mcpCtaCss()}
 <div class="container">
   ${buildGlobalNav("best")}
   <div class="breadcrumb"><a href="/">AgentDeals</a> &rsaquo; <a href="/best">Best Of</a> &rsaquo; ${escHtmlServer(categoryName)}</div>
-  <h1>Best Free ${escHtmlServer(categoryName)} Tools</h1>
-  <p class="page-meta">Every free ${escHtmlServer(categoryName.toLowerCase())} tier that clears our bar today. Updated ${tie.date}.${definition ? ` We list a product here when it ${escHtmlServer(definition)}.` : ""}</p>
+  <h1>Best Free ${escHtmlServer(listNoun)}</h1>
+  <p class="page-meta">Every free ${escHtmlServer(categoryName.toLowerCase())} tier that clears our bar today. Updated ${tie.date}.${meaning ? ` ${escHtmlServer(meaning)}` : ""}</p>
 
   <div class="tie-note">${tiePara}</div>
 
@@ -2593,12 +2615,13 @@ ${tableRows}
 
 function buildBestOfIndexPage(): string {
   const year = new Date().getFullYear();
-  const bestOfCount = bestOfSlugMap.size;
-  const categoryPageCount = [...bestOfSlugMap.values()].filter(fn => fn.categories.length > 0).length;
+  const publishing = publishedBestOf();
+  const bestOfCount = publishing.size;
+  const categoryPageCount = [...publishing.values()].filter(fn => fn.categories.length > 0).length;
   const title = `Best Free Developer Tools (${year}) — AgentDeals`;
   const metaDesc = `Every free tier that clears our bar, across ${bestOfCount} developer tool functions. Offers are never promoted — only demoted, on a named recorded fact. The method is published.`;
 
-  const sortedEntries = Array.from(bestOfSlugMap.entries())
+  const sortedEntries = Array.from(publishing.entries())
     .sort((a, b) => functionMembers(offers, b[1]).length - functionMembers(offers, a[1]).length);
 
   const cardsHtml = sortedEntries.map(([slug, fn]) => {
@@ -2687,7 +2710,7 @@ function summariseBestOfTies(date = utcDate()): BestOfTieSummary {
   let tieSum = 0;
   let bestOfPageCount = 0;
   let categoryPageCount = 0;
-  for (const [, fn] of bestOfSlugMap) {
+  for (const [, fn] of publishedBestOf(date)) {
     const r = rankFunction(fn, date);
     bestOfPageCount++;
     if (fn.categories.length > 0) categoryPageCount++;
@@ -2714,6 +2737,9 @@ function buildCriteriaPage(): string {
 
   const tieSummary = summariseBestOfTies(date);
   const { bestOfPageCount, categoriesWithUniqueTop, meanTie } = tieSummary;
+  const categoriesWithoutPage = categories.length - tieSummary.categoryPageCount;
+  const categoriesBelowReach = categories.length - [...bestOfSlugMap.values()].filter(fn => fn.categories.length > 0).length;
+  const categoriesBelowPicks = categoriesWithoutPage - categoriesBelowReach;
 
   const title = "How AgentDeals ranks — published criteria — AgentDeals";
   const metaDesc = "Our ranking method in full: the gates, the demerits and their weights, the tie-break seed, and the reason there is no top slot to sell. Recompute any ranked page yourself.";
@@ -2734,6 +2760,9 @@ function buildCriteriaPage(): string {
 ${entries.map(e => `<tr><td><code>${escHtmlServer(e.subtype)}</code></td><td>${escHtmlServer(e.definition)}</td><td style="text-align:center;font-family:var(--mono)">${grouped.has(e.subtype) ? "&#10003;" : "&mdash;"}</td></tr>`).join("\n")}
   </tbody></table>${groupParagraphs}`;
   }).join("\n");
+  const crossTaxonomyRows = CROSS_TAXONOMY_RULINGS.map(r =>
+    `<tr><td><code>${escHtmlServer(r.a.taxonomy)} / ${escHtmlServer(r.a.subtype)}</code><br><code>${escHtmlServer(r.b.taxonomy)} / ${escHtmlServer(r.b.subtype)}</code></td><td style="text-align:center;font-family:var(--mono)">${r.same ? `one function &mdash; <code>${escHtmlServer(r.canonical!.subtype)}</code> governs` : "two functions"}</td><td>${escHtmlServer(r.reason)}</td></tr>`,
+  ).join("\n");
   const subtypeCoverageClause = (() => {
     const parts = Object.keys(SUBTYPE_TAXONOMIES).map(taxonomy => {
       const inTaxonomy = offers.filter(o => o.category === taxonomy);
@@ -2851,9 +2880,10 @@ ${demeritRows}
   <div class="callout">
     <strong>${uniqueTopClause(tieSummary).replace(/^0 /, "Zero ")}.</strong> ${categoriesWithUniqueTop.length === 0
       ? "Under every criterion we currently record, there is no single best free database, no best free AI/ML tool, no best free anything."
-      : "Everywhere else, under every criterion we currently record, there is no single best free tier of anything."} On average ${meanTie} offers tie at the top of those pages. A best-of page is named after a product function: ${tieSummary.categoryPageCount} of the ${bestOfPageCount} are named after a category and the site publishes ${categories.length} categories in all, so the ${categories.length - tieSummary.categoryPageCount} with fewer than ${BEST_OF_MIN_VENDORS} generally-available offers have no best-of page and are not counted here. The remaining ${bestOfPageCount - tieSummary.categoryPageCount} are named after a subtype label.
+      : "Everywhere else, under every criterion we currently record, there is no single best free tier of anything."} On average ${meanTie} offers tie at the top of those pages. A best-of page is named after a product function: ${tieSummary.categoryPageCount} of the ${bestOfPageCount} are named after a category and the site publishes ${categories.length} categories in all, so the ${categoriesWithoutPage} with no page &mdash; ${categoriesBelowReach} reaching fewer than ${BEST_OF_MIN_VENDORS} generally-available offers and ${categoriesBelowPicks} whose list would publish fewer than ${BEST_OF_MIN_PICKS} today &mdash; are not counted here. The remaining ${bestOfPageCount - tieSummary.categoryPageCount} are named after a subtype label.
   </div>
   <p id="functions">${escHtmlServer(FUNCTION_NAMING_RULE)} ${escHtmlServer(FUNCTION_MEMBERSHIP_RULE)}</p>
+  <p>${escHtmlServer(FUNCTION_TITLE_RULE)} ${escHtmlServer(FUNCTION_PICK_RULE)}</p>
   <p>We think that is the honest answer and a better thing to publish than a manufactured winner. It is also the strongest form of &ldquo;our recommendations are not for sale&rdquo;: there is no top slot, so there is nothing to buy. A vendor cannot improve its position by talking to us &mdash; only by improving its offer, or by us being able to verify it.</p>
 
   <h3>The tie-break</h3>
@@ -2877,6 +2907,11 @@ ${membershipGateRows}
   <h3 id="subtypes">Subtypes</h3>
   <p>A category is a coarse property. Where we have published a subtype taxonomy for a category, the same discipline applies one level finer: a subtype is what the vendor's own copy says the product <em>is</em>, it is multi-label, and it decides membership only. ${escHtmlServer(SUBTYPE_MEMBERSHIP_RULE)}</p>
 ${subtypeTaxonomyTables}
+  <h4>Where two parents name one function</h4>
+  <p>${escHtmlServer(CROSS_TAXONOMY_RULE)}</p>
+  <table><thead><tr><th>Pair</th><th>Ruling</th><th>Why</th></tr></thead><tbody>
+${crossTaxonomyRows}
+  </tbody></table>
   <p>${escHtmlServer(SUBTYPE_MEMBERSHIP_GROUP_SCOPE)}</p>
   <p>Subtypes are published on every classified vendor page with the source URL and the sentence they were read from, exactly as the properties above are. ${subtypeCoverageClause}</p>
   <p><strong style="color:var(--text)">Where a taxonomy is published, silence is not a pass.</strong> A record we have not read against it is held out of that category's alternatives lists and named there, rather than offered on the strength of a reading we never did. That is the opposite of how the properties above treat absence, and it is deliberate: those describe a product we looked at, while a missing subtype describes only us.</p>
@@ -54938,7 +54973,7 @@ ${catList}
       xml += '  <url>\n    <loc>' + BASE_URL + '/category/' + toSlug(c.name) + '</loc>\n    <lastmod>' + catLastmod + '</lastmod>\n    <changefreq>weekly</changefreq>\n    <priority>0.8</priority>\n  </url>\n';
     }
     xml += '  <url>\n    <loc>' + BASE_URL + '/best</loc>\n    <lastmod>' + latestVerified + '</lastmod>\n    <changefreq>weekly</changefreq>\n    <priority>0.8</priority>\n  </url>\n';
-    for (const [s, fn] of bestOfSlugMap.entries()) {
+    for (const [s, fn] of publishedBestOf().entries()) {
       const memberStamps = [...new Set(functionMembers(offers, fn).map(o => toSlug(o.category)))]
         .map(c => categoryLastmod.get(c))
         .filter((v): v is string => Boolean(v))
@@ -55006,7 +55041,7 @@ ${catList}
     res.end(landingPageHtml);
   } else if ((url.pathname === "/best" || url.pathname === "/best/") && isGetOrHead) {
     recordApiHit("/best");
-    logRequest({ ts: new Date().toISOString(), type: "api", endpoint: "/best", params: {}, user_agent: req.headers["user-agent"] ?? "unknown", result_count: bestOfSlugMap.size });
+    logRequest({ ts: new Date().toISOString(), type: "api", endpoint: "/best", params: {}, user_agent: req.headers["user-agent"] ?? "unknown", result_count: publishedBestOf().size });
     res.writeHead(200, { "Content-Type": "text/html; charset=utf-8", "Cache-Control": "public, max-age=3600" });
     res.end(buildBestOfIndexPage());
   } else if (url.pathname.startsWith("/best/") && isGetOrHead) {
@@ -56739,7 +56774,7 @@ async function pingSearchEngines(): Promise<void> {
   for (const c of categories) {
     urlList.push(`${BASE_URL}/category/${toSlug(c.name)}`);
   }
-  for (const s of bestOfSlugMap.keys()) {
+  for (const s of publishedBestOf().keys()) {
     urlList.push(`${BASE_URL}/best/${s}`);
   }
   for (const s of comparisonMap.keys()) {

--- a/test/function-naming.test.ts
+++ b/test/function-naming.test.ts
@@ -1,0 +1,357 @@
+import { describe, it, before, after } from "node:test";
+import assert from "node:assert";
+import { spawn, type ChildProcess } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { enrichOffers, gateForOffer, getCategories, loadDealChanges, loadOffers } from "../dist/data.js";
+import {
+  SUBTYPE_TAXONOMIES,
+  CROSS_TAXONOMY_RULINGS,
+  crossTaxonomyCandidates,
+  crossTaxonomyRulingFor,
+  canonicalEntryFor,
+  governingDefinition,
+  type SubtypeTaxonomyEntry,
+} from "../dist/product-role.js";
+import {
+  buildProductFunctions,
+  functionMembers,
+  functionDefinitions,
+  functionMeaningSentence,
+  type ProductFunction,
+} from "../dist/product-function.js";
+import { rankOffers } from "../dist/ranking.js";
+import { verificationLedger } from "../dist/verification-state.js";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO = path.join(__dirname, "..");
+
+const offers = loadOffers();
+const categories = getCategories();
+const functions = buildProductFunctions(categories.map(c => c.name));
+const serveSource = fs.readFileSync(path.join(REPO, "src", "serve.ts"), "utf8");
+const MIN_VENDORS = Number(/const BEST_OF_MIN_VENDORS = (\d+);/.exec(serveSource)?.[1]);
+const MIN_PICKS = Number(/const BEST_OF_MIN_PICKS = (\d+);/.exec(serveSource)?.[1]);
+const TODAY = new Date().toISOString().slice(0, 10);
+
+function picksFor(fn: ProductFunction, date = TODAY): number {
+  return rankOffers(enrichOffers(functionMembers(offers, fn)), {
+    queryKey: `best-of:${fn.categories[0] ?? fn.subtypes[0]}`,
+    changes: loadDealChanges(),
+    date,
+    verificationLedger: verificationLedger(),
+  }).qualified.length;
+}
+
+const reaching = functions.filter(fn => functionMembers(offers, fn).filter(o => !o.eligibility).length >= MIN_VENDORS);
+const published = reaching.filter(fn => picksFor(fn) >= MIN_PICKS);
+
+function startServer(env: NodeJS.ProcessEnv = {}): Promise<{ child: ChildProcess; port: number }> {
+  return new Promise((resolve, reject) => {
+    const child = spawn("node", [path.join(REPO, "dist", "serve.js")], {
+      stdio: ["pipe", "pipe", "pipe"],
+      env: { ...process.env, PORT: "0", BASE_URL: "http://localhost", TZ: "UTC", ...env },
+    });
+    const timeout = setTimeout(() => { child.kill(); reject(new Error("Server startup timeout")); }, 60000);
+    child.stderr!.on("data", (data: Buffer) => {
+      const m = data.toString().match(/running on http:\/\/localhost:(\d+)/);
+      if (m) { clearTimeout(timeout); resolve({ child, port: parseInt(m[1], 10) }); }
+    });
+    child.on("error", (e) => { clearTimeout(timeout); reject(e); });
+  });
+}
+
+let server: ChildProcess;
+let port = 0;
+
+before(async () => { ({ child: server, port } = await startServer()); });
+after(() => { server?.kill(); });
+
+async function page(pathname: string): Promise<{ status: number; html: string }> {
+  const res = await fetch(`http://localhost:${port}${pathname}`, { redirect: "error" });
+  return { status: res.status, html: await res.text() };
+}
+
+const unescapeForTest = (s: string) =>
+  s.replace(/&amp;/g, "&").replace(/&#39;/g, "'").replace(/&quot;/g, '"').replace(/&lt;/g, "<").replace(/&gt;/g, ">");
+
+function vendorsListed(html: string): string[] {
+  return [...html.matchAll(/class="best-pick-name">([^<]*)</g)].map(m => unescapeForTest(m[1]));
+}
+
+function refName(ref: { taxonomy: string; subtype: string }): string {
+  return `${ref.taxonomy}/${ref.subtype}`;
+}
+
+describe("one function carries one name, whichever parent declared it", () => {
+  it("resolves the two labels for similarity search to a single function", () => {
+    const carrying = functions.filter(fn => fn.subtypes.includes("vector") || fn.subtypes.includes("vector_store"));
+    assert.strictEqual(carrying.length, 1, `${carrying.length} functions carry a similarity-search label`);
+    assert.deepStrictEqual([...carrying[0].subtypes].sort(), ["vector", "vector_store"]);
+    assert.deepStrictEqual([...carrying[0].taxonomies].sort(), ["AI / ML", "Databases"]);
+    assert.strictEqual(carrying[0].slug, "vector");
+  });
+
+  it("lists the records both parents filed on the page named after that function", async () => {
+    const fn = functions.find(f => f.slug === "vector")!;
+    const { status, html } = await page("/best/free-vector");
+    assert.strictEqual(status, 200);
+    const listed = new Set(vendorsListed(html));
+
+    const bothParents = offers.filter(o => (o.product_subtypes?.labels ?? []).some(l => l.subtype === "vector" || l.subtype === "vector_store"));
+    assert.ok(bothParents.some(o => o.category === "AI / ML"), "no record carries the label under the AI / ML parent");
+    assert.ok(bothParents.some(o => o.category === "Databases"), "no record carries the label under the Databases parent");
+
+    for (const vendor of ["Pinecone", "Qdrant", "Weaviate", "Chroma"]) {
+      const offer = offers.find(o => o.vendor === vendor);
+      assert.ok(offer, `the catalogue holds no ${vendor} record, so this test asserts nothing`);
+      assert.strictEqual(gateForOffer(offer!), null, `${vendor} is gated, so its absence would not be about naming`);
+      assert.ok(listed.has(vendor), `${vendor} carries a similarity-search label and is absent from /best/free-vector`);
+    }
+
+    const absent = bothParents.filter(o => !listed.has(o.vendor));
+    for (const offer of absent) {
+      assert.notStrictEqual(gateForOffer(offer), null, `${offer.vendor} is ungated and absent from /best/free-vector`);
+    }
+    assert.ok(
+      absent.some(o => (o.product_subtypes?.labels ?? []).some(l => l.subtype === "vector")),
+      "every record the free-tier gate withholds here carries the AI / ML label, so the gate and the merge are not separable",
+    );
+    assert.deepStrictEqual(functionMembers(offers, fn).length, bothParents.length);
+  });
+
+  it("rules on every pair the taxonomies flag across parents, and flags every pair it rules on", () => {
+    const candidates = crossTaxonomyCandidates();
+    assert.ok(candidates.length >= 3, `only ${candidates.length} cross-parent candidates, so this sweep is not reading the taxonomy`);
+    const unruled = candidates.filter(c => crossTaxonomyRulingFor(c.a, c.b) === null);
+    assert.deepStrictEqual(unruled.map(c => `${refName(c.a)} <> ${refName(c.b)}`), []);
+
+    for (const ruling of CROSS_TAXONOMY_RULINGS) {
+      const flagged = candidates.some(c => crossTaxonomyRulingFor(c.a, c.b) === ruling);
+      assert.ok(flagged, `${refName(ruling.a)} <> ${refName(ruling.b)} is ruled on and the taxonomies no longer bring it up`);
+      assert.ok(ruling.reason.length > 0, `${refName(ruling.a)} <> ${refName(ruling.b)} states no reason`);
+      if (ruling.same) assert.ok(ruling.canonical, `${refName(ruling.a)} <> ${refName(ruling.b)} is one function and names no governing entry`);
+    }
+    assert.ok(CROSS_TAXONOMY_RULINGS.some(r => r.same), "no pair is ruled one function, so the register proves nothing");
+    assert.ok(CROSS_TAXONOMY_RULINGS.some(r => !r.same), "no pair is ruled two functions, so the register never refuses a merge");
+  });
+
+  it("goes red on a label duplicated under another parent that nobody has ruled on", () => {
+    const seeded: Record<string, SubtypeTaxonomyEntry[]> = {
+      ...SUBTYPE_TAXONOMIES,
+      Monitoring: [
+        ...SUBTYPE_TAXONOMIES.Monitoring,
+        { subtype: "uptime_probe", definition: SUBTYPE_TAXONOMIES["Cloud Hosting"][0].definition },
+      ],
+    };
+    const candidates = crossTaxonomyCandidates(seeded);
+    const seededPair = candidates.find(c => c.a.subtype === "uptime_probe" || c.b.subtype === "uptime_probe");
+    assert.ok(seededPair, "a definition copied verbatim under another parent is not flagged as a candidate");
+    assert.strictEqual(crossTaxonomyRulingFor(seededPair!.a, seededPair!.b), null);
+    const unruled = candidates.filter(c => crossTaxonomyRulingFor(c.a, c.b) === null);
+    assert.strictEqual(unruled.length, 1, "the seed is the only unruled pair, so the completeness check is what went red");
+  });
+
+  it("gives a merged function one governing definition rather than one per parent", () => {
+    const fn = functions.find(f => f.slug === "vector")!;
+    assert.strictEqual(functionDefinitions(fn).length, 1, "the merged function publishes more than one definition of itself");
+    assert.strictEqual(functionDefinitions(fn)[0], governingDefinition("AI / ML", "vector_store"));
+    assert.strictEqual(canonicalEntryFor({ taxonomy: "AI / ML", subtype: "vector_store" }).subtype, "vector");
+  });
+
+  it("keeps the substring overlaps that are not one function apart", () => {
+    const ruling = crossTaxonomyRulingFor({ taxonomy: "Databases", subtype: "document" }, { taxonomy: "AI / ML", subtype: "document_extraction" });
+    assert.ok(ruling, "the document pair is not ruled on");
+    assert.strictEqual(ruling!.same, false);
+    const documents = functions.find(f => f.subtypes.includes("document"))!;
+    assert.ok(!documents.subtypes.includes("document_extraction"), "document extraction was folded into the document database function");
+  });
+});
+
+describe("a function page's sentences do not constrain the wording of a definition", () => {
+  const VERB_PHRASE = SUBTYPE_TAXONOMIES.Monitoring[0].definition;
+  const NOUN_PHRASE = SUBTYPE_TAXONOMIES.Databases[0].definition;
+  const ADDRESSED_TO_READER = SUBTYPE_TAXONOMIES["Cloud Hosting"][2].definition;
+
+  function definitionStartsAClause(sentence: string, definition: string): boolean {
+    const at = sentence.indexOf(definition);
+    if (at < 0) return false;
+    return /[:;—]$/.test(sentence.slice(0, at).trimEnd());
+  }
+
+  it("composes the same way for a verb phrase, a noun phrase and a phrase addressed to the reader", () => {
+    for (const definition of [VERB_PHRASE, NOUN_PHRASE, ADDRESSED_TO_READER]) {
+      const sentence = functionMeaningSentence([definition]);
+      assert.ok(definitionStartsAClause(sentence, definition), `a definition is spliced mid-clause: ${sentence}`);
+      assert.ok(sentence.endsWith("."), `the sentence does not end: ${sentence}`);
+    }
+  });
+
+  it("rejects the shape that reads correctly only for a verb phrase", () => {
+    assert.ok(definitionStartsAClause(`We list a product here when it ${VERB_PHRASE}.`, VERB_PHRASE) === false);
+    assert.ok(definitionStartsAClause(`We list a product here when it ${NOUN_PHRASE}.`, NOUN_PHRASE) === false);
+    assert.ok(definitionStartsAClause(functionMeaningSentence([NOUN_PHRASE]), NOUN_PHRASE));
+  });
+
+  it("places every definition it publishes at a clause boundary, in the description and the structured data", async () => {
+    let checked = 0;
+    for (const fn of published.filter(f => f.categories.length === 0)) {
+      const { html } = await page(`/best/free-${fn.slug}`);
+      const meta = unescapeForTest(/<meta name="description" content="([^"]*)"/.exec(html)?.[1] ?? "");
+      const jsonLd = JSON.parse(/<script type="application\/ld\+json">(\{"@context":"https:\/\/schema.org","@type":"ItemList".*?)<\/script>/.exec(html)?.[1] ?? "{}");
+      const pageMeta = unescapeForTest(/<p class="page-meta">([\s\S]*?)<\/p>/.exec(html)?.[1] ?? "");
+      for (const definition of functionDefinitions(fn)) {
+        checked++;
+        for (const [where, text] of [["meta description", meta], ["ItemList description", String(jsonLd.description ?? "")], ["page heading", pageMeta]] as const) {
+          assert.ok(definitionStartsAClause(text, definition), `/best/free-${fn.slug} splices its definition mid-clause in the ${where}: ${text}`);
+        }
+      }
+    }
+    assert.ok(checked >= 15, `only ${checked} definitions were published, so this sweep is not measuring the namespace`);
+  });
+
+  it("counts offers in the number it uses for them", async () => {
+    for (const fn of published) {
+      const { html } = await page(`/best/free-${fn.slug}`);
+      const meta = unescapeForTest(/<meta name="description" content="([^"]*)"/.exec(html)?.[1] ?? "");
+      const counted = [...meta.matchAll(/(\d+) (offers?)(?: (meets?|is|are))?/g)];
+      assert.ok(counted.length >= 2, `/best/free-${fn.slug} counts nothing in its description: ${meta}`);
+      for (const [, count, noun, verb] of counted) {
+        const plural = Number(count) !== 1;
+        assert.strictEqual(noun, plural ? "offers" : "offer", `/best/free-${fn.slug} writes "${count} ${noun}"`);
+        if (!verb) continue;
+        const agrees = plural ? ["meet", "are"] : ["meets", "is"];
+        assert.ok(agrees.includes(verb), `/best/free-${fn.slug} writes "${count} ${noun} ${verb}"`);
+      }
+    }
+  });
+});
+
+describe("a page's title names a class of product", () => {
+  const generic = new Set(["best", "free", "tools", "and", "&"]);
+  const contentTokens = (title: string) =>
+    title.toLowerCase().replace(/[^a-z0-9\s]/g, " ").split(/\s+/).filter(w => w.length > 0 && !generic.has(w));
+
+  it("never titles a subtype page with the attribute alone", () => {
+    const bare = published.filter(fn => fn.categories.length === 0 && contentTokens(fn.title).length < 2);
+    assert.deepStrictEqual(bare.map(fn => `/best/free-${fn.slug} is titled "${fn.title}"`), []);
+    assert.ok(published.some(fn => fn.categories.length === 0), "no subtype page is published, so this sweep asserts nothing");
+  });
+
+  it("takes a declared name from the noun its parent category supplies", () => {
+    let declared = 0;
+    for (const [taxonomy, entries] of Object.entries(SUBTYPE_TAXONOMIES)) {
+      for (const entry of entries) {
+        if (!entry.name) continue;
+        declared++;
+        const head = entry.name.split(" ").at(-1)!.toLowerCase();
+        assert.ok(
+          taxonomy.toLowerCase().split(/[^a-z]+/).includes(head),
+          `${taxonomy}/${entry.subtype} is named "${entry.name}" and ${head} is not a noun its parent supplies`,
+        );
+        const fn = functions.find(f => f.subtypes.includes(entry.subtype) && f.categories.length === 0);
+        if (fn) assert.strictEqual(fn.listNoun, entry.name, `/best/free-${fn.slug} does not publish the name declared for it`);
+      }
+    }
+    assert.ok(declared >= 3, `only ${declared} names are declared, so this sweep is not reading the taxonomy`);
+  });
+
+  it("does not title a page with a word our own catalogue uses for a different kind of product", async () => {
+    const fn = published.find(f => f.slug === "vector")!;
+    const memberCategories = new Set(functionMembers(offers, fn).map(o => o.category));
+    const otherSense = offers.filter(o => !memberCategories.has(o.category) && /\bvector\b/i.test(`${o.vendor} ${o.description ?? ""}`));
+    assert.ok(otherSense.length >= 2, "the catalogue holds no other sense of the word, so this test asserts nothing");
+    assert.ok(
+      otherSense.some(o => /design/i.test(o.category)),
+      "no design product uses the word, so the two senses this title has to separate are not both in the catalogue",
+    );
+    const { html } = await page("/best/free-vector");
+    const heading = /<h1>([^<]*)<\/h1>/.exec(html)?.[1] ?? "";
+    assert.ok(!/^Best Free Vector Tools?$/.test(heading), `/best/free-vector is titled "${heading}"`);
+    const distinguishing = contentTokens(heading).filter(t => t !== "vector");
+    assert.ok(distinguishing.length > 0, `/best/free-vector's title adds nothing to the bare attribute: ${heading}`);
+    for (const other of otherSense) {
+      const text = `${other.vendor} ${other.category} ${other.description ?? ""}`.toLowerCase();
+      assert.ok(
+        distinguishing.some(token => !text.includes(token)),
+        `${other.vendor} would answer to "${heading}" as readily as the products on the page`,
+      );
+    }
+  });
+
+  it("publishes no two titles distinguishable only by a word that does not distinguish their contents", async () => {
+    const index = await page("/best");
+    assert.strictEqual(index.status, 200);
+    const titles = published.map(fn => ({ slug: fn.slug, tokens: contentTokens(fn.title) }));
+    const collisions: string[] = [];
+    for (let i = 0; i < titles.length; i++) {
+      for (let j = i + 1; j < titles.length; j++) {
+        const a = titles[i];
+        const b = titles[j];
+        if (a.tokens.length !== b.tokens.length) continue;
+        const differing = a.tokens.filter((t, k) => t !== b.tokens[k]);
+        if (differing.length !== 1) continue;
+        const k = a.tokens.findIndex((t, n) => t !== b.tokens[n]);
+        if (a.tokens[k].startsWith(b.tokens[k]) || b.tokens[k].startsWith(a.tokens[k])) {
+          collisions.push(`/best/free-${a.slug} and /best/free-${b.slug}`);
+        }
+      }
+    }
+    assert.deepStrictEqual(collisions, []);
+  });
+
+  it("leaves every category-named page titled after its category", async () => {
+    const named = published.filter(fn => fn.categories.length > 0);
+    assert.strictEqual(named.length, 58);
+    for (const fn of named) {
+      assert.strictEqual(fn.title, fn.categories[0]);
+      assert.strictEqual(fn.listNoun, `${fn.categories[0]} Tools`);
+      const { status, html } = await page(`/best/free-${fn.slug}`);
+      assert.strictEqual(status, 200, `/best/free-${fn.slug} answers ${status}`);
+      assert.ok(html.includes(`<h1>Best Free ${fn.categories[0].replace(/&/g, "&amp;")} Tools</h1>`), `/best/free-${fn.slug} lost its category title`);
+    }
+  });
+});
+
+describe("a page named after a class publishes more than one of them", () => {
+  it("serves no page whose list holds a single pick", async () => {
+    let checked = 0;
+    for (const fn of published) {
+      const { status, html } = await page(`/best/free-${fn.slug}`);
+      assert.strictEqual(status, 200, `/best/free-${fn.slug} answers ${status}`);
+      const demotedAt = html.indexOf("<h2>Demoted");
+      const picks = vendorsListed(html.slice(0, demotedAt)).length;
+      assert.ok(picks >= MIN_PICKS, `/best/free-${fn.slug} publishes ${picks} pick`);
+      checked++;
+    }
+    assert.ok(checked >= 70, `only ${checked} pages were read, so this sweep is not measuring the namespace`);
+  });
+
+  it("withholds the URL from a function that reaches the record threshold and would publish one", async () => {
+    const withheld = reaching.filter(fn => picksFor(fn) < MIN_PICKS);
+    assert.ok(withheld.length > 0, "no function is withheld today, so this test asserts nothing");
+    const map = await page("/sitemap-pages.xml");
+    for (const fn of withheld) {
+      const reachable = functionMembers(offers, fn).filter(o => !o.eligibility).length;
+      assert.ok(reachable >= MIN_VENDORS, `${fn.slug} does not reach the record threshold, so it is not the case under test`);
+      const { status } = await page(`/best/free-${fn.slug}`);
+      assert.strictEqual(status, 404, `/best/free-${fn.slug} answers ${status} while publishing ${picksFor(fn)} pick`);
+      assert.ok(!map.html.includes(`/best/free-${fn.slug}<`), `/best/free-${fn.slug} answers 404 and is in the sitemap`);
+    }
+  });
+
+  it("states on the published method why a function with enough records can still have no page", async () => {
+    const { status, html } = await page("/criteria");
+    assert.strictEqual(status, 200);
+    assert.match(html, /the threshold counts what the page shows rather than what it could reach/);
+    assert.match(html, /whose list would publish fewer than 2 today/);
+  });
+
+  it("keeps the demoted band on the pages it still serves", async () => {
+    const { html } = await page("/best/free-vector");
+    assert.match(html, /Rankings start every offer at zero and can only demote/);
+    assert.match(html, /There is no top slot here to sell/);
+    assert.ok(!/\bbest pick\b|\bwinner\b|\bnumber one\b|\btop pick\b/i.test(html), "/best/free-vector crowns an entry");
+  });
+});

--- a/test/product-function-pages.test.ts
+++ b/test/product-function-pages.test.ts
@@ -25,9 +25,10 @@ const REPO = path.join(__dirname, "..");
 const offers = loadOffers();
 const categories = getCategories();
 const functions = buildProductFunctions(categories.map(c => c.name));
-const MIN_VENDORS = Number(/const BEST_OF_MIN_VENDORS = (\d+);/.exec(fs.readFileSync(path.join(REPO, "src", "serve.ts"), "utf8"))?.[1]);
-
-const published = functions.filter(fn => functionMembers(offers, fn).filter(o => !o.eligibility).length >= MIN_VENDORS);
+const serveSource = fs.readFileSync(path.join(REPO, "src", "serve.ts"), "utf8");
+const MIN_VENDORS = Number(/const BEST_OF_MIN_VENDORS = (\d+);/.exec(serveSource)?.[1]);
+const MIN_PICKS = Number(/const BEST_OF_MIN_PICKS = (\d+);/.exec(serveSource)?.[1]);
+const TODAY = new Date().toISOString().slice(0, 10);
 
 function rankedFor(fn: ProductFunction, date: string) {
   return rankOffers(enrichOffers(functionMembers(offers, fn)), {
@@ -37,6 +38,10 @@ function rankedFor(fn: ProductFunction, date: string) {
     verificationLedger: verificationLedger(),
   });
 }
+
+const reaching = functions.filter(fn => functionMembers(offers, fn).filter(o => !o.eligibility).length >= MIN_VENDORS);
+const published = reaching.filter(fn => rankedFor(fn, TODAY).qualified.length >= MIN_PICKS);
+const withheld = reaching.filter(fn => !published.includes(fn));
 
 function reachesAPage(offer: Offer): boolean {
   return gateForOffer(offer) === null;
@@ -89,9 +94,10 @@ function groupBlocks(html: string): { subtype: string; body: string }[] {
 const escapeForTest = (s: string) => s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;");
 
 describe("a page named after a product function draws on both encodings of it", () => {
-  it("the threshold this sweep uses is the one the site publishes with", () => {
-    assert.ok(Number.isInteger(MIN_VENDORS) && MIN_VENDORS > 0, "src/serve.ts must state a minimum these sweeps can read");
-    assert.ok(published.length > categories.length - 20, `only ${published.length} functions clear the threshold`);
+  it("the thresholds this sweep uses are the ones the site publishes with", () => {
+    assert.ok(Number.isInteger(MIN_VENDORS) && MIN_VENDORS > 0, "src/serve.ts must state a record minimum these sweeps can read");
+    assert.ok(Number.isInteger(MIN_PICKS) && MIN_PICKS > 1, "src/serve.ts must state a pick minimum above one");
+    assert.ok(published.length > categories.length - 20, `only ${published.length} functions clear both thresholds`);
   });
 
   it("lists Sentry on the error tracking page, quoting the page the label was read from", async () => {
@@ -199,7 +205,7 @@ describe("two names are the same function only when they name the same thing", (
 });
 
 describe("every function with enough vendors to compare has a page", () => {
-  it("publishes one for every subtype that clears the threshold", async () => {
+  it("publishes one for every subtype whose list would hold more than one pick, and no others", async () => {
     const bySubtype = new Map<string, Offer[]>();
     for (const offer of offers) {
       for (const label of offer.product_subtypes?.labels ?? []) {
@@ -209,21 +215,36 @@ describe("every function with enough vendors to compare has a page", () => {
       }
     }
     const owed = [...bySubtype.entries()].filter(([, list]) => list.filter(o => !o.eligibility).length >= MIN_VENDORS);
-    assert.ok(owed.length >= 20, `only ${owed.length} subtypes clear the threshold, so this sweep is not measuring the backlog`);
+    assert.ok(owed.length >= 20, `only ${owed.length} subtypes clear the record threshold, so this sweep is not measuring the backlog`);
+    let served = 0;
+    let withheldHere = 0;
     for (const [subtype] of owed) {
       const fn = functions.find(f => f.subtypes.includes(subtype));
       assert.ok(fn, `${subtype} names no function`);
+      const picks = rankedFor(fn!, TODAY).qualified.length;
       const { status } = await page(`/best/free-${fn!.slug}`);
-      assert.strictEqual(status, 200, `/best/free-${fn!.slug} answers ${status} for a subtype with ${bySubtype.get(subtype)!.length} vendors`);
+      if (picks >= MIN_PICKS) {
+        served++;
+        assert.strictEqual(status, 200, `/best/free-${fn!.slug} answers ${status} for a subtype with ${picks} picks`);
+      } else {
+        withheldHere++;
+        assert.notStrictEqual(status, 200, `/best/free-${fn!.slug} answers 200 while publishing ${picks} pick`);
+      }
     }
+    assert.ok(served >= 15, `only ${served} subtype pages are served, so this sweep is not measuring the namespace`);
+    assert.ok(withheldHere >= 1, "no subtype falls under the pick threshold, so the negative half of this sweep is vacuous");
   });
 
-  it("puts every one of them in the sitemap and on the index", async () => {
+  it("puts every one of them in the sitemap and on the index, and no withheld page in either", async () => {
     const map = await page("/sitemap-pages.xml");
     const index = await page("/best");
     for (const fn of published) {
       assert.ok(map.html.includes(`/best/${`free-${fn.slug}`}<`), `/best/free-${fn.slug} is in no sitemap`);
       assert.ok(index.html.includes(`href="/best/free-${fn.slug}"`), `/best/free-${fn.slug} is unreachable from /best`);
+    }
+    for (const fn of withheld) {
+      assert.ok(!map.html.includes(`/best/${`free-${fn.slug}`}<`), `/best/free-${fn.slug} is withheld and still in the sitemap`);
+      assert.ok(!index.html.includes(`href="/best/free-${fn.slug}"`), `/best/free-${fn.slug} is withheld and still linked from /best`);
     }
   });
 


### PR DESCRIPTION
Refs #1479.

`SUBTYPE_TAXONOMIES` was authored as an internal label set, one block per parent, and PR #1477 promoted it to a public page namespace without re-reading it as one. Four consequences, all four addressed.

## One function under two names

`vector` (Databases) and `vector_store` (AI / ML) named one thing, so Pinecone and Qdrant reached no page named for what they are. They resolve to one function at `/best/free-vector`.

The merge is not written down for this pair. `crossTaxonomyCandidates()` reads all four taxonomies against each other and flags a cross-parent pair when the stemmed definitions overlap or one label contains the other. `CROSS_TAXONOMY_RULINGS` rules on every flagged pair — one function with a governing entry, or two functions with the difference stated — and a flagged pair with no ruling fails the suite. Three are flagged today and three are ruled; the rulings are published at `/criteria#subtypes`.

## A sentence that only worked for a verb phrase

`We list a product here when it ${definition}` supplied the subject, so a definition written as a noun phrase or addressed to the reader read as broken English in `<meta name="description">` and in `ItemList.description`. It is composed with a colon now, which takes any of the three forms. Counts and their verbs agree in number.

## Titles that named an attribute

A subtype names an attribute of the class its parent names, so the attribute alone names no product. Three names are declared beside the definition, each taking its head noun from its parent category. A declared name is published as the whole list noun, so `/best/free-vector` is `Best Free Vector Databases` rather than `Best Free Vector Tools`.

## A page named "Best Free X" that published one X

`BEST_OF_MIN_PICKS` counts the list the page will publish rather than what the function can reach. Two pages that published one pick under a `Best Free` title are withdrawn from the URL, the sitemap, the index and the ping list.

## Verification

Full suite 4,588 tests, 4,586 pass. The two failures are #1190's and reproduce on `main` with this branch stashed. `scripts/mutate-1479.mjs` covers all four criteria and the negative control.
