### PR TITLE
Date every page from the records it lists (#1481)

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,8 @@
     "serve": "node dist/serve.js",
     "dev": "ts-node src/index.ts",
     "test": "node --test --test-concurrency 1 test/**/*.test.ts",
+    "mutate:1479": "node scripts/mutate-1479.mjs",
+    "mutate:1481": "node scripts/mutate-1481.mjs",
     "test:gated": "node --test --test-concurrency 1 --test-reporter=spec --test-reporter-destination=stdout --test-reporter=./scripts/reporters/failing-test-files.js --test-reporter-destination=$GATE_FAILING_FILES test/**/*.test.ts",
     "ratchet:budgets": "node scripts/ratchet-quality-budgets.js --lower",
     "lastmod:pages": "node scripts/update-page-lastmod.js",

--- a/scripts/mutate-1481.mjs
+++ b/scripts/mutate-1481.mjs
@@ -1,0 +1,84 @@
+import { readFileSync, writeFileSync } from "node:fs";
+import { execFileSync } from "node:child_process";
+
+const SUITE = ["test/derived-page-freshness.test.ts"];
+
+const MUTANTS = [
+  ["the-span-collapses-to-the-newest-record-it-holds", "src/page-freshness.ts",
+    "  if (earliest === latest) return `${FRESHNESS_VERB} ${earliest}.`;",
+    "  if (true) return `${FRESHNESS_VERB} ${latest}.`;"],
+
+  ["the-span-collapses-to-the-oldest-record-it-holds", "src/page-freshness.ts",
+    "  if (earliest === latest) return `${FRESHNESS_VERB} ${earliest}.`;",
+    "  if (true) return `${FRESHNESS_VERB} ${earliest}.`;"],
+
+  ["a-single-year-span-repeats-the-year-on-both-ends", "src/page-freshness.ts",
+    "  const opening = yearOf(earliest) === yearOf(latest)\n    ? earliest.slice(0, earliest.lastIndexOf(\" \"))\n    : earliest;",
+    "  const opening = earliest;"],
+
+  ["only-the-first-surface-is-given-the-claim", "src/page-freshness.ts",
+    "  return html.split(FRESHNESS_TOKEN).join(claim);",
+    "  return html.replace(FRESHNESS_TOKEN, claim);"],
+
+  ["a-page-that-can-derive-nothing-keeps-its-placeholder", "src/page-freshness.ts",
+    "  if (claim === \"\") return html.split(` ${FRESHNESS_TOKEN}`).join(\"\").split(FRESHNESS_TOKEN).join(\"\");",
+    "  if (claim === \"\") return html;"],
+
+  ["a-hand-compiled-page-is-dated-from-the-catalogue", "src/page-freshness.ts",
+    "  if (review && !review.reads_index) return compiledClaimFor(review, today);",
+    "  if (false) return compiledClaimFor(review!, today);"],
+
+  ["a-catalogue-page-is-dated-from-its-own-publication", "src/page-freshness.ts",
+    "  if (review && !review.reads_index) return compiledClaimFor(review, today);",
+    "  if (review) return compiledClaimFor(review, today);"],
+
+  ["the-claim-is-taken-from-links-that-are-not-records", "src/page-freshness.ts",
+    "const VENDOR_HREF = /href=\"\\/vendor\\/([a-z0-9][a-z0-9-]*)\"/g;",
+    "const VENDOR_HREF = /href=\"\\/alternative-to\\/([a-z0-9][a-z0-9-]*)\"/g;"],
+
+  ["a-date-we-cannot-parse-is-published-as-a-month", "src/page-freshness.ts",
+    "  const parts = ISO_DATE.exec(isoDate);\n  if (!parts) return \"\";",
+    "  const parts = /^(\\d{4})-?(\\d{2})?/.exec(isoDate);\n  if (!parts) return \"\";"],
+
+  ["the-response-stops-resolving-the-placeholder", "src/serve.ts",
+    "      args[0] = withLedeBeforeNav(withPageFreshness(args[0], url.pathname));",
+    "      args[0] = withLedeBeforeNav(args[0]);"],
+
+  ["a-hardcoded-month-comes-back-into-a-page-description", "src/serve.ts",
+    "Exact rate limits and token quotas. [[freshness]]\";",
+    "Exact rate limits and token quotas. Updated March 2026.\";"],
+];
+
+function run(cmd, args) {
+  try {
+    execFileSync(cmd, args, { stdio: "pipe", encoding: "utf-8" });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+const survivors = [];
+const uncompiled = [];
+const skipped = [];
+for (const [name, file, from, to] of MUTANTS) {
+  const original = readFileSync(file, "utf-8");
+  if (!original.includes(from)) {
+    console.log(`SKIP  ${name} — the line it mutates is not in ${file}`);
+    skipped.push(name);
+    continue;
+  }
+  writeFileSync(file, original.replace(from, to));
+  const built = run("npm", ["run", "build"]);
+  const green = built && run("node", ["--test", "--test-concurrency", "1", ...SUITE]);
+  writeFileSync(file, original);
+  if (!built) uncompiled.push(name);
+  console.log(`${green ? "SURVIVED" : built ? "killed  " : "DID NOT COMPILE"}  ${name}`);
+  if (green) survivors.push(name);
+}
+run("npm", ["run", "build"]);
+const killed = MUTANTS.length - survivors.length - uncompiled.length - skipped.length;
+console.log(`\n${killed}/${MUTANTS.length} killed`);
+if (survivors.length > 0) console.log("survivors:", survivors.join(", "));
+if (uncompiled.length > 0) console.log("did not compile:", uncompiled.join(", "));
+if (skipped.length > 0) console.log("skipped — target string moved, so these scored nothing:", skipped.join(", "));

--- a/src/page-freshness.ts
+++ b/src/page-freshness.ts
@@ -1,0 +1,71 @@
+import { compiledClause, getPageReview, utcToday, type PageReviewRecord } from "./page-reviews.js";
+
+export const FRESHNESS_TOKEN = "[[freshness]]";
+
+const MONTH_NAMES = [
+  "January", "February", "March", "April", "May", "June",
+  "July", "August", "September", "October", "November", "December",
+] as const;
+
+const ISO_DATE = /^(\d{4})-(\d{2})-(\d{2})$/;
+
+export function monthOf(isoDate: string): string {
+  const parts = ISO_DATE.exec(isoDate);
+  if (!parts) return "";
+  const name = MONTH_NAMES[Number(parts[2]) - 1];
+  return name === undefined ? "" : `${name} ${parts[1]}`;
+}
+
+function yearOf(monthAndYear: string): string {
+  return monthAndYear.slice(monthAndYear.lastIndexOf(" ") + 1);
+}
+
+export const FRESHNESS_VERB = "Verified";
+
+export function verifiedSpanClaim(verifiedDates: readonly string[]): string {
+  const dated = verifiedDates.filter(date => monthOf(date) !== "").sort();
+  if (dated.length === 0) return "";
+  const earliest = monthOf(dated[0]!);
+  const latest = monthOf(dated[dated.length - 1]!);
+  if (earliest === latest) return `${FRESHNESS_VERB} ${earliest}.`;
+  const opening = yearOf(earliest) === yearOf(latest)
+    ? earliest.slice(0, earliest.lastIndexOf(" "))
+    : earliest;
+  return `${FRESHNESS_VERB} ${opening} to ${latest}.`;
+}
+
+const VENDOR_HREF = /href="\/vendor\/([a-z0-9][a-z0-9-]*)"/g;
+
+export function vendorSlugsLinkedFrom(html: string): string[] {
+  return [...new Set(Array.from(html.matchAll(VENDOR_HREF), match => match[1]!))].sort();
+}
+
+export type VerifiedDatesForSlug = (vendorSlug: string) => readonly string[];
+
+export function compiledClaimFor(review: PageReviewRecord, today: string): string {
+  const clause = compiledClause(review, today);
+  return clause === "" ? "" : `${clause}.`;
+}
+
+export function freshnessClaimFor(
+  pagePath: string,
+  html: string,
+  verifiedDatesForSlug: VerifiedDatesForSlug,
+  today: string = utcToday(),
+  reviewFor: (pagePath: string) => PageReviewRecord | null = getPageReview,
+): string {
+  const review = reviewFor(pagePath);
+  if (review && !review.reads_index) return compiledClaimFor(review, today);
+  return verifiedSpanClaim(vendorSlugsLinkedFrom(html).flatMap(slug => [...verifiedDatesForSlug(slug)]));
+}
+
+export function claimsFreshness(html: string): boolean {
+  return html.includes(FRESHNESS_TOKEN);
+}
+
+export function withFreshnessClaim(html: string, claimFor: () => string): string {
+  if (!claimsFreshness(html)) return html;
+  const claim = claimFor();
+  if (claim === "") return html.split(` ${FRESHNESS_TOKEN}`).join("").split(FRESHNESS_TOKEN).join("");
+  return html.split(FRESHNESS_TOKEN).join(claim);
+}

--- a/src/serve.ts
+++ b/src/serve.ts
@@ -32,6 +32,7 @@ import { comparisonVerdictText, freeTierFaqAnswer, stabilityFaqAnswer, type Comp
 import { publishedVendorLevel, vendorVerdictSentence, vendorBadge, freeTierClaim, statesRiskCause, narrowingSentence, changeKindNoun, termsUnconfirmedBySource, unconfirmedTermsMetaSentence, type BadgeWithholding, type FreeTierClaim, type VendorVerdictInput } from "./vendor-verdict.js";
 import { tierRecordsAFreeTier } from "./free-tier-record.js";
 import { PAGE_HEAD_OPEN, withLedeBeforeNav } from "./page-lede.js";
+import { freshnessClaimFor, withFreshnessClaim } from "./page-freshness.js";
 import { UNGRADED_IMPACT_COLOR, changeImpactColor, changeImpactLabel, changeImpactWord, isChangeImpactLevel } from "./change-impact.js";
 import { COMPARED_SERVICES_PLACEHOLDER, appendToCompiledFigureSlots, fillComparedServicesCount, markCompiledFigures, recordsSinceCompiled, replaceTimelineRows, staticHalfOf, timelineRecordsFor, vendorForSubject, vendorSubjectsOnCompiledPage, type CompiledFigureSubject, type CompiledFigureVendor, type CompiledFigureVerdict, type CompiledPageRecord } from "./compiled-figures.js";
 import { CHECK_ESTABLISHES, CHECK_SCOPE_CLASS, NO_CATALOGUE_RECORD, citedSourceLinkHtml, citedSourcesListHtml, freeTierSourceOf, pageQuoteHtml, readClauseHtml, sourceMarkerHtml, uncitedSourceLinkHtml, withCitedSources, type CitedService, type FreeTierSource } from "./source-citation.js";
@@ -467,6 +468,26 @@ const offers = loadOffers();
 const categories = getCategories();
 const dealChanges = loadDealChanges();
 const trackedChangeCount = recordsStillInForce(dealChanges).length;
+
+const verifiedDatesBySlug = (() => {
+  const dates = new Map<string, string[]>();
+  for (const offer of offers) {
+    if (!offer.verifiedDate) continue;
+    const slug = toSlug(offer.vendor);
+    const held = dates.get(slug);
+    if (held) held.push(offer.verifiedDate);
+    else dates.set(slug, [offer.verifiedDate]);
+  }
+  return dates;
+})();
+
+function verifiedDatesForSlug(vendorSlug: string): readonly string[] {
+  return verifiedDatesBySlug.get(vendorSlug) ?? [];
+}
+
+function withPageFreshness(html: string, pagePath: string): string {
+  return withFreshnessClaim(html, () => freshnessClaimFor(pagePath, html, verifiedDatesForSlug));
+}
 
 function apiExampleSubjects(): ExampleSubjects {
   return exampleSubjects(
@@ -6968,7 +6989,7 @@ const ALTERNATIVES_PAGES: AlternativesPageConfig[] = [
   {
     slug: "ai-free-tiers",
     title: "Best Free AI APIs and Coding Tools in 2026",
-    metaDesc: "Compare free AI APIs, LLM inference, and coding tools — exact rate limits and free tier details for Groq, Cerebras, Mistral, OpenAI, Gemini, Cursor, GitHub Copilot, and 50+ more. Updated March 2026.",
+    metaDesc: "Compare free AI APIs, LLM inference, and coding tools — exact rate limits and free tier details for Groq, Cerebras, Mistral, OpenAI, Gemini, Cursor, GitHub Copilot, and 50+ more. [[freshness]]",
     contextHtml: "",
     tag: "ai-free-tier",
     primaryVendor: "OpenAI",
@@ -6977,7 +6998,7 @@ const ALTERNATIVES_PAGES: AlternativesPageConfig[] = [
   {
     slug: "database-alternatives",
     title: "Best Free Database Hosting for Developers in 2026",
-    metaDesc: "Compare 30+ free database hosting options — Postgres, MongoDB, Redis, SQLite, graph, vector, and time-series. Exact free tier limits for Supabase, Neon, Turso, Upstash, and more. Updated March 2026.",
+    metaDesc: "Compare 30+ free database hosting options — Postgres, MongoDB, Redis, SQLite, graph, vector, and time-series. Exact free tier limits for Supabase, Neon, Turso, Upstash, and more. [[freshness]]",
     contextHtml: "",
     tag: "database-alternative",
     primaryVendor: "Supabase",
@@ -6986,7 +7007,7 @@ const ALTERNATIVES_PAGES: AlternativesPageConfig[] = [
   {
     slug: "hosting-alternatives",
     title: "Best Free Hosting for Developers in 2026 — PaaS, Static, Serverless, Containers & VPS",
-    metaDesc: "Compare 30+ free hosting options — Railway, Render, Vercel, Netlify, Cloudflare, Fly.io, Oracle Cloud, and more. Exact free tier limits for PaaS, static, serverless, container, and VPS hosting. Updated March 2026.",
+    metaDesc: "Compare 30+ free hosting options — Railway, Render, Vercel, Netlify, Cloudflare, Fly.io, Oracle Cloud, and more. Exact free tier limits for PaaS, static, serverless, container, and VPS hosting. [[freshness]]",
     contextHtml: "",
     tag: "hosting-alternative",
     primaryVendor: "Heroku",
@@ -6995,7 +7016,7 @@ const ALTERNATIVES_PAGES: AlternativesPageConfig[] = [
   {
     slug: "monitoring-alternatives",
     title: "Best Free Monitoring Tools for Developers in 2026 — APM, Uptime, Logs & Error Tracking",
-    metaDesc: "Compare 70+ free monitoring tools — New Relic, Grafana Cloud, Datadog, Sentry, BetterStack, UptimeRobot, and more. Exact free tier limits by monitoring type. Updated March 2026.",
+    metaDesc: "Compare 70+ free monitoring tools — New Relic, Grafana Cloud, Datadog, Sentry, BetterStack, UptimeRobot, and more. Exact free tier limits by monitoring type. [[freshness]]",
     contextHtml: "",
     tag: "monitoring-alternative",
     primaryVendor: "Datadog",
@@ -7107,7 +7128,7 @@ const ALTERNATIVES_PAGES: AlternativesPageConfig[] = [
   {
     slug: "ci-cd-alternatives",
     title: "Best Free CI/CD Tools for Developers in 2026 — Build Minutes, Runners & Pipelines Compared",
-    metaDesc: "Compare 35+ free CI/CD tools — GitHub Actions, GitLab CI, CircleCI, Buildkite, Harness CI, Drone CI, and more. Exact free tier limits by CI/CD type. Updated March 2026.",
+    metaDesc: "Compare 35+ free CI/CD tools — GitHub Actions, GitLab CI, CircleCI, Buildkite, Harness CI, Drone CI, and more. Exact free tier limits by CI/CD type. [[freshness]]",
     contextHtml: "",
     tag: "ci-cd-hub",
     primaryVendor: "GitHub Actions",
@@ -7116,7 +7137,7 @@ const ALTERNATIVES_PAGES: AlternativesPageConfig[] = [
   {
     slug: "security-alternatives",
     title: "Best Free Security Tools for Developers in 2026 — SAST, Secrets, Auth & Container Security",
-    metaDesc: "Compare 100+ free security tools — Snyk, Semgrep, CodeQL, GitGuardian, Trivy, Auth0, Clerk, and more. Exact free tier limits by security domain. Updated March 2026.",
+    metaDesc: "Compare 100+ free security tools — Snyk, Semgrep, CodeQL, GitGuardian, Trivy, Auth0, Clerk, and more. Exact free tier limits by security domain. [[freshness]]",
     contextHtml: "",
     tag: "security-hub",
     primaryVendor: "Snyk",
@@ -7125,7 +7146,7 @@ const ALTERNATIVES_PAGES: AlternativesPageConfig[] = [
   {
     slug: "storage-alternatives",
     title: "Best Free Cloud Storage for Developers in 2026 — Object Storage, Media CDN & File Hosting Compared",
-    metaDesc: "Compare 55+ free cloud storage tools — Cloudflare R2, Backblaze B2, Tigris, Cloudinary, ImageKit, Google Cloud Storage, and more. Exact free tier limits by storage type. Updated March 2026.",
+    metaDesc: "Compare 55+ free cloud storage tools — Cloudflare R2, Backblaze B2, Tigris, Cloudinary, ImageKit, Google Cloud Storage, and more. Exact free tier limits by storage type. [[freshness]]",
     contextHtml: "",
     tag: "storage-hub",
     primaryVendor: "Cloudflare R2",
@@ -7134,7 +7155,7 @@ const ALTERNATIVES_PAGES: AlternativesPageConfig[] = [
   {
     slug: "testing-alternatives",
     title: "Best Free Testing Tools for Developers in 2026 — Browser, Visual, Load, E2E & API Testing Compared",
-    metaDesc: "Compare 45+ free testing tools — Cypress, BrowserStack, Playwright, k6, Percy, Chromatic, Postman, Selenium, and more. Exact free tier limits by testing domain. Updated March 2026.",
+    metaDesc: "Compare 45+ free testing tools — Cypress, BrowserStack, Playwright, k6, Percy, Chromatic, Postman, Selenium, and more. Exact free tier limits by testing domain. [[freshness]]",
     contextHtml: "",
     tag: "testing-hub",
     primaryVendor: "Cypress Cloud",
@@ -7143,7 +7164,7 @@ const ALTERNATIVES_PAGES: AlternativesPageConfig[] = [
   {
     slug: "analytics-alternatives",
     title: "Best Free Analytics Tools for Developers in 2026 — Product, Web, Event & Data Analytics Compared",
-    metaDesc: "Compare 45+ free analytics tools — PostHog, Amplitude, Mixpanel, Plausible, Umami, Tinybird, Segment, and more. Exact free tier limits by analytics domain. Updated March 2026.",
+    metaDesc: "Compare 45+ free analytics tools — PostHog, Amplitude, Mixpanel, Plausible, Umami, Tinybird, Segment, and more. Exact free tier limits by analytics domain. [[freshness]]",
     contextHtml: "",
     tag: "analytics-hub",
     primaryVendor: "PostHog",
@@ -7152,7 +7173,7 @@ const ALTERNATIVES_PAGES: AlternativesPageConfig[] = [
   {
     slug: "ai-ml-alternatives",
     title: "Best Free AI & ML Tools for Developers in 2026 — LLM APIs, AI Coding, Training & Observability Compared",
-    metaDesc: "Compare 65+ free AI/ML tools — Groq, Cerebras, OpenAI, Hugging Face, GitHub Copilot, Cursor, Langfuse, and more. Exact free tier limits by AI domain. Updated March 2026.",
+    metaDesc: "Compare 65+ free AI/ML tools — Groq, Cerebras, OpenAI, Hugging Face, GitHub Copilot, Cursor, Langfuse, and more. Exact free tier limits by AI domain. [[freshness]]",
     contextHtml: "",
     tag: "ai-ml-hub",
     primaryVendor: "OpenAI",
@@ -7161,7 +7182,7 @@ const ALTERNATIVES_PAGES: AlternativesPageConfig[] = [
   {
     slug: "design-alternatives",
     title: "Best Free Design Tools for Developers in 2026 — UI Kits, Prototyping, Icons & Assets Compared",
-    metaDesc: "Compare 100+ free design tools — Figma, Penpot, Canva, ShadcnUI, Lucide, Unsplash, Coolors, and more. Exact free tier limits by design domain. Updated March 2026.",
+    metaDesc: "Compare 100+ free design tools — Figma, Penpot, Canva, ShadcnUI, Lucide, Unsplash, Coolors, and more. Exact free tier limits by design domain. [[freshness]]",
     contextHtml: "",
     tag: "design-hub",
     primaryVendor: "Figma",
@@ -7170,7 +7191,7 @@ const ALTERNATIVES_PAGES: AlternativesPageConfig[] = [
   {
     slug: "email-alternatives",
     title: "Best Free Email Tools for Developers in 2026 — Transactional APIs, Marketing Platforms & Email Infrastructure Compared",
-    metaDesc: "Compare 59+ free email tools — Resend, Brevo, Mailjet, SendGrid, Mailchimp, SimpleLogin, Proton Mail, and more. Exact free tier limits by email domain. Updated March 2026.",
+    metaDesc: "Compare 59+ free email tools — Resend, Brevo, Mailjet, SendGrid, Mailchimp, SimpleLogin, Proton Mail, and more. Exact free tier limits by email domain. [[freshness]]",
     contextHtml: "",
     tag: "email-hub",
     primaryVendor: "Resend",
@@ -7179,7 +7200,7 @@ const ALTERNATIVES_PAGES: AlternativesPageConfig[] = [
   {
     slug: "project-management-alternatives",
     title: "Best Free Project Management & Collaboration Tools in 2026 — PM, Chat, Scheduling & Productivity Compared",
-    metaDesc: "Compare 93+ free project management tools — Linear, Asana, Trello, ClickUp, Notion, Slack alternatives, Cal.com, and more. Exact free tier limits. Updated March 2026.",
+    metaDesc: "Compare 93+ free project management tools — Linear, Asana, Trello, ClickUp, Notion, Slack alternatives, Cal.com, and more. Exact free tier limits. [[freshness]]",
     contextHtml: "",
     tag: "pm-hub",
     primaryVendor: "Linear",
@@ -7188,7 +7209,7 @@ const ALTERNATIVES_PAGES: AlternativesPageConfig[] = [
   {
     slug: "ide-code-editors-alternatives",
     title: "Best Free IDEs, Code Editors & AI Coding Tools in 2026 — Desktop, Cloud & AI Assistants Compared",
-    metaDesc: "Compare 59+ free IDEs and coding tools — VS Code, Cursor, GitHub Copilot, Zed, Replit, Windsurf, Devin, and more. Exact free tier limits. Updated March 2026.",
+    metaDesc: "Compare 59+ free IDEs and coding tools — VS Code, Cursor, GitHub Copilot, Zed, Replit, Windsurf, Devin, and more. Exact free tier limits. [[freshness]]",
     contextHtml: "",
     tag: "ide-hub",
     primaryVendor: "Visual Studio Code",
@@ -7197,7 +7218,7 @@ const ALTERNATIVES_PAGES: AlternativesPageConfig[] = [
   {
     slug: "free-llm-apis",
     title: "Best Free LLM APIs in 2026 — Compare Free Inference Tiers, Rate Limits & Models",
-    metaDesc: "Compare 25+ free LLM API providers — Groq, Cerebras, OpenRouter, Gemini, Mistral, OpenAI, Anthropic, NVIDIA NIM, and more. Exact rate limits and token quotas. Updated March 2026.",
+    metaDesc: "Compare 25+ free LLM API providers — Groq, Cerebras, OpenRouter, Gemini, Mistral, OpenAI, Anthropic, NVIDIA NIM, and more. Exact rate limits and token quotas. [[freshness]]",
     contextHtml: "",
     tag: "llm-api-hub",
     primaryVendor: "OpenAI",
@@ -7206,7 +7227,7 @@ const ALTERNATIVES_PAGES: AlternativesPageConfig[] = [
   {
     slug: "api-development-alternatives",
     title: "Best Free API Development Tools in 2026 — REST, GraphQL, Mocking & Documentation Compared",
-    metaDesc: "Compare 39+ free API development tools — Postman, Hoppscotch, Insomnia, Bruno, Mintlify, Swagger, RapidAPI, Nango, and more. Exact free tier limits. Updated March 2026.",
+    metaDesc: "Compare 39+ free API development tools — Postman, Hoppscotch, Insomnia, Bruno, Mintlify, Swagger, RapidAPI, Nango, and more. Exact free tier limits. [[freshness]]",
     contextHtml: "",
     tag: "api-dev-hub",
     primaryVendor: "Postman",
@@ -7233,7 +7254,7 @@ const ALTERNATIVES_PAGES: AlternativesPageConfig[] = [
   {
     slug: "team-collaboration-alternatives",
     title: "Best Free Team Collaboration Tools in 2026 — Chat, Video, Docs & Scheduling Compared",
-    metaDesc: "Compare 60+ free team collaboration tools — Slack, Discord, Zoom, Jitsi, Notion, Cal.com, Rocket.Chat, and more. Exact free tier limits. Updated March 2026.",
+    metaDesc: "Compare 60+ free team collaboration tools — Slack, Discord, Zoom, Jitsi, Notion, Cal.com, Rocket.Chat, and more. Exact free tier limits. [[freshness]]",
     contextHtml: "",
     tag: "collab-hub",
     primaryVendor: "Slack",
@@ -7332,7 +7353,7 @@ const ALTERNATIVES_PAGES: AlternativesPageConfig[] = [
   {
     slug: "google-developer-program-2026",
     title: "Google Developer Program 2026 — Premium Ending, Migration Guide & Alternatives",
-    metaDesc: "Google Developer Program Premium ($299/year) ends March 30, 2026. Compare GDP Premium vs AI Pro ($19.99/mo) vs AI Ultra ($249.99/mo). Migration steps, free alternatives for Cloud credits, Gemini API, Firebase. Updated March 2026.",
+    metaDesc: "Google Developer Program Premium ($299/year) ends March 30, 2026. Compare GDP Premium vs AI Pro ($19.99/mo) vs AI Ultra ($249.99/mo). Migration steps, free alternatives for Cloud credits, Gemini API, Firebase. [[freshness]]",
     contextHtml: "",
     tag: "gdp-pricing-analysis",
     primaryVendor: "Google",
@@ -7341,7 +7362,7 @@ const ALTERNATIVES_PAGES: AlternativesPageConfig[] = [
   {
     slug: "supabase-vs-firebase",
     title: "Supabase vs Firebase Free Tier Comparison — 2026 Deep Dive",
-    metaDesc: "Compare Supabase and Firebase free tiers side-by-side. Database, auth, storage, functions, bandwidth — verified data, cost-at-scale analysis, and BaaS alternatives. Updated March 2026.",
+    metaDesc: "Compare Supabase and Firebase free tiers side-by-side. Database, auth, storage, functions, bandwidth — verified data, cost-at-scale analysis, and BaaS alternatives. [[freshness]]",
     contextHtml: "",
     tag: "supabase-vs-firebase",
     primaryVendor: "Supabase",
@@ -7350,7 +7371,7 @@ const ALTERNATIVES_PAGES: AlternativesPageConfig[] = [
   {
     slug: "vercel-vs-netlify",
     title: "Vercel vs Netlify Free Tier Comparison — 2026 Deep Dive",
-    metaDesc: "Compare Vercel and Netlify free tiers side-by-side. Bandwidth, serverless functions, build minutes, storage — verified data, cost-at-scale analysis, and hosting alternatives. Updated March 2026.",
+    metaDesc: "Compare Vercel and Netlify free tiers side-by-side. Bandwidth, serverless functions, build minutes, storage — verified data, cost-at-scale analysis, and hosting alternatives. [[freshness]]",
     contextHtml: "",
     tag: "vercel-vs-netlify",
     primaryVendor: "Vercel",
@@ -7359,7 +7380,7 @@ const ALTERNATIVES_PAGES: AlternativesPageConfig[] = [
   {
     slug: "neon-vs-supabase",
     title: "Neon vs Supabase Free Tier Comparison — 2026 Deep Dive",
-    metaDesc: "Compare Neon and Supabase free tiers side-by-side. Storage, compute, branching, auth, edge functions — verified data, cost-at-scale analysis, and database alternatives. Updated March 2026.",
+    metaDesc: "Compare Neon and Supabase free tiers side-by-side. Storage, compute, branching, auth, edge functions — verified data, cost-at-scale analysis, and database alternatives. [[freshness]]",
     contextHtml: "",
     tag: "neon-vs-supabase",
     primaryVendor: "Neon",
@@ -7368,7 +7389,7 @@ const ALTERNATIVES_PAGES: AlternativesPageConfig[] = [
   {
     slug: "railway-vs-render",
     title: "Railway vs Render Free Tier Comparison — 2026 Deep Dive",
-    metaDesc: "Compare Railway and Render free tiers side-by-side. RAM, CPU, databases, sleep behavior, bandwidth — verified data, cost-at-scale analysis, and PaaS alternatives. Updated March 2026.",
+    metaDesc: "Compare Railway and Render free tiers side-by-side. RAM, CPU, databases, sleep behavior, bandwidth — verified data, cost-at-scale analysis, and PaaS alternatives. [[freshness]]",
     contextHtml: "",
     tag: "railway-vs-render",
     primaryVendor: "Railway",
@@ -7377,7 +7398,7 @@ const ALTERNATIVES_PAGES: AlternativesPageConfig[] = [
   {
     slug: "datadog-vs-new-relic",
     title: "Datadog vs New Relic Free Tier Comparison — 2026 Deep Dive",
-    metaDesc: "Compare Datadog and New Relic free tiers side-by-side. Hosts, data ingest, APM, logs, retention, synthetics — verified data, cost-at-scale analysis, and monitoring alternatives. Updated March 2026.",
+    metaDesc: "Compare Datadog and New Relic free tiers side-by-side. Hosts, data ingest, APM, logs, retention, synthetics — verified data, cost-at-scale analysis, and monitoring alternatives. [[freshness]]",
     contextHtml: "",
     tag: "datadog-vs-new-relic",
     primaryVendor: "Datadog",
@@ -7449,7 +7470,7 @@ const ALTERNATIVES_PAGES: AlternativesPageConfig[] = [
   {
     slug: "startup-credits",
     title: "Startup Credits Comparison 2026 — Cloud Credits, Eligibility & Hidden Constraints",
-    metaDesc: "Compare 15+ startup programs: AWS Activate, Google for Startups, Microsoft Founders Hub, Cloudflare, DigitalOcean Hatch, Stripe Atlas, Brex, Mercury, and more. Credit values, eligibility, vesting, and stacking strategies. Updated April 2026.",
+    metaDesc: "Compare 15+ startup programs: AWS Activate, Google for Startups, Microsoft Founders Hub, Cloudflare, DigitalOcean Hatch, Stripe Atlas, Brex, Mercury, and more. Credit values, eligibility, vesting, and stacking strategies. [[freshness]]",
     contextHtml: "",
     tag: "startup-credits",
     primaryVendor: "AWS Activate",
@@ -7458,7 +7479,7 @@ const ALTERNATIVES_PAGES: AlternativesPageConfig[] = [
   {
     slug: "ai-coding-pricing-2026",
     title: "AI Coding Tools Pricing Guide — 2026 Comparison",
-    metaDesc: "Side-by-side pricing comparison of Cursor, Windsurf, GitHub Copilot, Gemini Code Assist, Amazon Q, Claude Code, Augment Code and more. Free tiers, pro plans, and recent pricing changes. Updated March 2026.",
+    metaDesc: "Side-by-side pricing comparison of Cursor, Windsurf, GitHub Copilot, Gemini Code Assist, Amazon Q, Claude Code, Augment Code and more. Free tiers, pro plans, and recent pricing changes. [[freshness]]",
     contextHtml: "",
     tag: "ai-coding-pricing-2026",
     primaryVendor: "Cursor",
@@ -7467,7 +7488,7 @@ const ALTERNATIVES_PAGES: AlternativesPageConfig[] = [
   {
     slug: "ai-coding-tools-pricing",
     title: "AI Coding Tools Pricing Comparison 2026 — The Definitive Free Tier Breakdown",
-    metaDesc: "Compare 17 AI coding tools: Cursor, Windsurf, Amazon Kiro, GitHub Copilot, Claude Code, Devin, Bolt.new, Lovable, Codex, Gemini CLI and more. Free tiers, hidden costs, cost analysis for solo devs and teams. Updated April 2026.",
+    metaDesc: "Compare 17 AI coding tools: Cursor, Windsurf, Amazon Kiro, GitHub Copilot, Claude Code, Devin, Bolt.new, Lovable, Codex, Gemini CLI and more. Free tiers, hidden costs, cost analysis for solo devs and teams. [[freshness]]",
     contextHtml: "",
     tag: "ai-coding-tools-pricing",
     primaryVendor: "Cursor",
@@ -7476,7 +7497,7 @@ const ALTERNATIVES_PAGES: AlternativesPageConfig[] = [
   {
     slug: "ci-cd-pricing",
     title: "CI/CD Tools Pricing Comparison 2026 — Build Minutes, Runners & Costs Compared",
-    metaDesc: "Compare 17+ CI/CD tools: GitHub Actions, GitLab CI, CircleCI, Buildkite, Harness CI, Google Cloud Build, Bitrise and more. Free tiers, build minutes, concurrent jobs, pricing models, and hidden costs. Updated April 2026.",
+    metaDesc: "Compare 17+ CI/CD tools: GitHub Actions, GitLab CI, CircleCI, Buildkite, Harness CI, Google Cloud Build, Bitrise and more. Free tiers, build minutes, concurrent jobs, pricing models, and hidden costs. [[freshness]]",
     contextHtml: "",
     tag: "ci-cd-pricing",
     primaryVendor: "GitHub Actions",
@@ -7485,7 +7506,7 @@ const ALTERNATIVES_PAGES: AlternativesPageConfig[] = [
   {
     slug: "database-pricing",
     title: "Database Pricing Comparison 2026 — Free Tiers, Storage Limits & Costs Compared",
-    metaDesc: "Compare 25+ database services: Supabase, Neon, PlanetScale, MongoDB Atlas, Firebase, CockroachDB, Turso, Upstash, Redis Cloud, DynamoDB and more. Free tiers, storage limits, connections, pricing models, and hidden costs. Updated April 2026.",
+    metaDesc: "Compare 25+ database services: Supabase, Neon, PlanetScale, MongoDB Atlas, Firebase, CockroachDB, Turso, Upstash, Redis Cloud, DynamoDB and more. Free tiers, storage limits, connections, pricing models, and hidden costs. [[freshness]]",
     contextHtml: "",
     tag: "database-pricing",
     primaryVendor: "Supabase",
@@ -7494,7 +7515,7 @@ const ALTERNATIVES_PAGES: AlternativesPageConfig[] = [
   {
     slug: "vector-database-pricing",
     title: "Vector Database Pricing Comparison 2026 — Free Tiers, Storage Limits & Costs for RAG/AI",
-    metaDesc: "Compare 11+ vector databases: Pinecone, Qdrant, Weaviate, Chroma, Zilliz Cloud, LanceDB, Upstash Vector, Supabase pgvector, Neon pgvector, MongoDB Atlas Vector Search and more. Free tiers, vector limits, dimensions, pricing models. Updated April 2026.",
+    metaDesc: "Compare 11+ vector databases: Pinecone, Qdrant, Weaviate, Chroma, Zilliz Cloud, LanceDB, Upstash Vector, Supabase pgvector, Neon pgvector, MongoDB Atlas Vector Search and more. Free tiers, vector limits, dimensions, pricing models. [[freshness]]",
     contextHtml: "",
     tag: "vector-database-pricing",
     primaryVendor: "Pinecone",
@@ -7503,7 +7524,7 @@ const ALTERNATIVES_PAGES: AlternativesPageConfig[] = [
   {
     slug: "hosting-pricing",
     title: "Cloud Hosting & PaaS Pricing Comparison 2026 — Free Tiers, Limits & Hidden Costs",
-    metaDesc: "Compare 15+ cloud hosting and PaaS services: Railway, Vercel, Render, Netlify, Fly.io, Cloudflare Workers/Pages, Deno Deploy, Koyeb, Val Town, Google Cloud Run and more. Free tiers, bandwidth limits, build minutes, and pricing gotchas. Updated April 2026.",
+    metaDesc: "Compare 15+ cloud hosting and PaaS services: Railway, Vercel, Render, Netlify, Fly.io, Cloudflare Workers/Pages, Deno Deploy, Koyeb, Val Town, Google Cloud Run and more. Free tiers, bandwidth limits, build minutes, and pricing gotchas. [[freshness]]",
     contextHtml: "",
     tag: "hosting-pricing",
     primaryVendor: "Railway",
@@ -9537,7 +9558,7 @@ ${mcpCtaCss()}
 
 function buildAiFreeTiersPage(): string {
   const title = "Best Free AI APIs and Coding Tools in 2026";
-  const metaDesc = "Compare free AI APIs, LLM inference, and coding tools — exact rate limits and free tier details for Groq, Cerebras, Mistral, OpenAI, Gemini, Cursor, GitHub Copilot, and 50+ more. Updated March 2026.";
+  const metaDesc = "Compare free AI APIs, LLM inference, and coding tools — exact rate limits and free tier details for Groq, Cerebras, Mistral, OpenAI, Gemini, Cursor, GitHub Copilot, and 50+ more. [[freshness]]";
   const slug = "ai-free-tiers";
 
   const aiMlOffers = offers.filter(o => o.category === "AI / ML");
@@ -9785,7 +9806,7 @@ ${buildCards(enrichedCoding)}
 
 function buildHostingAlternativesPage(): string {
   const title = "Best Free Hosting for Developers in 2026 — PaaS, Static, Serverless, Containers & VPS";
-  const metaDesc = "Compare 30+ free hosting options — Railway, Render, Vercel, Netlify, Cloudflare, Fly.io, Oracle Cloud, and more. Exact free tier limits by hosting type. Updated March 2026.";
+  const metaDesc = "Compare 30+ free hosting options — Railway, Render, Vercel, Netlify, Cloudflare, Fly.io, Oracle Cloud, and more. Exact free tier limits by hosting type. [[freshness]]";
   const slug = "hosting-alternatives";
 
   const hostingOffers = offers.filter(o => o.category === "Cloud Hosting" || o.category === "Cloud IaaS");
@@ -10074,7 +10095,7 @@ ${buildCards(startupCredits)}
     </tbody>
   </table>
   </div>
-  <p style="color:var(--text-dim);font-size:.8rem;margin-top:.5rem">Oracle Cloud's Always Free tier is permanently free (not time-limited) and the most generous VPS offering. Cloudflare Pages and Workers offer unlimited bandwidth on free tier. Railway's Free plan opens with a 30-day $5 trial credit and then costs $1/month minimum. AWS and Azure free tiers are mostly 12-month introductory offers. All limits verified against live pricing pages, March 2026.</p>
+  <p style="color:var(--text-dim);font-size:.8rem;margin-top:.5rem">Oracle Cloud's Always Free tier is permanently free (not time-limited) and the most generous VPS offering. Cloudflare Pages and Workers offer unlimited bandwidth on free tier. Railway's Free plan opens with a 30-day $5 trial credit and then costs $1/month minimum. AWS and Azure free tiers are mostly 12-month introductory offers. [[freshness]]</p>
 
   <div class="context-box" style="border-left:3px solid ${riskColors.risky}">
     <div style="font-weight:600;color:${riskColors.risky};margin-bottom:.5rem">Hetzner raised prices twice in 2026, and its cheapest line is unavailable</div>
@@ -10126,7 +10147,7 @@ ${buildCards(startupCredits)}
 
 function buildDatabaseAlternativesPage(): string {
   const title = "Best Free Database Hosting for Developers in 2026";
-  const metaDesc = "Compare 30+ free database hosting options — Postgres, MongoDB, Redis, SQLite, graph, vector, and time-series. Exact free tier limits for Supabase, Neon, Turso, Upstash, and more. Updated March 2026.";
+  const metaDesc = "Compare 30+ free database hosting options — Postgres, MongoDB, Redis, SQLite, graph, vector, and time-series. Exact free tier limits for Supabase, Neon, Turso, Upstash, and more. [[freshness]]";
   const slug = "database-alternatives";
 
   const dbOffers = offers.filter(o => o.category === "Databases");
@@ -10412,7 +10433,7 @@ ${buildCards(timeSeries)}
     </tbody>
   </table>
   </div>
-  <p style="color:var(--text-dim);font-size:.8rem;margin-top:.5rem">Storage limits are for the free tier only. CockroachDB (10 GiB) offers the most generous managed storage. PocketBase, Weaviate, and Xata (post-April-2026 open-source pivot) are unlimited when self-hosted. All limits verified against live pricing pages, April 2026.</p>
+  <p style="color:var(--text-dim);font-size:.8rem;margin-top:.5rem">Storage limits are for the free tier only. CockroachDB (10 GiB) offers the most generous managed storage. PocketBase, Weaviate, and Xata (post-April-2026 open-source pivot) are unlimited when self-hosted. [[freshness]]</p>
 
   <h2>Which Free Database Should I Use?</h2>
   <div class="decision-guide">
@@ -10459,7 +10480,7 @@ ${buildCards(timeSeries)}
 
 function buildMonitoringAlternativesPage(): string {
   const title = "Best Free Monitoring Tools for Developers in 2026 — APM, Uptime, Logs & Error Tracking";
-  const metaDesc = "Compare 70+ free monitoring tools — New Relic, Grafana Cloud, Datadog, Sentry, BetterStack, UptimeRobot, and more. Exact free tier limits by monitoring type. Updated March 2026.";
+  const metaDesc = "Compare 70+ free monitoring tools — New Relic, Grafana Cloud, Datadog, Sentry, BetterStack, UptimeRobot, and more. Exact free tier limits by monitoring type. [[freshness]]";
   const slug = "monitoring-alternatives";
 
   const monitoringOffers = offers.filter(o => o.category === "Monitoring" || o.category === "Error Tracking");
@@ -10747,7 +10768,7 @@ ${buildCards(startupPrograms)}
     </tbody>
   </table>
   </div>
-  <p style="color:var(--text-dim);font-size:.8rem;margin-top:.5rem">New Relic's 100 GB/month is the most generous APM free tier. Axiom leads on log storage (500 GB ingest). UptimeRobot offers the most free monitors (50). Prometheus and Grafana (self-hosted) have no limits. Datadog's free tier is the most restrictive among major APM vendors. All limits verified against live pricing pages, March 2026.</p>
+  <p style="color:var(--text-dim);font-size:.8rem;margin-top:.5rem">New Relic's 100 GB/month is the most generous APM free tier. Axiom leads on log storage (500 GB ingest). UptimeRobot offers the most free monitors (50). Prometheus and Grafana (self-hosted) have no limits. Datadog's free tier is the most restrictive among major APM vendors. [[freshness]]</p>
 
   <div class="context-box" style="border-left:3px solid ${riskColors.risky}">
     <div style="font-weight:600;color:${riskColors.risky};margin-bottom:.5rem">Freshping Shutdown — March 6, 2026</div>
@@ -10799,7 +10820,7 @@ ${buildCards(startupPrograms)}
 
 function buildCiCdAlternativesPage(): string {
   const title = "Best Free CI/CD Tools for Developers in 2026 — Build Minutes, Runners & Pipelines Compared";
-  const metaDesc = "Compare 35+ free CI/CD tools — GitHub Actions, GitLab CI, CircleCI, Buildkite, Harness CI, Drone CI, and more. Exact free tier limits by CI/CD type. Updated March 2026.";
+  const metaDesc = "Compare 35+ free CI/CD tools — GitHub Actions, GitLab CI, CircleCI, Buildkite, Harness CI, Drone CI, and more. Exact free tier limits by CI/CD type. [[freshness]]";
   const slug = "ci-cd-alternatives";
 
   const cicdOffers = offers.filter(o => o.category === "CI/CD");
@@ -11065,7 +11086,7 @@ ${buildCards(specialized)}
     </tbody>
   </table>
   </div>
-  <p style="color:var(--text-dim);font-size:.8rem;margin-top:.5rem">GitHub Actions dominates with unlimited public repo minutes and the largest marketplace of reusable actions. CircleCI offers the most free credits among hosted platforms. Google Cloud Build has the most generous hosted minutes (2,500/mo). Drone CI and Woodpecker CI are unlimited when self-hosted. All limits verified against live pricing pages, March 2026.</p>
+  <p style="color:var(--text-dim);font-size:.8rem;margin-top:.5rem">GitHub Actions dominates with unlimited public repo minutes and the largest marketplace of reusable actions. CircleCI offers the most free credits among hosted platforms. Google Cloud Build has the most generous hosted minutes (2,500/mo). Drone CI and Woodpecker CI are unlimited when self-hosted. [[freshness]]</p>
 
   <h2>Which Free CI/CD Tool Should I Use?</h2>
   <div class="decision-guide">
@@ -11112,7 +11133,7 @@ ${buildCards(specialized)}
 
 function buildSecurityAlternativesPage(): string {
   const title = "Best Free Security Tools for Developers in 2026 — SAST, Secrets, Auth & Container Security";
-  const metaDesc = "Compare 100+ free security tools — Snyk, Semgrep, CodeQL, GitGuardian, Trivy, Auth0, Clerk, and more. Exact free tier limits by security domain. Updated March 2026.";
+  const metaDesc = "Compare 100+ free security tools — Snyk, Semgrep, CodeQL, GitGuardian, Trivy, Auth0, Clerk, and more. Exact free tier limits by security domain. [[freshness]]";
   const slug = "security-alternatives";
 
   const securityOffers = offers.filter(o => o.category === "Security" || o.category === "Secrets Management" || o.category === "Auth" || o.category === "Error Tracking");
@@ -11401,7 +11422,7 @@ ${buildCards(other)}
     </tbody>
   </table>
   </div>
-  <p style="color:var(--text-dim);font-size:.8rem;margin-top:.5rem">Snyk leads the all-in-one category with code, dependency, container, and IaC scanning in a single tool. For pure SAST, Semgrep and CodeQL are both excellent and free for open-source. GitGuardian is the standard for secret detection. Trivy dominates container scanning. Auth0 has the most generous free auth tier at 25K MAU. All limits verified against live pricing pages, March 2026.</p>
+  <p style="color:var(--text-dim);font-size:.8rem;margin-top:.5rem">Snyk leads the all-in-one category with code, dependency, container, and IaC scanning in a single tool. For pure SAST, Semgrep and CodeQL are both excellent and free for open-source. GitGuardian is the standard for secret detection. Trivy dominates container scanning. Auth0 has the most generous free auth tier at 25K MAU. [[freshness]]</p>
 
   <h2>Which Free Security Tool Should I Use?</h2>
   <div class="decision-guide">
@@ -11448,7 +11469,7 @@ ${buildCards(other)}
 
 function buildTestingAlternativesPage(): string {
   const title = "Best Free Testing Tools for Developers in 2026 — Browser, Visual, Load, E2E & API Testing Compared";
-  const metaDesc = "Compare 45+ free testing tools — Cypress, BrowserStack, Playwright, k6, Percy, Chromatic, Postman, Selenium, and more. Exact free tier limits by testing domain. Updated March 2026.";
+  const metaDesc = "Compare 45+ free testing tools — Cypress, BrowserStack, Playwright, k6, Percy, Chromatic, Postman, Selenium, and more. Exact free tier limits by testing domain. [[freshness]]";
   const slug = "testing-alternatives";
 
   const testingOffers = offers.filter(o => o.category === "Testing");
@@ -11732,7 +11753,7 @@ ${buildCards(other)}
     </tbody>
   </table>
   </div>
-  <p style="color:var(--text-dim);font-size:.8rem;margin-top:.5rem">Cypress Cloud leads for JavaScript E2E with 500 free results/month and a polished dashboard. BrowserStack and Sauce Labs are unbeatable for OSS projects needing cross-browser coverage. For load testing, Grafana k6 Cloud gives 500 VUh/month with the popular k6 scripting framework. Chromatic dominates Storybook visual testing at 5K snapshots/month. All limits verified against live pricing pages, March 2026.</p>
+  <p style="color:var(--text-dim);font-size:.8rem;margin-top:.5rem">Cypress Cloud leads for JavaScript E2E with 500 free results/month and a polished dashboard. BrowserStack and Sauce Labs are unbeatable for OSS projects needing cross-browser coverage. For load testing, Grafana k6 Cloud gives 500 VUh/month with the popular k6 scripting framework. Chromatic dominates Storybook visual testing at 5K snapshots/month. [[freshness]]</p>
 
   <h2>Which Free Testing Tool Should I Use?</h2>
   <div class="decision-guide">
@@ -11779,7 +11800,7 @@ ${buildCards(other)}
 
 function buildStorageAlternativesPage(): string {
   const title = "Best Free Cloud Storage for Developers in 2026 — Object Storage, Media CDN & File Hosting Compared";
-  const metaDesc = "Compare 55+ free cloud storage tools — Cloudflare R2, Backblaze B2, Tigris, Cloudinary, ImageKit, Google Cloud Storage, and more. Exact free tier limits by storage type. Updated March 2026.";
+  const metaDesc = "Compare 55+ free cloud storage tools — Cloudflare R2, Backblaze B2, Tigris, Cloudinary, ImageKit, Google Cloud Storage, and more. Exact free tier limits by storage type. [[freshness]]";
   const slug = "storage-alternatives";
 
   const storageOffers = offers.filter(o => o.category === "Storage" || o.category === "CDN");
@@ -12041,7 +12062,7 @@ ${buildCards(other)}
     </tbody>
   </table>
   </div>
-  <p style="color:var(--text-dim);font-size:.8rem;margin-top:.5rem">Cloudflare R2 leads on value with 10 GB free and zero egress fees \u2014 a game-changer for read-heavy workloads. Backblaze B2 undercuts it on storage and serves up to 3x what you store for nothing, charging $0.01/GB only past that. For media, Cloudinary and ImageKit both offer generous transformation pipelines. MinIO is the go-to for self-hosted S3-compatible storage. All limits verified against live pricing pages, March 2026.</p>
+  <p style="color:var(--text-dim);font-size:.8rem;margin-top:.5rem">Cloudflare R2 leads on value with 10 GB free and zero egress fees \u2014 a game-changer for read-heavy workloads. Backblaze B2 undercuts it on storage and serves up to 3x what you store for nothing, charging $0.01/GB only past that. For media, Cloudinary and ImageKit both offer generous transformation pipelines. MinIO is the go-to for self-hosted S3-compatible storage. [[freshness]]</p>
 
   <h2>Which Free Storage Should I Use?</h2>
   <div class="decision-guide">
@@ -12088,7 +12109,7 @@ ${buildCards(other)}
 
 function buildAnalyticsAlternativesPage(): string {
   const title = "Best Free Analytics Tools for Developers in 2026 — Product, Web, Event & Data Analytics Compared";
-  const metaDesc = "Compare 45+ free analytics tools — PostHog, Amplitude, Mixpanel, Plausible, Umami, Tinybird, Segment, and more. Exact free tier limits by analytics domain. Updated March 2026.";
+  const metaDesc = "Compare 45+ free analytics tools — PostHog, Amplitude, Mixpanel, Plausible, Umami, Tinybird, Segment, and more. Exact free tier limits by analytics domain. [[freshness]]";
   const slug = "analytics-alternatives";
 
   const analyticsOffers = offers.filter(o => o.category === "Analytics");
@@ -12357,7 +12378,7 @@ ${buildCards(other)}
     </tbody>
   </table>
   </div>
-  <p style="color:var(--text-dim);font-size:.8rem;margin-top:.5rem">PostHog leads on value with 1M events/month free including session replays, feature flags, and A/B testing \u2014 the most complete free analytics package. Amplitude matches on event volume (10M) but caps at 10K monthly tracked users. For privacy-first web analytics, Plausible and Umami are both self-hostable with no limits. Microsoft Clarity is uniquely free with no caps on session replay. All limits verified against live pricing pages, March 2026.</p>
+  <p style="color:var(--text-dim);font-size:.8rem;margin-top:.5rem">PostHog leads on value with 1M events/month free including session replays, feature flags, and A/B testing \u2014 the most complete free analytics package. Amplitude matches on event volume (10M) but caps at 10K monthly tracked users. For privacy-first web analytics, Plausible and Umami are both self-hostable with no limits. Microsoft Clarity is uniquely free with no caps on session replay. [[freshness]]</p>
 
   <h2>Which Free Analytics Tool Should I Use?</h2>
   <div class="decision-guide">
@@ -12404,7 +12425,7 @@ ${buildCards(other)}
 
 function buildAiMlAlternativesPage(): string {
   const title = "Best Free AI & ML Tools for Developers in 2026 — LLM APIs, AI Coding, Training & Observability Compared";
-  const metaDesc = "Compare 65+ free AI/ML tools — Groq, Cerebras, OpenAI, Hugging Face, GitHub Copilot, Cursor, Langfuse, and more. Exact free tier limits by AI domain. Updated March 2026.";
+  const metaDesc = "Compare 65+ free AI/ML tools — Groq, Cerebras, OpenAI, Hugging Face, GitHub Copilot, Cursor, Langfuse, and more. Exact free tier limits by AI domain. [[freshness]]";
   const slug = "ai-ml-alternatives";
 
   const aiOffers = offers.filter(o => o.category === "AI / ML" || o.category === "AI Coding");
@@ -12673,7 +12694,7 @@ ${buildCards(other)}
     </tbody>
   </table>
   </div>
-  <p style="color:var(--text-dim);font-size:.8rem;margin-top:.5rem">Groq and Cerebras lead on free LLM inference volume \u2014 Groq for speed (LPU), Cerebras for daily token quota (1M/day). Mistral offers the broadest model access on free tier (all models including Large). For AI coding, GitHub Copilot and Cursor both offer 2,000 free completions/month, while Gemini CLI is completely free and open-source. Langfuse is the standout for LLM observability (open-source, 50K observations free). All limits verified against live pricing pages, March 2026.</p>
+  <p style="color:var(--text-dim);font-size:.8rem;margin-top:.5rem">Groq and Cerebras lead on free LLM inference volume \u2014 Groq for speed (LPU), Cerebras for daily token quota (1M/day). Mistral offers the broadest model access on free tier (all models including Large). For AI coding, GitHub Copilot and Cursor both offer 2,000 free completions/month, while Gemini CLI is completely free and open-source. Langfuse is the standout for LLM observability (open-source, 50K observations free). [[freshness]]</p>
 
   <h2>Which Free AI Tool Should I Use?</h2>
   <div class="decision-guide">
@@ -12720,7 +12741,7 @@ ${buildCards(other)}
 
 function buildEmailAlternativesPage(): string {
   const title = "Best Free Email Tools for Developers in 2026 — Transactional APIs, Marketing Platforms & Email Infrastructure Compared";
-  const metaDesc = "Compare 59+ free email tools — Resend, Brevo, Mailjet, SendGrid, Mailchimp, SimpleLogin, Proton Mail, and more. Exact free tier limits by email domain. Updated March 2026.";
+  const metaDesc = "Compare 59+ free email tools — Resend, Brevo, Mailjet, SendGrid, Mailchimp, SimpleLogin, Proton Mail, and more. Exact free tier limits by email domain. [[freshness]]";
   const slug = "email-alternatives";
 
   const emailOffers = offers.filter(o => o.category === "Email");
@@ -13003,7 +13024,7 @@ ${buildCards(other)}
     </tbody>
   </table>
   </div>
-  <p style="color:var(--text-dim);font-size:.8rem;margin-top:.5rem">Resend leads the modern transactional email space with React Email integration and 3K emails/month free. Brevo offers the most generous marketing free tier with 300 emails/day and unlimited contacts. For privacy, SimpleLogin and AnonAddy are both open source with self-hosting options. All limits verified against live pricing pages, March 2026.</p>
+  <p style="color:var(--text-dim);font-size:.8rem;margin-top:.5rem">Resend leads the modern transactional email space with React Email integration and 3K emails/month free. Brevo offers the most generous marketing free tier with 300 emails/day and unlimited contacts. For privacy, SimpleLogin and AnonAddy are both open source with self-hosting options. [[freshness]]</p>
 
   <h2>Which Free Email Tool Should I Use?</h2>
   <div class="decision-guide">
@@ -13050,7 +13071,7 @@ ${buildCards(other)}
 
 function buildDesignAlternativesPage(): string {
   const title = "Best Free Design Tools for Developers in 2026 — UI Kits, Prototyping, Icons & Assets Compared";
-  const metaDesc = "Compare 100+ free design tools — Figma, Penpot, Canva, ShadcnUI, Lucide, Unsplash, Coolors, and more. Exact free tier limits by design domain. Updated March 2026.";
+  const metaDesc = "Compare 100+ free design tools — Figma, Penpot, Canva, ShadcnUI, Lucide, Unsplash, Coolors, and more. Exact free tier limits by design domain. [[freshness]]";
   const slug = "design-alternatives";
 
   const designOffers = offers.filter(o => o.category === "Design");
@@ -13340,7 +13361,7 @@ ${buildCards(other)}
     </tbody>
   </table>
   </div>
-  <p style="color:var(--text-dim);font-size:.8rem;margin-top:.5rem">Figma remains the industry standard for UI/UX design with a generous free Starter plan. Penpot is the leading open-source alternative with no limits. For developers who prefer code, ShadcnUI and DaisyUI eliminate the need for a design tool entirely. The icon ecosystem is especially strong \u2014 Lucide, Iconoir, and Tabler all offer 1,000+ MIT-licensed icons. All limits verified against live pricing pages, March 2026.</p>
+  <p style="color:var(--text-dim);font-size:.8rem;margin-top:.5rem">Figma remains the industry standard for UI/UX design with a generous free Starter plan. Penpot is the leading open-source alternative with no limits. For developers who prefer code, ShadcnUI and DaisyUI eliminate the need for a design tool entirely. The icon ecosystem is especially strong \u2014 Lucide, Iconoir, and Tabler all offer 1,000+ MIT-licensed icons. [[freshness]]</p>
 
   <h2>Which Free Design Tool Should I Use?</h2>
   <div class="decision-guide">
@@ -13387,7 +13408,7 @@ ${buildCards(other)}
 
 function buildProjectManagementAlternativesPage(): string {
   const title = "Best Free Project Management & Collaboration Tools in 2026 — PM, Chat, Scheduling & Productivity Compared";
-  const metaDesc = "Compare 93+ free project management tools — Linear, Asana, Trello, ClickUp, Notion, Slack alternatives, Cal.com, and more. Exact free tier limits. Updated March 2026.";
+  const metaDesc = "Compare 93+ free project management tools — Linear, Asana, Trello, ClickUp, Notion, Slack alternatives, Cal.com, and more. Exact free tier limits. [[freshness]]";
   const slug = "project-management-alternatives";
 
   const pmOffers = offers.filter(o => o.category === "Project Management" || o.category === "Team Collaboration");
@@ -13677,7 +13698,7 @@ ${buildCards(other)}
     </tbody>
   </table>
   </div>
-  <p style="color:var(--text-dim);font-size:.8rem;margin-top:.5rem">Linear leads modern issue tracking with a fast, keyboard-driven interface and 250 free issues. Plane and Huly offer unlimited open-source PM. For team chat, Pumble provides unlimited message history free — a key advantage over Slack. Cal.com is the leading open-source scheduling tool. All limits verified against live pricing pages, March 2026.</p>
+  <p style="color:var(--text-dim);font-size:.8rem;margin-top:.5rem">Linear leads modern issue tracking with a fast, keyboard-driven interface and 250 free issues. Plane and Huly offer unlimited open-source PM. For team chat, Pumble provides unlimited message history free — a key advantage over Slack. Cal.com is the leading open-source scheduling tool. [[freshness]]</p>
 
   <h2>Which Free PM Tool Should I Use?</h2>
   <div class="decision-guide">
@@ -13724,7 +13745,7 @@ ${buildCards(other)}
 
 function buildIdeCodeEditorsAlternativesPage(): string {
   const title = "Best Free IDEs, Code Editors & AI Coding Tools in 2026 — Desktop, Cloud & AI Assistants Compared";
-  const metaDesc = "Compare 59+ free IDEs and coding tools — VS Code, Cursor, GitHub Copilot, Zed, Replit, Windsurf, Devin, and more. Exact free tier limits. Updated March 2026.";
+  const metaDesc = "Compare 59+ free IDEs and coding tools — VS Code, Cursor, GitHub Copilot, Zed, Replit, Windsurf, Devin, and more. Exact free tier limits. [[freshness]]";
   const slug = "ide-code-editors-alternatives";
 
   const ideOffers = offers.filter(o => o.category === "IDE & Code Editors" || o.category === "AI Coding");
@@ -13993,7 +14014,7 @@ ${buildCards(other)}
     </tbody>
   </table>
   </div>
-  <p style="color:var(--text-dim);font-size:.8rem;margin-top:.5rem">VS Code remains the dominant free editor with the largest extension ecosystem. GitHub Copilot's free tier (2,000 completions/month) makes AI coding accessible to all developers. For open-source alternatives, Cline and Aider let you use any LLM provider. Devin's price drop from $500 to $20/month signals the rapid commoditization of AI coding agents. All limits verified against live pricing pages, March 2026.</p>
+  <p style="color:var(--text-dim);font-size:.8rem;margin-top:.5rem">VS Code remains the dominant free editor with the largest extension ecosystem. GitHub Copilot's free tier (2,000 completions/month) makes AI coding accessible to all developers. For open-source alternatives, Cline and Aider let you use any LLM provider. Devin's price drop from $500 to $20/month signals the rapid commoditization of AI coding agents. [[freshness]]</p>
 
   <h2>Which Free IDE or AI Coding Tool Should I Use?</h2>
   <div class="decision-guide">
@@ -14040,7 +14061,7 @@ ${buildCards(other)}
 
 function buildFreeLlmApisPage(): string {
   const title = "Best Free LLM APIs in 2026 — Compare Free Inference Tiers, Rate Limits & Models";
-  const metaDesc = "Compare 25+ free LLM API providers — Groq, Cerebras, OpenRouter, Gemini, Mistral, OpenAI, Anthropic, NVIDIA NIM, and more. Exact rate limits and token quotas. Updated March 2026.";
+  const metaDesc = "Compare 25+ free LLM API providers — Groq, Cerebras, OpenRouter, Gemini, Mistral, OpenAI, Anthropic, NVIDIA NIM, and more. Exact rate limits and token quotas. [[freshness]]";
   const slug = "free-llm-apis";
 
   const aiOffers = offers.filter(o => o.category === "AI / ML");
@@ -14301,7 +14322,7 @@ ${buildCards(aiGateways)}
     </tbody>
   </table>
   </div>
-  <p style="color:var(--text-dim);font-size:.8rem;margin-top:.5rem">Groq and Cerebras lead on free inference \u2014 Groq for speed (custom LPU silicon), Cerebras for daily token volume (1M/day). Mistral offers the broadest model access on free tier (all models, 1B tokens/month at 2 RPM). OpenRouter is ideal if you want one API key for ~30 free models. GitHub Models has the widest selection (100+ models). For proprietary frontier models, most providers are pay-as-you-go with signup credits rather than ongoing free tiers. All limits verified March 2026.</p>
+  <p style="color:var(--text-dim);font-size:.8rem;margin-top:.5rem">Groq and Cerebras lead on free inference \u2014 Groq for speed (custom LPU silicon), Cerebras for daily token volume (1M/day). Mistral offers the broadest model access on free tier (all models, 1B tokens/month at 2 RPM). OpenRouter is ideal if you want one API key for ~30 free models. GitHub Models has the widest selection (100+ models). For proprietary frontier models, most providers are pay-as-you-go with signup credits rather than ongoing free tiers. [[freshness]]</p>
 
   <h2>Which Free LLM API Should I Use?</h2>
   <div class="decision-guide">
@@ -14348,7 +14369,7 @@ ${buildCards(aiGateways)}
 
 function buildApiDevelopmentAlternativesPage(): string {
   const title = "Best Free API Development Tools in 2026 — REST, GraphQL, Mocking & Documentation Compared";
-  const metaDesc = "Compare 39+ free API development tools — Postman, Hoppscotch, Insomnia, Bruno, Mintlify, Swagger, RapidAPI, Nango, and more. Exact free tier limits. Updated March 2026.";
+  const metaDesc = "Compare 39+ free API development tools — Postman, Hoppscotch, Insomnia, Bruno, Mintlify, Swagger, RapidAPI, Nango, and more. Exact free tier limits. [[freshness]]";
   const slug = "api-development-alternatives";
 
   const apiOffers = offers.filter(o => o.category === "API Development");
@@ -14614,7 +14635,7 @@ ${buildCards(apiIntegration)}
     </tbody>
   </table>
   </div>
-  <p style="color:var(--text-dim);font-size:.8rem;margin-top:.5rem">Hoppscotch and Bruno lead the open-source API client space \u2014 both MIT-licensed with no vendor lock-in. Postman remains the industry standard with the largest ecosystem. For GraphQL, Apollo GraphOS handles federation while Hasura generates instant APIs. Mintlify is the top choice for modern API docs. All limits verified March 2026.</p>
+  <p style="color:var(--text-dim);font-size:.8rem;margin-top:.5rem">Hoppscotch and Bruno lead the open-source API client space \u2014 both MIT-licensed with no vendor lock-in. Postman remains the industry standard with the largest ecosystem. For GraphQL, Apollo GraphOS handles federation while Hasura generates instant APIs. Mintlify is the top choice for modern API docs. [[freshness]]</p>
 
   <h2>Which Free API Tool Should I Use?</h2>
   <div class="decision-guide">
@@ -14661,7 +14682,7 @@ ${buildCards(apiIntegration)}
 
 function buildTeamCollaborationAlternativesPage(): string {
   const title = "Best Free Team Collaboration Tools in 2026 — Chat, Video, Docs & Scheduling Compared";
-  const metaDesc = "Compare 60+ free team collaboration tools — Slack, Discord, Zoom, Jitsi, Notion, Cal.com, Rocket.Chat, and more. Exact free tier limits. Updated March 2026.";
+  const metaDesc = "Compare 60+ free team collaboration tools — Slack, Discord, Zoom, Jitsi, Notion, Cal.com, Rocket.Chat, and more. Exact free tier limits. [[freshness]]";
   const slug = "team-collaboration-alternatives";
 
   const collabOffers = offers.filter(o =>
@@ -14935,7 +14956,7 @@ ${buildCards(other)}
     </tbody>
   </table>
   </div>
-  <p style="color:var(--text-dim);font-size:.8rem;margin-top:.5rem">Pumble leads for free team chat with unlimited message history — a key advantage over Slack's 90-day limit. For video, Jitsi Meet is completely free and open source. Cal.com is the leading open-source scheduling tool. All limits verified against live pricing pages, March 2026.</p>
+  <p style="color:var(--text-dim);font-size:.8rem;margin-top:.5rem">Pumble leads for free team chat with unlimited message history — a key advantage over Slack's 90-day limit. For video, Jitsi Meet is completely free and open source. Cal.com is the leading open-source scheduling tool. [[freshness]]</p>
 
   <h2>Which Free Collaboration Tool Should I Use?</h2>
   <div class="decision-guide">
@@ -19357,7 +19378,7 @@ ${mcpCtaCss()}
 
 function buildGoogleDeveloperProgram2026Page(): string {
   const title = "Google Developer Program 2026 — Premium Ending, Migration Guide & Alternatives";
-  const metaDesc = "Google Developer Program Premium ($299/year) ends March 30, 2026. Compare GDP Premium vs AI Pro ($19.99/mo) vs AI Ultra ($249.99/mo). Migration steps, free alternatives for Cloud credits, Gemini API, Firebase. Updated March 2026.";
+  const metaDesc = "Google Developer Program Premium ($299/year) ends March 30, 2026. Compare GDP Premium vs AI Pro ($19.99/mo) vs AI Ultra ($249.99/mo). Migration steps, free alternatives for Cloud credits, Gemini API, Firebase. [[freshness]]";
   const slug = "google-developer-program-2026";
   const pubDate = "2026-03-26";
 
@@ -19755,7 +19776,7 @@ ${mcpCtaCss()}
   </div>
 
   <div class="methodology">
-    <strong>Methodology:</strong> Pricing data sourced from <a href="https://blog.google/innovation-and-ai/technology/developers-tools/gdp-premium-ai-pro-ultra/" target="_blank" rel="noopener">Google's official blog post</a>, <a href="https://developers.google.com/profile/help/benefits" target="_blank" rel="noopener">Developer Program benefits page</a>, and <a href="https://ai.google.dev/pricing" target="_blank" rel="noopener">Google AI pricing page</a>. Alternative pricing verified against vendor pages as of March 2026. Cloud credit comparisons use official free tier limits read from each provider's pricing page.
+    <strong>Methodology:</strong> Pricing data sourced from <a href="https://blog.google/innovation-and-ai/technology/developers-tools/gdp-premium-ai-pro-ultra/" target="_blank" rel="noopener">Google's official blog post</a>, <a href="https://developers.google.com/profile/help/benefits" target="_blank" rel="noopener">Developer Program benefits page</a>, and <a href="https://ai.google.dev/pricing" target="_blank" rel="noopener">Google AI pricing page</a>. [[freshness]] Cloud credit comparisons use official free tier limits read from each provider's pricing page.
   </div>
 
   <div class="search-cta">
@@ -19774,7 +19795,7 @@ ${mcpCtaCss()}
 
 function buildSupabaseVsFirebasePage(): string {
   const title = "Supabase vs Firebase Free Tier Comparison — 2026 Deep Dive";
-  const metaDesc = "Compare Supabase and Firebase free tiers side-by-side. Database, auth, storage, functions, bandwidth — verified data, cost-at-scale analysis, and BaaS alternatives. Updated March 2026.";
+  const metaDesc = "Compare Supabase and Firebase free tiers side-by-side. Database, auth, storage, functions, bandwidth — verified data, cost-at-scale analysis, and BaaS alternatives. [[freshness]]";
   const slug = "supabase-vs-firebase";
   const pubDate = "2026-03-26";
 
@@ -19968,7 +19989,7 @@ ${mcpCtaCss()}
   </div>
 
   <h2 id="comparison">1. Free Tier Comparison Table</h2>
-  <p class="section-intro">Side-by-side comparison using verified data from our index. <span class="vs-badge vs-supabase">Supabase</span> and <span class="vs-badge vs-firebase">Firebase</span> free tiers as of March 2026.</p>
+  <p class="section-intro">Side-by-side comparison using verified data from our index. <span class="vs-badge vs-supabase">Supabase</span> and <span class="vs-badge vs-firebase">Firebase</span> free tiers. [[freshness]]</p>
   <div style="overflow-x:auto">
     <table class="pricing-table">
       <thead>
@@ -20097,7 +20118,7 @@ ${mcpCtaCss()}
 
 function buildVercelVsNetlifyPage(): string {
   const title = "Vercel vs Netlify Free Tier Comparison — 2026 Deep Dive";
-  const metaDesc = "Compare Vercel and Netlify free tiers side-by-side. Bandwidth, serverless functions, build minutes, storage, commercial use — verified data, cost-at-scale analysis, and hosting alternatives. Updated March 2026.";
+  const metaDesc = "Compare Vercel and Netlify free tiers side-by-side. Bandwidth, serverless functions, build minutes, storage, commercial use — verified data, cost-at-scale analysis, and hosting alternatives. [[freshness]]";
   const slug = "vercel-vs-netlify";
   const pubDate = "2026-03-26";
 
@@ -20290,7 +20311,7 @@ ${mcpCtaCss()}
   </div>
 
   <h2 id="comparison">1. Free Tier Comparison Table</h2>
-  <p class="section-intro">Side-by-side comparison using verified data from our index. <span class="vs-badge vs-vercel">Vercel</span> and <span class="vs-badge vs-netlify">Netlify</span> free tiers as of March 2026.</p>
+  <p class="section-intro">Side-by-side comparison using verified data from our index. <span class="vs-badge vs-vercel">Vercel</span> and <span class="vs-badge vs-netlify">Netlify</span> free tiers. [[freshness]]</p>
   <div style="overflow-x:auto">
     <table class="pricing-table">
       <thead>
@@ -20414,7 +20435,7 @@ ${mcpCtaCss()}
 
 function buildNeonVsSupabasePage(): string {
   const title = "Neon vs Supabase Free Tier Comparison — 2026 Deep Dive";
-  const metaDesc = "Compare Neon and Supabase free tiers side-by-side. Storage, compute, branching, auth, edge functions, realtime — verified data, cost-at-scale analysis, and database alternatives. Updated March 2026.";
+  const metaDesc = "Compare Neon and Supabase free tiers side-by-side. Storage, compute, branching, auth, edge functions, realtime — verified data, cost-at-scale analysis, and database alternatives. [[freshness]]";
   const slug = "neon-vs-supabase";
   const pubDate = "2026-03-26";
 
@@ -20609,7 +20630,7 @@ ${mcpCtaCss()}
   </div>
 
   <h2 id="comparison">1. Free Tier Comparison Table</h2>
-  <p class="section-intro">Side-by-side comparison using verified data from our index. <span class="vs-badge vs-neon">Neon</span> and <span class="vs-badge vs-supabase">Supabase</span> free tiers as of March 2026.</p>
+  <p class="section-intro">Side-by-side comparison using verified data from our index. <span class="vs-badge vs-neon">Neon</span> and <span class="vs-badge vs-supabase">Supabase</span> free tiers. [[freshness]]</p>
   <div style="overflow-x:auto">
     <table class="pricing-table">
       <thead>
@@ -20733,7 +20754,7 @@ ${mcpCtaCss()}
 
 function buildRailwayVsRenderPage(): string {
   const title = "Railway vs Render — Free Tier Comparison (2026)";
-  const metaDesc = "Compare Railway and Render free tiers side-by-side. RAM, CPU, databases, Redis, sleep behavior, bandwidth, custom domains — verified data from 1,600+ developer tools. Usage-based flexibility vs predictable billing.";
+  const metaDesc = "Compare Railway and Render free tiers side-by-side. RAM, CPU, databases, Redis, sleep behavior, bandwidth, custom domains — verified data from 1,600+ developer tools. Usage-based flexibility vs predictable billing. [[freshness]]";
   const slug = "railway-vs-render";
   const pubDate = "2026-03-26";
 
@@ -20930,7 +20951,7 @@ ${mcpCtaCss()}
   </div>
 
   <h2 id="comparison">1. Free Tier Comparison Table</h2>
-  <p class="section-intro">Side-by-side comparison using verified data from our index. <span class="vs-badge vs-railway">Railway</span> and <span class="vs-badge vs-render">Render</span> free tiers as of March 2026.</p>
+  <p class="section-intro">Side-by-side comparison using verified data from our index. <span class="vs-badge vs-railway">Railway</span> and <span class="vs-badge vs-render">Render</span> free tiers. [[freshness]]</p>
   <div style="overflow-x:auto">
     <table class="pricing-table">
       <thead>
@@ -21054,7 +21075,7 @@ ${mcpCtaCss()}
 
 function buildDatadogVsNewRelicPage(): string {
   const title = "Datadog vs New Relic — Free Tier Comparison (2026)";
-  const metaDesc = "Compare Datadog and New Relic free tiers side-by-side. Hosts, data ingest, APM, logs, synthetics, retention, alerting — verified data from 1,600+ developer tools. Per-host pricing vs per-GB pricing.";
+  const metaDesc = "Compare Datadog and New Relic free tiers side-by-side. Hosts, data ingest, APM, logs, synthetics, retention, alerting — verified data from 1,600+ developer tools. Per-host pricing vs per-GB pricing. [[freshness]]";
   const slug = "datadog-vs-new-relic";
   const pubDate = "2026-03-26";
 
@@ -21251,7 +21272,7 @@ ${mcpCtaCss()}
   </div>
 
   <h2 id="comparison">1. Free Tier Comparison Table</h2>
-  <p class="section-intro">Side-by-side comparison using verified data from our index. <span class="vs-badge vs-datadog">Datadog</span> and <span class="vs-badge vs-newrelic">New Relic</span> free tiers as of March 2026.</p>
+  <p class="section-intro">Side-by-side comparison using verified data from our index. <span class="vs-badge vs-datadog">Datadog</span> and <span class="vs-badge vs-newrelic">New Relic</span> free tiers. [[freshness]]</p>
   <div style="overflow-x:auto">
     <table class="pricing-table">
       <thead>
@@ -21786,7 +21807,7 @@ ${mcpCtaCss()}
   </div>
 
   <div class="methodology">
-    <strong>Methodology:</strong> Free tier details sourced from <a href="https://www.hashicorp.com/products/terraform/pricing" target="_blank" rel="noopener">HashiCorp's pricing page</a> and verified against each alternative's pricing page as of March 2026. Migration steps based on official Terraform backend migration documentation. Resource counts and feature comparisons from our index of ${offers.length.toLocaleString()} tracked developer tools.
+    <strong>Methodology:</strong> Free tier details sourced from <a href="https://www.hashicorp.com/products/terraform/pricing" target="_blank" rel="noopener">HashiCorp's pricing page</a>. [[freshness]] Migration steps based on official Terraform backend migration documentation. Resource counts and feature comparisons from our index of ${offers.length.toLocaleString()} tracked developer tools.
   </div>
 
   <div class="search-cta">
@@ -22181,7 +22202,7 @@ function buildTerraformCloudFreeTierRemovedPage(): string {
     + '  </div>\n'
     + '\n'
     + '  <div class="methodology">\n'
-    + '    <strong>Methodology:</strong> Pricing data sourced from <a href="https://www.hashicorp.com/products/terraform/pricing" target="_blank" rel="noopener">HashiCorp\'s pricing page</a> and verified against each alternative\'s pricing page as of April 2026. Cost estimates for self-hosted options assume a small cloud VM ($5-15/month for Atlantis/OpenTofu runners). Resource limits and features were read from each platform\'s free tier documentation on ' + pubDate + '. Stability indicators are computed from our tracked pricing changes. See also our <a href="/hcp-terraform-migration">pre-deadline migration guide</a> for step-by-step instructions.\n'
+    + '    <strong>Methodology:</strong> Pricing data sourced from <a href="https://www.hashicorp.com/products/terraform/pricing" target="_blank" rel="noopener">HashiCorp\'s pricing page</a>. [[freshness]] Cost estimates for self-hosted options assume a small cloud VM ($5-15/month for Atlantis/OpenTofu runners). Resource limits and features were read from each platform\'s free tier documentation on ' + pubDate + '. Stability indicators are computed from our tracked pricing changes. See also our <a href="/hcp-terraform-migration">pre-deadline migration guide</a> for step-by-step instructions.\n'
     + '  </div>\n'
     + '\n'
     + '  <div class="search-cta">\n'
@@ -22527,7 +22548,7 @@ ${mcpCtaCss()}
   </div>
 
   <div class="methodology">
-    <strong>Methodology:</strong> Gemini API pricing details sourced from <a href="https://ai.google.dev/gemini-api/docs/pricing" target="_blank" rel="noopener">Google's Gemini API pricing page</a> and <a href="https://ai.google.dev/gemini-api/docs/billing" target="_blank" rel="noopener">billing documentation</a>. Rate limit reductions verified via our <a href="/changes">deal change tracker</a> (3 Gemini changes tracked since December 2025). Alternative provider limits verified against their pricing pages as of March 2026. Risk assessments are based on pricing history and free tier stability.
+    <strong>Methodology:</strong> Gemini API pricing details sourced from <a href="https://ai.google.dev/gemini-api/docs/pricing" target="_blank" rel="noopener">Google's Gemini API pricing page</a> and <a href="https://ai.google.dev/gemini-api/docs/billing" target="_blank" rel="noopener">billing documentation</a>. Rate limit reductions verified via our <a href="/changes">deal change tracker</a> (3 Gemini changes tracked since December 2025). [[freshness]] Risk assessments are based on pricing history and free tier stability.
   </div>
 
   <div class="search-cta">
@@ -22956,7 +22977,7 @@ function buildGeminiApiPricingChangesPage(): string {
     + '  </div>\n'
     + '\n'
     + '  <div class="methodology">\n'
-    + '    <strong>Methodology:</strong> Pricing data sourced from <a href="https://ai.google.dev/gemini-api/docs/pricing" target="_blank" rel="noopener">Google\'s Gemini API pricing page</a> and <a href="https://ai.google.dev/gemini-api/docs/billing" target="_blank" rel="noopener">billing documentation</a>. Alternative provider limits verified against their respective pricing pages as of April 2026. Cost estimates assume average request sizes (~1K tokens in, ~500 tokens out) and may vary by use case. Risk assessments and stability indicators are computed from our tracked pricing changes. See also our <a href="/gemini-api-pricing-2026">Gemini billing deep-dive</a> for spend cap tier details.\n'
+    + '    <strong>Methodology:</strong> Pricing data sourced from <a href="https://ai.google.dev/gemini-api/docs/pricing" target="_blank" rel="noopener">Google\'s Gemini API pricing page</a> and <a href="https://ai.google.dev/gemini-api/docs/billing" target="_blank" rel="noopener">billing documentation</a>. [[freshness]] Cost estimates assume average request sizes (~1K tokens in, ~500 tokens out) and may vary by use case. Risk assessments and stability indicators are computed from our tracked pricing changes. See also our <a href="/gemini-api-pricing-2026">Gemini billing deep-dive</a> for spend cap tier details.\n'
     + '  </div>\n'
     + '\n'
     + '  <div class="search-cta">\n'
@@ -24868,7 +24889,7 @@ ${mcpCtaCss()}
   <div class="methodology">
     <p><strong>How we track this data:</strong> AgentDeals monitors free tier changes across ${offers.length.toLocaleString()} developer tools in ${categories.length} categories. Stability ratings are computed from our <a href="/changes">deal changes database</a> \u2014 OpenAI is classified as <strong style="color:${stabilityColor}">${openaiStability}</strong> based on ${openaiChanges.length} tracked changes including free tier removal, limit reductions, and API deprecation.</p>
     <p><strong>Migration complexity ratings</strong> are based on the scope of code changes required: Low (API shape change only), Medium (some logic restructuring), High (architectural changes to state management or data flow).</p>
-    <p><strong>Cost data</strong> is from official vendor pricing pages, verified April 2026. Tool-specific costs (file search, web search) are Responses API additions not present in the Assistants API.</p>
+    <p><strong>Cost data</strong> is from official vendor pricing pages. ${pageCompiledClause("/openai-assistants-migration-2026")}. Tool-specific costs (file search, web search) are Responses API additions not present in the Assistants API.</p>
     <p>For real-time data, use our <a href="/stability">stability dashboard</a>, <a href="/feed.xml">Atom feed</a>, or <a href="/setup">MCP server</a>. Full dataset available via <a href="/api/offers">REST API</a>.</p>
   </div>
 
@@ -27198,7 +27219,7 @@ ${mcpCtaCss()}
 
 function buildStartupCreditsPage(): string {
   const title = "Startup Credits Comparison 2026 — Cloud Credits, Eligibility & Hidden Constraints";
-  const metaDesc = "Compare 15+ startup programs: AWS Activate, Google for Startups, Microsoft Founders Hub, Cloudflare, DigitalOcean Hatch, Stripe Atlas, Brex, Mercury, and more. Credit values, eligibility, vesting, and stacking strategies. Updated April 2026.";
+  const metaDesc = "Compare 15+ startup programs: AWS Activate, Google for Startups, Microsoft Founders Hub, Cloudflare, DigitalOcean Hatch, Stripe Atlas, Brex, Mercury, and more. Credit values, eligibility, vesting, and stacking strategies. [[freshness]]";
   const slug = "startup-credits";
   const pubDate = "2026-03-27";
 
@@ -27465,7 +27486,7 @@ function buildStartupCreditsPage(): string {
     '  </div>\n' +
     '\n' +
     '  <h2 id="comparison-table">Comparison Table</h2>\n' +
-    '  <p class="section-intro">All credit values verified as of April 2026. Hover rows to highlight. Programs sorted by category.</p>\n' +
+    '  <p class="section-intro">[[freshness]] Hover rows to highlight. Programs sorted by category.</p>\n' +
     '\n' +
     '  <div style="overflow-x:auto">\n' +
     '  <table class="pricing-table">\n' +
@@ -27595,7 +27616,7 @@ function buildStartupCreditsPage(): string {
 
 function buildAiCodingPricing2026Page(): string {
   const title = "AI Coding Tools Pricing Guide — 2026 Comparison";
-  const metaDesc = "Side-by-side pricing comparison of Cursor, Windsurf, GitHub Copilot, Gemini Code Assist, Amazon Q, Claude Code, Augment Code and more. Free tiers, pro plans, and recent pricing changes. Updated March 2026.";
+  const metaDesc = "Side-by-side pricing comparison of Cursor, Windsurf, GitHub Copilot, Gemini Code Assist, Amazon Q, Claude Code, Augment Code and more. Free tiers, pro plans, and recent pricing changes. [[freshness]]";
   const slug = "ai-coding-pricing-2026";
   const pubDate = "2026-03-27";
 
@@ -27872,7 +27893,7 @@ ${mcpCtaCss()}
   </div>
 
   <h2 id="pricing-table">Pricing Comparison Table</h2>
-  <p class="section-intro">All prices verified as of March 2026. Hover rows to highlight. Click tool names for full vendor profiles with free tier details.</p>
+  <p class="section-intro">[[freshness]] Hover rows to highlight. Click tool names for full vendor profiles with free tier details.</p>
 
   <div style="overflow-x:auto">
   <table class="pricing-table">
@@ -27986,7 +28007,7 @@ ${mcpCtaCss()}
 
 function buildAiCodingToolsPricingPage(): string {
   const title = "AI Coding Tools Pricing Comparison 2026 — The Definitive Free Tier Breakdown";
-  const metaDesc = "Compare 17 AI coding tools: Cursor, Windsurf, Amazon Kiro, GitHub Copilot, Claude Code, Devin, Bolt.new, Lovable, Codex, Gemini CLI and more. Free tiers, hidden costs, cost analysis for solo devs and teams. Updated April 2026.";
+  const metaDesc = "Compare 17 AI coding tools: Cursor, Windsurf, Amazon Kiro, GitHub Copilot, Claude Code, Devin, Bolt.new, Lovable, Codex, Gemini CLI and more. Free tiers, hidden costs, cost analysis for solo devs and teams. [[freshness]]";
   const slug = "ai-coding-tools-pricing";
   const pubDate = "2026-04-08";
 
@@ -28520,7 +28541,7 @@ function buildAiCodingToolsPricingPage(): string {
     '  </div>\n' +
     '\n' +
     '  <h2 id="pricing-table">Pricing Comparison Table</h2>\n' +
-    '  <p class="section-intro">All prices verified as of April 2026. Hover rows to highlight. Click tool names for full vendor profiles with free tier details.</p>\n' +
+    '  <p class="section-intro">[[freshness]] Hover rows to highlight. Click tool names for full vendor profiles with free tier details.</p>\n' +
     '\n' +
     '  <div style="overflow-x:auto">\n' +
     '  <table class="pricing-table">\n' +
@@ -28736,7 +28757,7 @@ function buildAiCodingToolsPricingPage(): string {
 
 function buildCiCdPricingPage(): string {
   const title = "CI/CD Tools Pricing Comparison 2026 — Build Minutes, Runners & Costs Compared";
-  const metaDesc = "Compare 17+ CI/CD tools: GitHub Actions, GitLab CI, CircleCI, Buildkite, Harness CI, Google Cloud Build, Bitrise and more. Free tiers, build minutes, concurrent jobs, pricing models, and hidden costs. Updated April 2026.";
+  const metaDesc = "Compare 17+ CI/CD tools: GitHub Actions, GitLab CI, CircleCI, Buildkite, Harness CI, Google Cloud Build, Bitrise and more. Free tiers, build minutes, concurrent jobs, pricing models, and hidden costs. [[freshness]]";
   const slug = "ci-cd-pricing";
   const pubDate = "2026-04-09";
 
@@ -29271,7 +29292,7 @@ function buildCiCdPricingPage(): string {
     '  </div>\n' +
     '\n' +
     '  <h2 id="pricing-table">Pricing Comparison Table</h2>\n' +
-    '  <p class="section-intro">All prices verified as of April 2026. Hover rows to highlight. Click tool names for full vendor profiles with free tier details.</p>\n' +
+    '  <p class="section-intro">[[freshness]] Hover rows to highlight. Click tool names for full vendor profiles with free tier details.</p>\n' +
     '\n' +
     '  <div style="overflow-x:auto">\n' +
     '  <table class="pricing-table">\n' +
@@ -29487,7 +29508,7 @@ function buildCiCdPricingPage(): string {
 
 function buildDatabasePricingPage(): string {
   const title = "Database Pricing Comparison 2026 — Free Tiers, Storage Limits & Costs Compared";
-  const metaDesc = "Compare 25+ database services: Supabase, Neon, PlanetScale, MongoDB Atlas, Firebase, CockroachDB, Turso, Upstash, Redis Cloud, DynamoDB and more. Free tiers, storage limits, connections, pricing models, and hidden costs. Updated April 2026.";
+  const metaDesc = "Compare 25+ database services: Supabase, Neon, PlanetScale, MongoDB Atlas, Firebase, CockroachDB, Turso, Upstash, Redis Cloud, DynamoDB and more. Free tiers, storage limits, connections, pricing models, and hidden costs. [[freshness]]";
   const slug = "database-pricing";
   const pubDate = "2026-04-09";
 
@@ -30157,7 +30178,7 @@ function buildDatabasePricingPage(): string {
     '  </div>\n' +
     '\n' +
     '  <h2 id="pricing-table">Pricing Comparison Table</h2>\n' +
-    '  <p class="section-intro">All prices verified as of April 2026. Hover rows to highlight. Click service names for full vendor profiles with free tier details.</p>\n' +
+    '  <p class="section-intro">[[freshness]] Hover rows to highlight. Click service names for full vendor profiles with free tier details.</p>\n' +
     '\n' +
     '  <div style="overflow-x:auto">\n' +
     '  <table class="pricing-table">\n' +
@@ -30373,7 +30394,7 @@ function buildDatabasePricingPage(): string {
 
 function buildVectorDatabasePricingPage(): string {
   const title = "Vector Database Pricing Comparison 2026 — Free Tiers, Storage Limits & Costs for RAG/AI";
-  const metaDesc = "Compare 11+ vector databases: Pinecone, Qdrant, Weaviate, Chroma, Zilliz Cloud, LanceDB, Upstash Vector, Supabase pgvector, Neon pgvector, MongoDB Atlas Vector Search and more. Free tiers, vector limits, dimensions, pricing models. Updated April 2026.";
+  const metaDesc = "Compare 11+ vector databases: Pinecone, Qdrant, Weaviate, Chroma, Zilliz Cloud, LanceDB, Upstash Vector, Supabase pgvector, Neon pgvector, MongoDB Atlas Vector Search and more. Free tiers, vector limits, dimensions, pricing models. [[freshness]]";
   const slug = "vector-database-pricing";
   const pubDate = "2026-04-10";
 
@@ -30814,7 +30835,7 @@ function buildVectorDatabasePricingPage(): string {
     '  </div>\n' +
     '\n' +
     '  <h2 id="pricing-table">Free Tier Comparison Table</h2>\n' +
-    '  <p class="section-intro">All prices verified as of April 2026. Hover rows to highlight. Click service names for full vendor profiles with free tier details.</p>\n' +
+    '  <p class="section-intro">[[freshness]] Hover rows to highlight. Click service names for full vendor profiles with free tier details.</p>\n' +
     '\n' +
     '  <div style="overflow-x:auto">\n' +
     '  <table class="pricing-table">\n' +
@@ -31034,7 +31055,7 @@ function buildVectorDatabasePricingPage(): string {
 
 function buildHostingPricingPage(): string {
   const title = "Cloud Hosting & PaaS Pricing Comparison 2026 — Free Tiers, Limits & Hidden Costs";
-  const metaDesc = "Compare 15+ cloud hosting and PaaS services: Railway, Vercel, Render, Netlify, Fly.io, Cloudflare Workers/Pages, Deno Deploy, Koyeb, Val Town, Google Cloud Run and more. Free tiers, bandwidth limits, build minutes, and pricing gotchas. Updated April 2026.";
+  const metaDesc = "Compare 15+ cloud hosting and PaaS services: Railway, Vercel, Render, Netlify, Fly.io, Cloudflare Workers/Pages, Deno Deploy, Koyeb, Val Town, Google Cloud Run and more. Free tiers, bandwidth limits, build minutes, and pricing gotchas. [[freshness]]";
   const slug = "hosting-pricing";
   const pubDate = "2026-04-13";
 
@@ -31545,7 +31566,7 @@ function buildHostingPricingPage(): string {
     '  </div>\n' +
     '\n' +
     '  <h2 id="pricing-table">Pricing Comparison Table</h2>\n' +
-    '  <p class="section-intro">All prices verified as of April 2026. Hover rows to highlight. Click platform names for full vendor profiles with free tier details.</p>\n' +
+    '  <p class="section-intro">[[freshness]] Hover rows to highlight. Click platform names for full vendor profiles with free tier details.</p>\n' +
     '\n' +
     '  <div style="overflow-x:auto">\n' +
     '  <table class="pricing-table">\n' +
@@ -53594,7 +53615,7 @@ const httpServer = createHttpServer(async (req, res) => {
   const rawEnd = res.end.bind(res);
   res.end = ((...args: unknown[]) => {
     if (typeof args[0] === "string" && /^text\/html/.test(servedContentType)) {
-      args[0] = withLedeBeforeNav(args[0]);
+      args[0] = withLedeBeforeNav(withPageFreshness(args[0], url.pathname));
     }
     return rawEnd(...(args as never[]));
   }) as typeof res.end;

--- a/test/derived-page-freshness.test.ts
+++ b/test/derived-page-freshness.test.ts
@@ -1,0 +1,364 @@
+import { describe, it, before, after } from "node:test";
+import assert from "node:assert";
+import { spawn, type ChildProcess } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { assertPopulationFloor } from "./population-floor.ts";
+import {
+  FRESHNESS_TOKEN,
+  FRESHNESS_VERB,
+  freshnessClaimFor,
+  monthOf,
+  vendorSlugsLinkedFrom,
+  verifiedSpanClaim,
+  withFreshnessClaim,
+} from "../dist/page-freshness.js";
+import { loadOffers } from "../dist/data.js";
+import { toSlug } from "../dist/slug.js";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+let server: ChildProcess;
+let base = "";
+
+function startServer(): Promise<ChildProcess> {
+  return new Promise((resolve, reject) => {
+    const serverPath = path.join(__dirname, "..", "dist", "serve.js");
+    const proc = spawn("node", [serverPath], {
+      stdio: ["pipe", "pipe", "pipe"],
+      env: { ...process.env, PORT: "0", BASE_URL: "http://localhost" },
+    });
+    const timeout = setTimeout(() => {
+      proc.kill();
+      reject(new Error("Server startup timeout"));
+    }, 30000);
+    proc.stderr!.on("data", (data: Buffer) => {
+      const match = data.toString().match(/running on http:\/\/localhost:(\d+)/);
+      if (match) {
+        base = `http://localhost:${match[1]}`;
+        clearTimeout(timeout);
+        resolve(proc);
+      }
+    });
+    proc.on("error", err => {
+      clearTimeout(timeout);
+      reject(err);
+    });
+  });
+}
+
+const MONTHS =
+  "January|February|March|April|May|June|July|August|September|October|November|December";
+
+const SERVED_CLAIM = new RegExp(
+  `(?:${FRESHNESS_VERB} (?:${MONTHS})(?: \\d{4})? to (?:${MONTHS}) \\d{4}` +
+    `|${FRESHNESS_VERB} (?:${MONTHS}) \\d{4}` +
+    `|Compiled \\d{4}-\\d{2}-\\d{2}[^.]*)\\.`,
+);
+
+const HARDCODED_CLAIM = new RegExp(
+  `\\b(?:Updated|updated|Verified|verified|Compiled|compiled)` +
+    `(?: against [^.<>"]{0,60})?(?: as of)? (?:${MONTHS}),? \\d{4}`,
+  "g",
+);
+
+const PAGES_CARRYING_A_DERIVED_CLAIM_FLOOR = 20;
+
+const datesBySlug = (() => {
+  const dates = new Map<string, string[]>();
+  for (const offer of loadOffers()) {
+    if (!offer.verifiedDate) continue;
+    const slug = toSlug(offer.vendor);
+    const held = dates.get(slug);
+    if (held) held.push(offer.verifiedDate);
+    else dates.set(slug, [offer.verifiedDate]);
+  }
+  return dates;
+})();
+
+function verifiedDatesForSlug(slug: string): readonly string[] {
+  return datesBySlug.get(slug) ?? [];
+}
+
+function metaDescriptionOf(html: string): string {
+  return (html.match(/<meta name="description" content="([^"]*)"/i)?.[1] ?? "").replace(/&amp;/g, "&");
+}
+
+function ledeOf(html: string): string {
+  return (html.match(/<p class="page-claim">([\s\S]*?)<\/p>/)?.[1] ?? "").replace(/&amp;/g, "&");
+}
+
+function structuredDescriptionsOf(html: string): string[] {
+  return [...html.matchAll(/"description":"((?:[^"\\]|\\.)*)"/g)].map(m =>
+    m[1]!.replace(/\\"/g, '"').replace(/\\\\/g, "\\"),
+  );
+}
+
+async function fetchPage(pathname: string): Promise<string> {
+  const response = await fetch(base + pathname, { redirect: "error" });
+  assert.strictEqual(response.status, 200, `${pathname} did not return 200`);
+  return response.text();
+}
+
+async function sitemapPagePaths(): Promise<string[]> {
+  const xml = await fetchPage("/sitemap-pages.xml");
+  return [...xml.matchAll(/<loc>([^<]+)<\/loc>/g)].map(m => new URL(m[1]!).pathname);
+}
+
+interface ServedPage {
+  path: string;
+  html: string;
+}
+
+async function fetchAll(paths: string[]): Promise<ServedPage[]> {
+  const served: ServedPage[] = [];
+  const queue = [...paths];
+  const workers = Array.from({ length: 8 }, async () => {
+    for (let next = queue.pop(); next !== undefined; next = queue.pop()) {
+      served.push({ path: next, html: await fetchPage(next) });
+    }
+  });
+  await Promise.all(workers);
+  return served;
+}
+
+interface StoredReview {
+  path: string;
+  published: string;
+  reviewed_at: string | null;
+  reads_index: boolean;
+}
+
+const storedReviews = new Map<string, StoredReview>(
+  (
+    JSON.parse(
+      fs.readFileSync(path.join(__dirname, "..", "data", "page-reviews.json"), "utf-8"),
+    ) as { pages: StoredReview[] }
+  ).pages.map(page => [page.path, page]),
+);
+
+const MONTH_NAMES = [
+  "January", "February", "March", "April", "May", "June",
+  "July", "August", "September", "October", "November", "December",
+];
+
+function namedMonth(isoDate: string): string {
+  return `${MONTH_NAMES[Number(isoDate.slice(5, 7)) - 1]} ${isoDate.slice(0, 4)}`;
+}
+
+function claimTheDataSupports(pagePath: string, html: string, today: string): string {
+  const review = storedReviews.get(pagePath);
+  if (review && !review.reads_index) {
+    const checked = review.reviewed_at !== null && review.reviewed_at <= today ? review.reviewed_at : null;
+    return checked === null
+      ? `Compiled ${review.published}, not re-checked since.`
+      : `Compiled ${review.published}, last checked ${checked}.`;
+  }
+  const dates = [...html.matchAll(/href="\/vendor\/([a-z0-9][a-z0-9-]*)"/g)]
+    .flatMap(link => [...verifiedDatesForSlug(link[1]!)])
+    .sort();
+  if (dates.length === 0) return "";
+  const oldest = namedMonth(dates[0]!);
+  const newest = namedMonth(dates[dates.length - 1]!);
+  if (oldest === newest) return `${FRESHNESS_VERB} ${oldest}.`;
+  const sameYear = dates[0]!.slice(0, 4) === dates[dates.length - 1]!.slice(0, 4);
+  return `${FRESHNESS_VERB} ${sameYear ? oldest.split(" ")[0] : oldest} to ${newest}.`;
+}
+
+const REVIEW_OF_A_HAND_COMPILED_PAGE = {
+  path: "/x",
+  published: "2026-04-09",
+  tier: "A",
+  vendors_asserted: [],
+  vendors_tabulated: [],
+  badge_subjects_unresolved: [],
+  reviewed_at: null,
+  reviewer: null,
+  review_outcome: null,
+  review_note: null,
+  reads_index: false,
+  reads_changes: false,
+  data_source: "unsourced",
+  data_source_reason: null,
+};
+
+describe("A freshness date derived from the records a page lists", () => {
+  it("reads a month and a year out of a stored date", () => {
+    assert.strictEqual(monthOf("2026-09-05"), "September 2026");
+    assert.strictEqual(monthOf("2025-12-31"), "December 2025");
+    assert.strictEqual(monthOf("not-a-date"), "");
+    assert.strictEqual(monthOf("2026-13-01"), "");
+    assert.strictEqual(monthOf("20260905"), "");
+    assert.strictEqual(monthOf("2026-09"), "");
+  });
+
+  it("claims nothing when it holds no dated record", () => {
+    assert.strictEqual(verifiedSpanClaim([]), "");
+    assert.strictEqual(verifiedSpanClaim(["", "unknown"]), "");
+  });
+
+  it("names one month when every record it holds was read in that month", () => {
+    assert.strictEqual(verifiedSpanClaim(["2026-08-04"]), "Verified August 2026.");
+    assert.strictEqual(
+      verifiedSpanClaim(["2026-08-28", "2026-08-04", "2026-08-15"]),
+      "Verified August 2026.",
+    );
+  });
+
+  it("names the span its records cover, oldest first", () => {
+    assert.strictEqual(
+      verifiedSpanClaim(["2026-09-05", "2026-07-01", "2026-08-14"]),
+      "Verified July to September 2026.",
+    );
+  });
+
+  it("repeats the year only when the span crosses one", () => {
+    assert.strictEqual(
+      verifiedSpanClaim(["2026-03-02", "2025-12-19"]),
+      "Verified December 2025 to March 2026.",
+    );
+  });
+
+  it("spans the records it can date and ignores the rest", () => {
+    assert.strictEqual(
+      verifiedSpanClaim(["2026-07-01", "", "2026-09-05", "soon"]),
+      "Verified July to September 2026.",
+    );
+  });
+
+  it("carries no character that would change meaning inside an attribute", () => {
+    for (const claim of [verifiedSpanClaim(["2026-07-01", "2026-09-05"]), verifiedSpanClaim(["2026-08-04"])]) {
+      assert.ok(!/[<>&"']/.test(claim), `${claim} would have to be escaped`);
+    }
+  });
+
+  it("collects the vendor records a page links to, once each", () => {
+    const html =
+      '<a href="/vendor/groq">Groq</a><a href="/alternative-to/groq">x</a>' +
+      '<a href="/vendor/cerebras">C</a><a href="/vendor/groq#changes">again</a>';
+    assert.deepStrictEqual(vendorSlugsLinkedFrom(html), ["cerebras", "groq"]);
+  });
+
+  it("puts one derived claim everywhere the page declares it", () => {
+    const html = `<meta content="a ${FRESHNESS_TOKEN}"><p>b ${FRESHNESS_TOKEN}</p>`;
+    assert.strictEqual(
+      withFreshnessClaim(html, () => "Verified August 2026."),
+      '<meta content="a Verified August 2026."><p>b Verified August 2026.</p>',
+    );
+  });
+
+  it("leaves no placeholder behind when it can derive nothing", () => {
+    const html = `<meta content="a sentence. ${FRESHNESS_TOKEN}">`;
+    assert.strictEqual(withFreshnessClaim(html, () => ""), '<meta content="a sentence.">');
+  });
+
+  it("dates a page from its own review when that page does not read the catalogue", () => {
+    const html = '<a href="/vendor/groq">Groq</a>';
+    assert.strictEqual(
+      freshnessClaimFor("/x", html, () => ["2026-09-05"], "2026-09-09", () => REVIEW_OF_A_HAND_COMPILED_PAGE as never),
+      "Compiled 2026-04-09, not re-checked since.",
+    );
+  });
+
+  it("dates a page from its listed records when that page reads the catalogue", () => {
+    const html = '<a href="/vendor/groq">Groq</a>';
+    assert.strictEqual(
+      freshnessClaimFor(
+        "/x",
+        html,
+        () => ["2026-09-05"],
+        "2026-09-09",
+        () => ({ ...REVIEW_OF_A_HAND_COMPILED_PAGE, reads_index: true }) as never,
+      ),
+      "Verified September 2026.",
+    );
+  });
+});
+
+describe("Freshness dates as served", () => {
+  let served: ServedPage[] = [];
+
+  before(async () => {
+    server = await startServer();
+    served = await fetchAll(await sitemapPagePaths());
+  });
+
+  after(() => {
+    server?.kill();
+  });
+
+  it("resolves every freshness placeholder it declares", () => {
+    const unresolved = served.filter(page => page.html.includes(FRESHNESS_TOKEN)).map(page => page.path).sort();
+    assert.deepStrictEqual(unresolved, []);
+  });
+
+  it("publishes only a date the records behind the page support", () => {
+    const today = new Date().toISOString().slice(0, 10);
+    const wrong: string[] = [];
+    for (const page of served) {
+      const claimed = SERVED_CLAIM.exec(metaDescriptionOf(page.html));
+      if (!claimed) continue;
+      const supported = claimTheDataSupports(page.path, page.html, today);
+      if (claimed[0] !== supported) {
+        wrong.push(`${page.path}: says ${claimed[0]}, its records say ${supported || "nothing"}`);
+      }
+    }
+    assert.deepStrictEqual(wrong.sort(), []);
+  });
+
+  it("says the same thing to a reader, a snippet and a structured-data extractor", () => {
+    const disagreeing: string[] = [];
+    for (const page of served) {
+      const claimed = SERVED_CLAIM.exec(metaDescriptionOf(page.html));
+      if (!claimed) continue;
+      if (!ledeOf(page.html).includes(claimed[0])) {
+        disagreeing.push(`${page.path}: the visible opening omits ${claimed[0]}`);
+      }
+      if (!structuredDescriptionsOf(page.html).some(text => text.includes(claimed[0]))) {
+        disagreeing.push(`${page.path}: no structured description carries ${claimed[0]}`);
+      }
+    }
+    assert.deepStrictEqual(disagreeing.sort(), []);
+  });
+
+  it("dates a body of pages, not a handful", () => {
+    const dated = served.filter(page => SERVED_CLAIM.test(metaDescriptionOf(page.html)));
+    assertPopulationFloor(
+      dated.length,
+      PAGES_CARRYING_A_DERIVED_CLAIM_FLOOR,
+      "pages publishing a derived freshness date",
+    );
+  });
+
+  it("dates the free LLM API comparison from the providers it lists", () => {
+    const html = served.find(page => page.path === "/free-llm-apis")?.html;
+    assert.ok(html, "/free-llm-apis is not in the page sitemap");
+    const meta = metaDescriptionOf(html);
+    const claimed = SERVED_CLAIM.exec(meta);
+    assert.ok(claimed, `/free-llm-apis publishes no freshness date: ${meta}`);
+    assert.strictEqual(
+      claimed[0],
+      claimTheDataSupports("/free-llm-apis", html, new Date().toISOString().slice(0, 10)),
+    );
+
+    const listed = vendorSlugsLinkedFrom(html).flatMap(slug => [...verifiedDatesForSlug(slug)]).sort();
+    assert.ok(listed.length > 0, "/free-llm-apis links to no dated record");
+    assert.ok(
+      listed[listed.length - 1]! >= "2026-09-01",
+      `/free-llm-apis lists nothing read this month: newest is ${listed[listed.length - 1]}`,
+    );
+    assert.ok(!/March 2026/.test(meta), `/free-llm-apis still dates itself to March: ${meta}`);
+  });
+});
+
+describe("Freshness dates in the source", () => {
+  it("hardcodes no month a page could publish as its own freshness", () => {
+    const source = fs.readFileSync(path.join(__dirname, "..", "src", "serve.ts"), "utf-8");
+    const hardcoded = [...source.matchAll(HARDCODED_CLAIM)].map(found => {
+      const line = source.slice(0, found.index).split("\n").length;
+      return `src/serve.ts:${line}: ${found[0]}`;
+    });
+    assert.deepStrictEqual(hardcoded, []);
+  });
+});


### PR DESCRIPTION
Refs #1481

30 pages told readers and extractors we were last updated in March or April 2026. 1,536 of our 1,580 records were verified in July, August or September. The string is one literal per page and it reaches three surfaces — the meta description, the JSON-LD `description`, and the visible paragraph that opens the extracted body text — so one wrong sentence was wrong three times.

The date is derived now, from one value per page.

## Two families, two sources

- **A page the catalogue perturbation moves** takes the span of the records it links: `Verified July to September 2026.` The span is the claim that holds for every record on the page. The newest date alone is the direction #1061 removed; the oldest alone reads worse than the literal it replaces.
- **A page it does not move** takes its own review record: `Compiled 2026-04-09, not re-checked since.` Seven of the thirty are hand-compiled tables. Stamping a September catalogue date on April figures is #1081's defect, so those get the date their figures were actually compiled.

`reads_index` is the split. It is a declared field, but `pageSourceViolations` already holds it to a catalogue-perturbation measurement, so it is not a declaration this change has to take on trust.

## How it resolves

A page declares `[[freshness]]`. The response wrapper that already inserts the lede resolves it — from the vendor records the rendered page links to, or from the page's review record. Reading the served HTML rather than a list passed in is what makes "the records it lists" literally true, and it is why the three surfaces cannot drift apart: they are one string, substituted once.

## Scope

The issue's grep finds 58 occurrences in page descriptions. The served population is **93 across six shapes**; four of them are body prose on the same pages, and two would have contradicted the derived date rendered two lines above them — `/supabase-vs-firebase` said `free tiers as of March 2026` under a lede that now reads `Verified August 2026`, and the seven hand-compiled pricing tables opened with `All prices verified as of April 2026`.

`/openai-assistants-migration-2026` also dated its cost table by hand; it reads its review record directly rather than through the placeholder, because that sentence is about the table and not about the page.

## Left alone, on purpose

- `/free-saas-stack` and `/free-startup-stack` date GitHub's own runner pricing change. That is a fact about a vendor, not a claim about us.
- `/hetzner-pricing-2026` says two rows "were verified in March 2026 and we have not re-read them". A page-level date would lose what that sentence exists to say.

## Tests

`test/derived-page-freshness.test.ts`, 18 tests. Every URL in `sitemap-pages.xml` is fetched, and a served freshness date must equal one recomputed inside the test from `data/index.json` and `data/page-reviews.json` — not from the module under test, so mutating the module cannot move both sides of the comparison. The same sweep asserts the claim reaches the meta description, a JSON-LD description and the visible lede, and that no page serves an unresolved placeholder. A separate check fails on any hardcoded month-year freshness claim left in `src/serve.ts`, which is what keeps the property true when the 31st page is added.

`scripts/mutate-1481.mjs` is 11 mutants, all killed, wired as `npm run mutate:1481`. `npm run mutate:1479` is wired too.

Suite 4,606 — 4,604 pass. The 2 failures are #1190's and reproduce on `main` with this branch stashed.
