### PR TITLE
Read every page in one zone, so the ledger is the same wherever it is generated (#1434)

### DIFF
--- a/data/page-lastmod.json
+++ b/data/page-lastmod.json
@@ -11,11 +11,11 @@
       "changed": "2026-09-09"
     },
     "/ai-coding-pricing-2026": {
-      "hash": "ca23cce291aab321",
+      "hash": "5e50ec8046734175",
       "changed": "2026-09-09"
     },
     "/ai-coding-tools-pricing": {
-      "hash": "3d7fb9e9c9fa8f65",
+      "hash": "99ed53b51706023d",
       "changed": "2026-09-09"
     },
     "/ai-free-tiers": {
@@ -43,7 +43,7 @@
       "changed": "2026-09-09"
     },
     "/analytics-free-tier-comparison-2026": {
-      "hash": "bc3ad1dfdaa250a8",
+      "hash": "6f2e4c8b34260aed",
       "changed": "2026-09-09"
     },
     "/api-development-alternatives": {
@@ -51,7 +51,7 @@
       "changed": "2026-09-09"
     },
     "/api-development-free-tier-comparison-2026": {
-      "hash": "223c7553a3b3a19e",
+      "hash": "a8a1b1e7bfc8cb70",
       "changed": "2026-09-09"
     },
     "/api/docs": {
@@ -59,7 +59,7 @@
       "changed": "2026-09-05"
     },
     "/auth-comparison-2026": {
-      "hash": "b50d2cab36df75f9",
+      "hash": "be22a3df5765d724",
       "changed": "2026-09-09"
     },
     "/auth0-alternatives": {
@@ -75,15 +75,15 @@
       "changed": "2026-09-09"
     },
     "/aws-app-runner-migration": {
-      "hash": "0506832c6c5f651d",
+      "hash": "40f8e0369ce46ca0",
       "changed": "2026-09-09"
     },
     "/aws-free-tier-2026": {
-      "hash": "2143ddf833404b29",
+      "hash": "981f7d6a019cd5aa",
       "changed": "2026-09-09"
     },
     "/azure-free-tier-2026": {
-      "hash": "ca58a44ce6a32c59",
+      "hash": "c73205704d45f76b",
       "changed": "2026-09-09"
     },
     "/backblaze-b2-vs-cloudflare-r2": {
@@ -107,11 +107,11 @@
       "changed": "2026-09-09"
     },
     "/ci-cd-pricing": {
-      "hash": "6d281c40eb5367b4",
+      "hash": "390eed2f7ead2ec6",
       "changed": "2026-09-09"
     },
     "/cicd-free-tier-comparison-2026": {
-      "hash": "ffaadb412a01c007",
+      "hash": "ff199b3076c01729",
       "changed": "2026-09-09"
     },
     "/circleci-vs-github-actions": {
@@ -119,7 +119,7 @@
       "changed": "2026-09-09"
     },
     "/cloud-free-tier-comparison-2026": {
-      "hash": "2fc3c5aa96d8ca49",
+      "hash": "c96ede92cca17603",
       "changed": "2026-09-09"
     },
     "/cloudflare-pages-vs-vercel": {
@@ -1539,7 +1539,7 @@
       "changed": "2026-09-09"
     },
     "/dall-e-shutdown": {
-      "hash": "cb75cbe3fe7e1a69",
+      "hash": "3d5f0f161dfecbed",
       "changed": "2026-09-09"
     },
     "/database-alternatives": {
@@ -1547,11 +1547,11 @@
       "changed": "2026-09-09"
     },
     "/database-free-tier-comparison-2026": {
-      "hash": "ec48b03951841abb",
+      "hash": "20811ecbbea08184",
       "changed": "2026-09-09"
     },
     "/database-pricing": {
-      "hash": "fd84be3d7eb4aa39",
+      "hash": "09afcd1e12fab4ce",
       "changed": "2026-09-09"
     },
     "/datadog-alternatives": {
@@ -1579,7 +1579,7 @@
       "changed": "2026-09-09"
     },
     "/digitalocean-free-tier-2026": {
-      "hash": "3b2adf6d0d36fd1e",
+      "hash": "5e26165f4d0ef5ba",
       "changed": "2026-09-09"
     },
     "/disclosure": {
@@ -1591,7 +1591,7 @@
       "changed": "2026-09-09"
     },
     "/email-comparison-2026": {
-      "hash": "a0e8815afb822913",
+      "hash": "076b6c94f7f2d862",
       "changed": "2026-09-09"
     },
     "/email-service-alternatives": {
@@ -1627,7 +1627,7 @@
       "changed": "2026-09-09"
     },
     "/firebase-studio-shutdown": {
-      "hash": "405bb0ffd31becfa",
+      "hash": "696d98557435b292",
       "changed": "2026-09-09"
     },
     "/free-ai-stack": {
@@ -1683,7 +1683,7 @@
       "changed": "2026-09-09"
     },
     "/gcp-free-tier-2026": {
-      "hash": "59d1df1c5c64b93a",
+      "hash": "8b4c3c68a868d3bc",
       "changed": "2026-09-09"
     },
     "/gemini-api-pricing-2026": {
@@ -1691,7 +1691,7 @@
       "changed": "2026-09-09"
     },
     "/gemini-api-pricing-changes": {
-      "hash": "0f99d84e0a3bc1e1",
+      "hash": "a7a545e4a4c64947",
       "changed": "2026-09-09"
     },
     "/github-actions-alternatives": {
@@ -1755,11 +1755,11 @@
       "changed": "2026-09-09"
     },
     "/hosting-free-tier-comparison-2026": {
-      "hash": "ce2f544dc5ff4069",
+      "hash": "06a3cdef88a06414",
       "changed": "2026-09-09"
     },
     "/hosting-pricing": {
-      "hash": "ba0dd96b5ed3b680",
+      "hash": "cb23eec777a225af",
       "changed": "2026-09-09"
     },
     "/ide-code-editors-alternatives": {
@@ -1767,7 +1767,7 @@
       "changed": "2026-09-09"
     },
     "/llm-api-pricing": {
-      "hash": "77358873a297bbdc",
+      "hash": "200b4c7080e1b103",
       "changed": "2026-09-09"
     },
     "/localstack-alternatives": {
@@ -1783,7 +1783,7 @@
       "changed": "2026-09-09"
     },
     "/monitoring-comparison-2026": {
-      "hash": "cd7c70ac80e19790",
+      "hash": "61c2c3e2d708357f",
       "changed": "2026-09-09"
     },
     "/neon-vs-supabase": {
@@ -1799,19 +1799,19 @@
       "changed": "2026-09-09"
     },
     "/openai-assistants-alternatives": {
-      "hash": "abef06d1b520a2e3",
+      "hash": "550fb7eb11ed3122",
       "changed": "2026-09-09"
     },
     "/openai-assistants-migration": {
-      "hash": "bcfd3523529e02df",
+      "hash": "1dcb99d0b1a9eb9b",
       "changed": "2026-09-09"
     },
     "/openai-assistants-migration-2026": {
-      "hash": "ffc2a370d71c7bfe",
+      "hash": "74741db7ccfc39c4",
       "changed": "2026-09-09"
     },
     "/openai-realtime-migration": {
-      "hash": "a55f38675e8ad019",
+      "hash": "bcbe4ed95f2c9b44",
       "changed": "2026-09-09"
     },
     "/postman-alternatives": {
@@ -1855,11 +1855,11 @@
       "changed": "2026-09-09"
     },
     "/security-free-tier-comparison-2026": {
-      "hash": "c761fde06fc145d7",
+      "hash": "f2cae8dc036c02ea",
       "changed": "2026-09-09"
     },
     "/serverless-free-tier-comparison-2026": {
-      "hash": "1b988886d406803d",
+      "hash": "2e9e8ae07a9d0630",
       "changed": "2026-09-09"
     },
     "/setup": {
@@ -1867,7 +1867,7 @@
       "changed": "2026-09-09"
     },
     "/shutdowns": {
-      "hash": "de1ceff27907a63a",
+      "hash": "ab6b2b614e6eba79",
       "changed": "2026-09-09"
     },
     "/stability": {
@@ -1903,7 +1903,7 @@
       "changed": "2026-09-09"
     },
     "/startup-credits": {
-      "hash": "59596ba17fb94725",
+      "hash": "ca5a9ea261643520",
       "changed": "2026-09-09"
     },
     "/state-of-free-tiers": {
@@ -1915,7 +1915,7 @@
       "changed": "2026-09-09"
     },
     "/storage-comparison-2026": {
-      "hash": "be3911a315275eda",
+      "hash": "2d618dbaea37bf16",
       "changed": "2026-09-09"
     },
     "/supabase-vs-firebase": {
@@ -1927,7 +1927,7 @@
       "changed": "2026-09-09"
     },
     "/tenor-alternatives": {
-      "hash": "a95ccdce75752068",
+      "hash": "de07107c5f8bf923",
       "changed": "2026-09-09"
     },
     "/terraform-alternatives": {
@@ -1943,7 +1943,7 @@
       "changed": "2026-09-09"
     },
     "/testing-free-tier-comparison-2026": {
-      "hash": "5aeef997832f47d8",
+      "hash": "0bef36120b1fdd31",
       "changed": "2026-09-09"
     },
     "/vector-database-pricing": {

--- a/scripts/mutate-1434.mjs
+++ b/scripts/mutate-1434.mjs
@@ -20,6 +20,14 @@ const MUTANTS = [
     "            data/page-lastmod.json",
     "            data/link_health.json"],
 
+  ["the-pages-are-read-in-whatever-zone-the-machine-is-set-to", "scripts/update-page-lastmod.js",
+    "      env: { ...process.env, TZ: LEDGER_TIMEZONE, PORT: \"0\"",
+    "      env: { ...process.env, PORT: \"0\""],
+
+  ["the-zone-the-ledger-is-read-in-is-not-utc", "scripts/update-page-lastmod.js",
+    "const LEDGER_TIMEZONE = \"UTC\";",
+    "const LEDGER_TIMEZONE = \"America/Los_Angeles\";"],
+
   ["a-page-whose-output-moved-keeps-the-day-it-had", "src/page-lastmod.ts",
     "    } else if (before.hash === hash) {",
     "    } else if (true) {"],

--- a/scripts/update-page-lastmod.js
+++ b/scripts/update-page-lastmod.js
@@ -16,6 +16,10 @@ this ledger. A page whose rendered output is unchanged keeps the day it last cha
 whose output has moved is stamped with today. That is what makes the date an observation
 rather than a constant: freezing it requires the pages to stop changing.
 
+The pages are read with TZ=UTC. Some of them render a date from a timestamp without naming a
+zone, so a machine west of Greenwich renders that date a day earlier and the page hashes
+differently. Pinning the zone is what makes the ledger the same wherever it is generated.
+
 Usage: node scripts/update-page-lastmod.js [options]
 
   --check         Report what would move and exit 1 if anything would, without writing
@@ -25,6 +29,8 @@ Usage: node scripts/update-page-lastmod.js [options]
 `;
 
 const ORIGIN = "http://localhost";
+
+const LEDGER_TIMEZONE = "UTC";
 
 function parseArgs(argv) {
   const opts = { check: false, date: new Date().toISOString().slice(0, 10), json: false };
@@ -46,7 +52,7 @@ function startServer(inventoryOut) {
   return new Promise((resolve, reject) => {
     const proc = spawn("node", [join(REPO, "dist", "serve.js")], {
       stdio: ["pipe", "pipe", "pipe"],
-      env: { ...process.env, PORT: "0", BASE_URL: ORIGIN, AGENTDEALS_PAGE_INVENTORY_OUT: inventoryOut },
+      env: { ...process.env, TZ: LEDGER_TIMEZONE, PORT: "0", BASE_URL: ORIGIN, AGENTDEALS_PAGE_INVENTORY_OUT: inventoryOut },
     });
     const timeout = setTimeout(() => {
       proc.kill();

--- a/test/page-lastmod.test.ts
+++ b/test/page-lastmod.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, before, after } from "node:test";
 import assert from "node:assert";
 import { assertPopulationFloor } from "./population-floor.ts";
-import { spawn, type ChildProcess } from "node:child_process";
+import { spawn, spawnSync, type ChildProcess } from "node:child_process";
 import { mkdtempSync, readdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
@@ -406,6 +406,30 @@ describe("the ledger keeps up with the code that renders the pages", () => {
         `${workflow.file} re-dates the pages only when the re-verification it also runs succeeds`,
       );
     }
+  });
+
+  it("reads the pages in a fixed zone, so the same commit gives the same ledger anywhere", () => {
+    const updater = readFileSync(path.join(REPO, "scripts", "update-page-lastmod.js"), "utf8");
+    assert.match(
+      updater,
+      /env: \{ \.\.\.process\.env, TZ: [A-Z_]+,/,
+      "the updater reads the pages in whatever zone the machine is set to, so a ledger generated west of Greenwich disagrees with one generated in CI",
+    );
+    assert.match(updater, /LEDGER_TIMEZONE = "UTC"/, "the zone the ledger is read in is not UTC");
+
+    const west = spawnSync("node", ["-e", "process.stdout.write(new Date('2026-09-24T00:00:00Z').toLocaleDateString('en-US', { month: 'long', day: 'numeric', year: 'numeric' }))"], {
+      encoding: "utf8",
+      env: { ...process.env, TZ: "America/Los_Angeles" },
+    });
+    const utc = spawnSync("node", ["-e", "process.stdout.write(new Date('2026-09-24T00:00:00Z').toLocaleDateString('en-US', { month: 'long', day: 'numeric', year: 'numeric' }))"], {
+      encoding: "utf8",
+      env: { ...process.env, TZ: "UTC" },
+    });
+    assert.notEqual(
+      west.stdout,
+      utc.stdout,
+      "this test is pointless if the runtime no longer renders a UTC midnight differently west of Greenwich",
+    );
   });
 
   it("sends the days it read to main through the one gate that runs the suite first", () => {


### PR DESCRIPTION
Refs #1434

The first run of `page-lastmod.yml` after #1484 found **34 pages moved** where the merge commit had just recorded their hashes. Nothing between the two changed what the pages render.

Diffing one of them against production:

```
/shutdowns   local  <span>September 23, 2026</span>
             prod   <span>September 24, 2026</span>
```

Those pages render a date from a UTC timestamp without naming a zone. This sandbox is `America/Los_Angeles`; the runner and Railway are UTC. Running the updater here under `TZ=UTC` reproduces the runner's set exactly — 34 pages, same set, nothing either way. Under the machine's own zone it reproduces the ledger #1484 committed.

So the ledger was not reproducible, and a ledger generated on a developer machine and one generated in CI would have re-dated each other forever.

## What changes

`scripts/update-page-lastmod.js` starts its server with `TZ` pinned to `LEDGER_TIMEZONE`, which is `UTC`. The ledger here is regenerated against that reading, so `main` carries what CI computes and the next run finds nothing.

The test asserts the pin, and asserts its own premise: that the runtime does render a UTC midnight differently west of Greenwich, so the assertion is not vacuous if that ever stops being true.

`npm run mutate:1434` — **11 mutants, 11 killed**, including the two added here: dropping the pin, and pinning it to a zone that is not UTC.

Suite 4,613 — 4,611 pass. The 2 are #1190's, the same two files with the same assertion text as on `main`.

## What this does not fix

The pages themselves. `/shutdowns`, `/dall-e-shutdown`, `/firebase-studio-shutdown`, `/openai-assistants-migration`, `/tenor-alternatives` and the rest publish a shutdown or deadline date that is a day early whenever the server is not in UTC. Production is UTC, so nothing wrong is being served — it is one deploy region away from being served. Reported on #1434, no issue opened.
