### PR TITLE
Date a feed entry from the record, and read a quoted summary as the vendor's words (#1335)

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,8 @@
     "validate": "node scripts/validate-data.ts",
     "test:referral-pipeline": "npm run build && node scripts/test-referral-pipeline.ts",
     "build:mcpb": "npm run build && npx @anthropic-ai/mcpb pack .",
-    "queue:curated-alternatives": "node scripts/curated-alternatives-queue.js"
+    "queue:curated-alternatives": "node scripts/curated-alternatives-queue.js",
+    "mutate:1335": "node scripts/mutate-1335.mjs"
   },
   "dependencies": {
     "@modelcontextprotocol/ext-apps": "^1.5.0",

--- a/scripts/mutate-1335.mjs
+++ b/scripts/mutate-1335.mjs
@@ -1,0 +1,80 @@
+import { readFileSync, writeFileSync } from "node:fs";
+import { execFileSync } from "node:child_process";
+
+const SUITE = [
+  "test/change-feed-provenance.test.ts",
+  "test/change-date-provenance.test.ts",
+  "test/homepage-cites-what-it-serves.test.ts",
+];
+
+const MUTANTS = [
+  ["an-entry-is-stamped-with-the-instant-it-was-asked-for", "src/change-dates.ts",
+    "  return new Date(noon <= now.getTime() ? noon : Date.parse(`${stamped}T00:00:00Z`)).toISOString();",
+    "  return new Date(Math.min(noon, now.getTime())).toISOString();"],
+
+  ["a-day-not-yet-reached-is-stamped-in-the-future", "src/change-dates.ts",
+    "  const stamped = /^\\d{4}-\\d{2}-\\d{2}$/.test(day) && day < served ? day : served;",
+    "  const stamped = /^\\d{4}-\\d{2}-\\d{2}$/.test(day) ? day : served;"],
+
+  ["a-day-that-is-not-a-date-falls-back-to-the-instant", "src/change-dates.ts",
+    "  const served = now.toISOString().slice(0, 10);",
+    "  const served = new Date().toISOString().slice(0, 10);"],
+
+  ["every-entry-in-one-document-reads-its-own-clock", "src/serve.ts",
+    "    const fields = feedEntryFields(c, servedAt);",
+    "    const fields = feedEntryFields(c);"],
+
+  ["the-channel-stamp-reads-a-clock-of-its-own", "src/serve.ts",
+    "  <updated>${feedUpdatedTimestamp(selected, servedAt)}</updated>",
+    "  <updated>${feedUpdatedTimestamp(selected)}</updated>"],
+
+  ["the-weekly-digest-dates-each-week-from-its-own-clock", "src/serve.ts",
+    "      const pubDate = feedEntryUpdated(newestChange, servedAt);",
+    "      const pubDate = feedEntryUpdated(newestChange);"],
+
+  ["a-quoted-record-is-read-as-our-own-sentence", "test/homepage-cites-what-it-serves.test.ts",
+    "    const { prose } = withoutQuotedRecords(withoutMarkup(home), publishedSummaries());",
+    "    const prose = withoutMarkup(home);"],
+
+  ["any-fragment-counts-as-a-quotation", "test/homepage-cites-what-it-serves.test.ts",
+    "const QUOTED_RECORD_MIN_LENGTH = 30;",
+    "const QUOTED_RECORD_MIN_LENGTH = 0;"],
+
+  ["a-quotation-is-matched-before-the-page-escapes-it", "test/homepage-cites-what-it-serves.test.ts",
+    "    const served = asServed(summary);",
+    "    const served = summary;"],
+];
+
+function run(cmd, args) {
+  try {
+    execFileSync(cmd, args, { stdio: "pipe", encoding: "utf-8" });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+const survivors = [];
+const uncompiled = [];
+const skipped = [];
+for (const [name, file, from, to] of MUTANTS) {
+  const original = readFileSync(file, "utf-8");
+  if (!original.includes(from)) {
+    console.log(`SKIP  ${name} — the line it mutates is not in ${file}`);
+    skipped.push(name);
+    continue;
+  }
+  writeFileSync(file, original.replace(from, to));
+  const built = run("npm", ["run", "build"]);
+  const green = built && run("npx", ["tsx", "--test", "--test-concurrency", "1", ...SUITE]);
+  writeFileSync(file, original);
+  if (!built) uncompiled.push(name);
+  console.log(`${green ? "SURVIVED" : built ? "killed  " : "DID NOT COMPILE"}  ${name}`);
+  if (green) survivors.push(name);
+}
+run("npm", ["run", "build"]);
+const killed = MUTANTS.length - survivors.length - uncompiled.length - skipped.length;
+console.log(`\n${killed}/${MUTANTS.length} killed`);
+if (survivors.length > 0) console.log("survivors:", survivors.join(", "));
+if (uncompiled.length > 0) console.log("did not compile:", uncompiled.join(", "));
+if (skipped.length > 0) console.log("skipped — target string moved, so these scored nothing:", skipped.join(", "));

--- a/src/change-dates.ts
+++ b/src/change-dates.ts
@@ -190,9 +190,10 @@ export function capListSections<T>(sections: T[][], cap: number): T[] {
 }
 
 export function feedEntryUpdated(day: string, now: Date = new Date()): string {
-  const noon = Date.parse(`${day}T12:00:00Z`);
-  if (Number.isNaN(noon)) return now.toISOString();
-  return new Date(Math.min(noon, now.getTime())).toISOString();
+  const served = now.toISOString().slice(0, 10);
+  const stamped = /^\d{4}-\d{2}-\d{2}$/.test(day) && day < served ? day : served;
+  const noon = Date.parse(`${stamped}T12:00:00Z`);
+  return new Date(noon <= now.getTime() ? noon : Date.parse(`${stamped}T00:00:00Z`)).toISOString();
 }
 
 export function endsTheListedOffer(change: ExpiringChange): boolean {

--- a/src/serve.ts
+++ b/src/serve.ts
@@ -50140,12 +50140,12 @@ ${filterScript}
 </html>`;
 }
 
-function buildPricingChangesFeed(): string {
+function buildPricingChangesFeed(servedAt: Date = new Date()): string {
   const selected = changeFeedEntries(loadDealChanges(), CHANGE_FEED_ENTRY_LIMIT);
   const escXml = (s: string) => s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;").replace(/'/g, "&apos;");
   const ns = CHANGE_FEED_NAMESPACE_PREFIX;
   const entries = selected.map((c) => {
-    const fields = feedEntryFields(c);
+    const fields = feedEntryFields(c, servedAt);
     const anchor = `${toSlug(c.vendor)}-${c.date}`;
     const id = `agentdeals-${anchor}`;
     const effective = fields.effectiveDate
@@ -50173,7 +50173,7 @@ ${feedEntrySourceXml(c, escXml, ns)}
   <link href="${BASE_URL}/pricing-changes/feed.xml" rel="self" type="application/atom+xml"/>
   <link href="${BASE_URL}${WEEKLY_DIGEST_FEED.path}" rel="related" type="application/atom+xml" title="${escXml(WEEKLY_DIGEST_FEED.title)}"/>
   <id>urn:agentdeals:pricing-changes-feed</id>
-  <updated>${feedUpdatedTimestamp(selected)}</updated>
+  <updated>${feedUpdatedTimestamp(selected, servedAt)}</updated>
   <author><name>AgentDeals</name></author>
 ${entries}
 </feed>`;
@@ -54695,6 +54695,7 @@ const httpServer = createHttpServer(async (req, res) => {
     recordApiHit(feedPath);
     const baseUrl = BASE_URL;
     const escXml = (s: string) => s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;").replace(/'/g, "&apos;");
+    const servedAt = new Date();
     const weekEntries: string[] = [];
     const entryUpdates: string[] = [];
     for (let w = 0; w < 4; w++) {
@@ -54702,7 +54703,7 @@ const httpServer = createHttpServer(async (req, res) => {
       if (digest.top_changes.length === 0) continue;
       const weekUrl = w === 0 ? `${baseUrl}/this-week` : `${baseUrl}/this-week?week=${w}`;
       const newestChange = latestChangeDate(digest.top_changes) ?? digest.week_of;
-      const pubDate = feedEntryUpdated(newestChange);
+      const pubDate = feedEntryUpdated(newestChange, servedAt);
       entryUpdates.push(pubDate);
       const title = `Week of ${weekRangeLabel(digest.week_of, digest.week_ending)}: ${digest.headline}`;
       weekEntries.push(`  <entry>
@@ -54717,7 +54718,7 @@ ${digestSourceXml([...digest.top_changes, ...digest.discovered_changes], escXml)
     }
     const corrections = correctionEntriesXml(baseUrl, escXml);
     for (const c of FEED_CORRECTIONS) entryUpdates.push(c.updated);
-    const updatedTs = channelUpdatedTimestamp(entryUpdates);
+    const updatedTs = channelUpdatedTimestamp(entryUpdates, servedAt);
     const subtitle = `Weekly digest of developer tool pricing changes, free tier removals, and new deals. ${WEEKLY_FEED_POPULATION_NOTE}`;
     const atom = `<?xml version="1.0" encoding="UTF-8"?>
 <feed xmlns="http://www.w3.org/2005/Atom" xmlns:${CHANGE_FEED_NAMESPACE_PREFIX}="${CHANGE_FEED_NAMESPACE}">

--- a/test/change-date-provenance.test.ts
+++ b/test/change-date-provenance.test.ts
@@ -481,7 +481,7 @@ describe("capping a list built from several sections", () => {
 describe("feed entry updated timestamps", () => {
   it("never stamps an entry later than the moment the feed is built", () => {
     const now = new Date("2026-08-28T01:03:00Z");
-    assert.strictEqual(feedEntryUpdated("2026-08-28", now), "2026-08-28T01:03:00.000Z");
+    assert.strictEqual(feedEntryUpdated("2026-08-28", now), "2026-08-28T00:00:00.000Z");
   });
 
   it("still stamps noon for a day that is already over", () => {
@@ -494,8 +494,21 @@ describe("feed entry updated timestamps", () => {
     assert.strictEqual(feedEntryUpdated("2026-08-28", now), "2026-08-28T12:00:00.000Z");
   });
 
-  it("falls back to now when the day is not a date", () => {
+  it("gives two builds of the same day the same stamp", () => {
+    const early = feedEntryUpdated("2026-08-28", new Date("2026-08-28T01:03:00Z"));
+    const later = feedEntryUpdated("2026-08-28", new Date("2026-08-28T01:03:00.004Z"));
+    assert.strictEqual(early, later);
+  });
+
+  it("stamps a day it cannot have reached yet no later than one it has", () => {
+    const now = new Date("2026-08-28T18:00:00Z");
+    const ahead = feedEntryUpdated("2026-10-07", now);
+    assert.ok(ahead <= now.toISOString(), `stamped ${ahead}, later than ${now.toISOString()}`);
+    assert.ok(ahead >= feedEntryUpdated("2026-08-28", now), "a later record sorts under an earlier one");
+  });
+
+  it("falls back to the day it is built on when the day is not a date", () => {
     const now = new Date("2026-08-28T01:03:00Z");
-    assert.strictEqual(feedEntryUpdated("not-a-date", now), "2026-08-28T01:03:00.000Z");
+    assert.strictEqual(feedEntryUpdated("not-a-date", now), "2026-08-28T00:00:00.000Z");
   });
 });

--- a/test/change-feed-provenance.test.ts
+++ b/test/change-feed-provenance.test.ts
@@ -52,6 +52,29 @@ function unescapeXml(s: string): string {
     .replace(/&amp;/g, "&");
 }
 
+function argumentList(source: string, openParen: number): string | null {
+  let depth = 0;
+  for (let i = openParen; i < source.length; i++) {
+    const c = source[i];
+    if (c === "(") depth++;
+    else if (c === ")") {
+      depth--;
+      if (depth === 0) return source.slice(openParen + 1, i);
+    }
+  }
+  return null;
+}
+
+function holdsATopLevelComma(args: string): boolean {
+  let depth = 0;
+  for (const c of args) {
+    if ("([{".includes(c)) depth++;
+    else if (")]}".includes(c)) depth--;
+    else if (c === "," && depth === 0) return true;
+  }
+  return false;
+}
+
 function parseEntries(doc: string): Entry[] {
   return [...doc.matchAll(/<entry>([\s\S]*?)<\/entry>/g)].map((m) => {
     const body = m[1];
@@ -240,6 +263,28 @@ describe("the change feeds date every entry by when we recorded it and say what 
   it("never dates an entry later than the moment the document was served", () => {
     const late = entries.filter((e) => e.updated > startedAt);
     assert.deepStrictEqual(late.map((e) => `${e.title} ${e.updated}`), []);
+  });
+
+  it("dates every stamp in a document from the clock the document was built with", () => {
+    const source = readFileSync(path.join(REPO, "src", "serve.ts"), "utf8");
+    const readsItsOwnClock: string[] = [];
+    for (const call of ["feedEntryFields", "feedEntryUpdated", "feedUpdatedTimestamp", "channelUpdatedTimestamp"]) {
+      for (const m of source.matchAll(new RegExp(`\\b${call}\\(`, "g"))) {
+        const args = argumentList(source, m.index! + m[0].length - 1);
+        if (args !== null && !holdsATopLevelComma(args)) readsItsOwnClock.push(`${call}(${args})`);
+      }
+    }
+    assert.deepStrictEqual(readsItsOwnClock, [], `feed stamps built from a clock of their own: ${readsItsOwnClock.join(", ")}`);
+  });
+
+  it("hands a reader who polls twice the same stamps, so nothing is re-announced", async () => {
+    const stamps = (doc: string) => [...doc.matchAll(/<updated>([^<]+)<\/updated>/g)].map(([, s]) => s);
+    for (const route of [...FEED_ROUTES, WEEKLY_DIGEST_FEED.path]) {
+      const first = stamps(await (await fetch(`http://localhost:${port}${route}`)).text());
+      const second = stamps(await (await fetch(`http://localhost:${port}${route}`)).text());
+      assert.ok(first.length > 0, `${route} carries no <updated>`);
+      assert.deepStrictEqual(second, first, `${route} dates its entries by the moment it was asked`);
+    }
   });
 
   it("orders entries newest recorded first", () => {

--- a/test/homepage-cites-what-it-serves.test.ts
+++ b/test/homepage-cites-what-it-serves.test.ts
@@ -76,6 +76,28 @@ function withoutMarkup(html: string): string {
   return noScript.replace(/<pre[\s\S]*?<\/pre>/g, " ").replace(/<code[\s\S]*?<\/code>/g, " ");
 }
 
+const QUOTED_RECORD_MIN_LENGTH = 30;
+
+function asServed(text: string): string {
+  return text.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;");
+}
+
+function withoutQuotedRecords(html: string, summaries: string[]): { prose: string; removed: number } {
+  let prose = html;
+  let removed = 0;
+  for (const summary of summaries) {
+    const served = asServed(summary);
+    if (served.length < QUOTED_RECORD_MIN_LENGTH || !prose.includes(served)) continue;
+    prose = prose.split(served).join(" ");
+    removed++;
+  }
+  return { prose, removed };
+}
+
+function publishedSummaries(): string[] {
+  return [...new Set(loadDealChanges().map((c) => c.summary ?? "").filter((s) => s.length > 0))];
+}
+
 function namedOutsideALink(prose: string, name: string): boolean {
   const outside = prose.replace(/<a\b[^>]*>[\s\S]*?<\/a>/g, "   ").replace(/<[^>]*>/g, " ");
   return mentions(outside, name);
@@ -221,13 +243,48 @@ describe("the homepage publishes only what it can serve", () => {
   });
 
   it("reaches a page for every vendor it names in prose", () => {
-    const prose = withoutMarkup(home);
+    const { prose } = withoutQuotedRecords(withoutMarkup(home), publishedSummaries());
     const excused = new Set([...NAMES_A_CLIENT_NOT_A_CLAIM, ...NAMES_AN_EXAMPLE_QUERY]);
     const unreachable = loadOffers()
       .map((o) => o.vendor)
       .filter((vendor) => vendor.length >= 4 && !excused.has(vendor))
       .filter((vendor) => namedOutsideALink(prose, vendor) && !namedInsideALink(prose, vendor));
     assert.deepStrictEqual([...new Set(unreachable)], [], `vendors named on / that reach no page: ${unreachable.join(", ")}`);
+  });
+
+  it("recognises the records it quotes, so that rule is about our own sentences", () => {
+    const { removed } = withoutQuotedRecords(withoutMarkup(home), publishedSummaries());
+    assert.ok(removed > 0, "no summary on / was matched back to the record it is quoted from");
+  });
+});
+
+describe("a vendor named inside a record we quote", () => {
+  const SUMMARY = "The free tier now has unlimited crash reports and access to the Slack community.";
+  const CARD = `<div class="rc-summary">${SUMMARY} <a href="https://example.com/pricing">Source</a></div>`;
+
+  it("is not a name the page owes a link", () => {
+    const { prose } = withoutQuotedRecords(CARD, [SUMMARY]);
+    assert.strictEqual(namedOutsideALink(prose, "Slack"), false);
+  });
+
+  it("is still owed one when we write the name in our own sentence", () => {
+    const ours = `<p>We track the Slack free tier.</p>${CARD}`;
+    const { prose } = withoutQuotedRecords(ours, [SUMMARY]);
+    assert.strictEqual(namedOutsideALink(prose, "Slack"), true);
+  });
+
+  it("is recognised through the escaping the page serves it with", () => {
+    const summary = `The "Pro" tier & the Slack app were merged.`;
+    const card = `<div class="rc-summary">${asServed(summary)}</div>`;
+    const { prose, removed } = withoutQuotedRecords(card, [summary]);
+    assert.strictEqual(removed, 1);
+    assert.strictEqual(namedOutsideALink(prose, "Slack"), false);
+  });
+
+  it("leaves a record too short to be a quotation in place", () => {
+    const short = "Slack changed";
+    const { removed } = withoutQuotedRecords(`<p>${short}</p>`, [short]);
+    assert.strictEqual(removed, 0);
   });
 });
 


### PR DESCRIPTION
Refs #1335

The daily re-verification has been refused on its last three runs by assertions about what we publish, not by a wrong record. Two defects.

## A feed entry was stamped with the instant the request arrived

`feedEntryUpdated(day, now)` returned `min(day at 12:00Z, now)`, so a change recorded today and served before noon carried the moment of the fetch. Three consequences, all of them things a reader sees:

- Every poll of a feed returned different `<updated>` values for the same unchanged entries, so an aggregator re-announces them on each fetch.
- Each entry called `new Date()` for itself, so entries recorded on the same day carried increasing stamps inside a document that declares itself ordered newest first.
- The channel `<updated>` was read after the entries, so it was later than every entry and later than the moment the reader asked.

An entry is now stamped from the record: the recorded day at noon once that noon has passed, the start of that day before it, and never a day the server has not reached yet. Two builds on the same day agree.

A document is also dated from one clock — `buildPricingChangesFeed` and the weekly digest each take a `servedAt` and pass it to every stamp. A source-level assertion holds any future call site to it, since the difference is only observable across a boundary the suite cannot wait for.

## The homepage read a vendor's own words as ours

`reaches a page for every vendor it names in prose` scans the rendered body for all 1,572 vendor names. Shake's new record says its free tier includes "access to the Slack community", the homepage publishes that summary verbatim, and Slack is a vendor in our index — so the page was held to linking a vendor it makes no claim about.

The boundary is now stated rather than assumed: we answer for the names in our own sentences, and a change summary is quoted from a record whose own vendor is linked beside it — which `links the vendor on every change it puts on the page` already asserts and this change does not touch.

Quoted text is matched back to the record it came from, through `loadDealChanges()` and the escaping the page serves it with, rather than to a CSS class. It therefore covers every surface that publishes a summary and does not drift when markup does. A guard fails if no summary on `/` is recognised, so the exclusion cannot silently empty.

## Verification

Run against `data-quarantine/rolling-reverification-20260909T105647Z-11f7acf`, the data the 10:46Z run was refused for: all four refusing assertions pass, and that run's 37 verified records, 17 flagged and 10 recorded changes are unblocked. This PR's own CI run is the other arm — the same code against `main`'s data.

`npm run mutate:1335`: 9 mutants, 9 killed.
