### PR TITLE
Report a quality budget rather than asserting it (#1327)

### DIFF
--- a/.github/workflows/reverify.yml
+++ b/.github/workflows/reverify.yml
@@ -85,6 +85,17 @@ jobs:
             bash scripts/report-data-push-outcome.sh "Daily rolling re-verification" shipped-over-failures "$NON_BLOCKING_FILES"
           fi
 
+      - name: Measure the quality budgets against the data that reached main
+        id: budgets
+        run: node scripts/report-quality-budgets.js --body /tmp/quality-budgets.md --github-output
+
+      - name: Say on an issue which budget is over its ceiling
+        if: always() && steps.budgets.outputs.over != ''
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          OVER: ${{ steps.budgets.outputs.over }}
+        run: bash scripts/report-quality-budgets.sh /tmp/quality-budgets.md "$OVER"
+
       - name: Check the change log is still being written to
         id: staleness
         if: always()

--- a/data/quality_budgets.json
+++ b/data/quality_budgets.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
   "budgets": {
-    "stale_fact_pages": 57,
+    "stale_fact_pages": 58,
     "unsourced_tier_a": 22,
     "uncited_change_records": 98,
     "source_checks_ok_without_quoted_evidence": 508,
@@ -13,6 +13,7 @@
     "ungated_pages_withholding_superseded_terms": 165
   },
   "raised_because": {
+    "stale_fact_pages": "57 to 58 on 2026-09-09. A review that recorded review_outcome: fail used to restart the staleness clock, so finding errors on a page improved this count by more than fixing them would. The clock now starts at the last read that found nothing outstanding, which is the rule dateModifiedFor already applied to the date those pages publish. Six pages moved and /email-comparison-2026 joined the cohort; 338 stale facts became 346. Nothing about the catalogue changed — the measurement did.",
     "uncited_change_records": "95 to 98 on 2026-09-06. stathat.com, searchly.com and Prospect.io each cited the page their own summary reports as unreadable, and dropping that citation is the honest fix rather than repointing it at a page that would pass a liveness check. The 35 records that report our own index lost a citation in the same change and are outside this count rather than spending slots in it."
   }
 }

--- a/package.json
+++ b/package.json
@@ -56,7 +56,9 @@
     "test:referral-pipeline": "npm run build && node scripts/test-referral-pipeline.ts",
     "build:mcpb": "npm run build && npx @anthropic-ai/mcpb pack .",
     "queue:curated-alternatives": "node scripts/curated-alternatives-queue.js",
-    "mutate:1335": "node scripts/mutate-1335.mjs"
+    "mutate:1335": "node scripts/mutate-1335.mjs",
+    "mutate:1327": "node scripts/mutate-1327.mjs",
+    "report:budgets": "node scripts/report-quality-budgets.js"
   },
   "dependencies": {
     "@modelcontextprotocol/ext-apps": "^1.5.0",

--- a/scripts/demo-1327.mjs
+++ b/scripts/demo-1327.mjs
@@ -1,0 +1,99 @@
+import { spawnSync } from "node:child_process";
+import { copyFileSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { QUALITY_BUDGET_NAMES, aDataRunMayRaise } from "../dist/page-reviews.js";
+
+const REPO = join(dirname(fileURLToPath(import.meta.url)), "..");
+const BUDGETS = join(REPO, "data", "quality_budgets.json");
+const HELD = `${BUDGETS}.demo-1327`;
+
+const HELP = `Show that a quality budget over its ceiling no longer decides whether the suite passes.
+
+Every budget a data run cannot raise is put far under what the shipped data measures, the test
+files that used to hold those counts are run, and the reporter is asked what it would say. A
+green suite and a report naming every overrun is the pair this demonstrates. The budgets file is
+restored either way.
+
+Usage: node scripts/demo-1327.mjs [--all]
+
+  --all   Run the whole suite rather than the files that held a budget
+`;
+
+const FILES = [
+  "test/stale-page-facts.test.ts",
+  "test/page-data-provenance.test.ts",
+  "test/page-source-ratchet.test.ts",
+  "test/faq-provenance.test.ts",
+  "test/uncited-change-records.test.ts",
+  "test/change-reporting.test.ts",
+  "test/vendor-naming.test.ts",
+  "test/quality-budget-report.test.ts",
+];
+
+function run(command, args) {
+  return spawnSync(command, args, { cwd: REPO, encoding: "utf-8", env: { ...process.env, TZ: "UTC" } });
+}
+
+function main() {
+  if (process.argv.includes("--help") || process.argv.includes("-h")) {
+    console.log(HELP);
+    return 0;
+  }
+  const whole = process.argv.includes("--all");
+
+  const shipped = JSON.parse(readFileSync(BUDGETS, "utf-8"));
+  const lowered = { ...shipped, budgets: { ...shipped.budgets } };
+  const held = [];
+  for (const name of QUALITY_BUDGET_NAMES) {
+    if (aDataRunMayRaise(name)) continue;
+    lowered.budgets[name] = Math.floor(shipped.budgets[name] / 2);
+    held.push(`${name} ${shipped.budgets[name]} → ${lowered.budgets[name]}`);
+  }
+
+  console.log("── Every budget a data run cannot raise, put under what the data measures ──");
+  for (const line of held) console.log(`  ${line}`);
+  console.log();
+
+  copyFileSync(BUDGETS, HELD);
+  let suite;
+  let report;
+  try {
+    writeFileSync(BUDGETS, `${JSON.stringify(lowered, null, 2)}\n`);
+    report = run("node", ["scripts/report-quality-budgets.js", "--json"]);
+    suite = whole
+      ? run("npm", ["test"])
+      : run("node", ["--test", "--test-concurrency", "1", ...FILES]);
+  } finally {
+    copyFileSync(HELD, BUDGETS);
+    rmSync(HELD, { force: true });
+  }
+
+  const summary = (suite.stdout ?? "").match(/^ℹ (?:tests|pass|fail) \d+$/gm) ?? [];
+  console.log("── The suite, with every one of those over its ceiling ──");
+  for (const line of summary) console.log(`  ${line}`);
+  if (suite.status !== 0) {
+    console.log((suite.stdout ?? "").split("✖ failing tests:")[1]?.slice(0, 4000) ?? suite.stderr);
+  }
+  console.log(suite.status === 0 ? "  green\n" : `  RED (exit ${suite.status})\n`);
+
+  console.log("── What the reporter would say about the same data ──");
+  if (report.status !== 0) {
+    console.log(`  the reporter failed: ${report.stderr}`);
+  } else {
+    for (const m of JSON.parse(report.stdout).over) {
+      console.log(`  ${m.name}: ceiling ${m.budget}, measured ${m.measured} — ${m.measured - m.budget} over`);
+    }
+  }
+
+  const over = report.status === 0 ? JSON.parse(report.stdout).over.length : 0;
+  const ok = suite.status === 0 && over === held.length;
+  console.log(
+    ok
+      ? `\n${held.length} budgets over ceiling, ${over} of them reported, suite green.`
+      : `\nsuite exit ${suite.status}, ${over} of ${held.length} reported.`,
+  );
+  return ok ? 0 : 1;
+}
+
+process.exit(main());

--- a/scripts/mutate-1327.mjs
+++ b/scripts/mutate-1327.mjs
@@ -1,0 +1,109 @@
+import { readFileSync, writeFileSync } from "node:fs";
+import { execFileSync } from "node:child_process";
+
+const SUITE = [
+  "test/stale-page-facts.test.ts",
+  "test/quality-budget-report.test.ts",
+  "test/page-data-provenance.test.ts",
+  "test/faq-provenance.test.ts",
+];
+
+const MUTANTS = [
+  ["a-failed-review-restarts-the-staleness-clock", "src/page-reviews.ts",
+    '  const clockStarts = reviewedAt !== null && record.review_outcome === "fail" ? record.published : lastRead;',
+    "  const clockStarts = lastRead;"],
+
+  ["a-failed-review-stops-the-review-cadence-clock-too", "src/page-reviews.ts",
+    "  const daysSince = Math.max(0, daysBetween(lastRead, today));",
+    "  const daysSince = Math.max(0, daysBetween(clockStarts, today));"],
+
+  ["the-published-date-drifts-from-the-staleness-clock-again", "src/page-reviews.ts",
+    "  return reviewStatus(record, today).clock_starts;",
+    "  return reviewStatus(record, today).reviewed_at ?? record.published;"],
+
+  ["a-count-a-data-run-raises-is-reported-as-an-overrun", "src/quality-budgets.ts",
+    "  return measurements.filter(m => m.measured > m.budget && !aDataRunMayRaise(m.name));",
+    "  return measurements.filter(m => m.measured > m.budget);"],
+
+  ["a-budget-nothing-measured-is-read-as-zero", "src/quality-budgets.ts",
+    '    if (typeof count !== "number") continue;',
+    '    if (typeof count !== "number") {\n      out.push({ name, budget: budgets[name], measured: 0, cohort: [] });\n      continue;\n    }'],
+
+  ["the-report-carries-no-marker-to-find-it-by", "src/quality-budgets.ts",
+    "  lines.push(`<!-- ${BUDGET_REPORT_MARKER} -->`);",
+    '  lines.push("");'],
+
+  ["a-cohort-is-printed-whole-however-long-it-is", "src/quality-budgets.ts",
+    "  const shown = cohort.slice(0, COHORT_SHOWN);",
+    "  const shown = cohort.slice();"],
+
+  ["an-overrun-that-names-no-entries-prints-nothing", "src/quality-budgets.ts",
+    '  if (cohort.length === 0) return ["  The measurement names no entries."];',
+    "  if (cohort.length === 0) return [];"],
+
+  ["a-digit-counts-as-a-figure", "src/faq-provenance.ts",
+    "  return !statesVendorFigure(answer) && /\\d/.test(answer);",
+    "  return /\\d/.test(answer);"],
+
+  ["any-structured-block-counts-as-an-faq", "src/faq-provenance.ts",
+    '      if (!entry || entry["@type"] !== "FAQPage" || !Array.isArray(entry.mainEntity)) continue;',
+    "      if (!entry || !Array.isArray(entry.mainEntity)) continue;"],
+
+  ["a-server-that-answered-nothing-is-a-measurement-of-zero", "scripts/report-quality-budgets.js",
+    "    if (served.size < FAQ_PAGES_FLOOR) {",
+    "    if (false) {"],
+
+  ["the-issue-is-looked-up-by-searching-for-the-markers-words", "scripts/report-quality-budgets.sh",
+    'EXISTING="$(gh issue list --state open --limit 200 --json number,body \\\n  --jq "[.[] | select(.body | contains(\\"<!-- $MARKER -->\\"))] | .[0].number // empty")"',
+    'EXISTING="$(gh issue list --state open --search "$MARKER in:body" --json number --jq \'.[0].number // empty\')"'],
+
+  ["nothing-in-test-reads-as-a-budget", "test/budget-assertions.ts",
+    "  if (!IDENTIFIER_PATH.test(text)) return false;",
+    "  if (!IDENTIFIER_PATH.test(text)) return false;\n  return false;"],
+
+  ["a-budget-compared-to-a-budget-counts-as-a-ratchet", "test/budget-assertions.ts",
+    "    if (!compared.some(readsTheBudgetsFile) || compared.every(readsTheBudgetsFile)) continue;",
+    "    if (!compared.some(readsTheBudgetsFile)) continue;"],
+
+  ["only-one-function-is-checked-for-a-defaulted-budget", "test/budget-assertions.ts",
+    "  pageSourceViolations: 3,",
+    "  // pageSourceViolations: 3,"],
+
+  ["a-ceiling-on-a-count-a-data-run-raises-is-flagged-too", "test/budget-assertions.ts",
+    "    const holding = [...named].filter(name => !aDataRunMayRaise(name as QualityBudgetName));",
+    "    const holding = [...named];"],
+];
+
+function run(cmd, args) {
+  try {
+    execFileSync(cmd, args, { stdio: "pipe", encoding: "utf-8", env: { ...process.env, TZ: "UTC" } });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+const survivors = [];
+const uncompiled = [];
+const skipped = [];
+for (const [name, file, from, to] of MUTANTS) {
+  const original = readFileSync(file, "utf-8");
+  if (!original.includes(from)) {
+    console.log(`SKIP  ${name} — the line it mutates is not in ${file}`);
+    skipped.push(name);
+    continue;
+  }
+  writeFileSync(file, original.replace(from, to));
+  const built = run("npm", ["run", "build"]);
+  const green = built && run("npx", ["tsx", "--test", "--test-concurrency", "1", ...SUITE]);
+  writeFileSync(file, original);
+  if (!built) uncompiled.push(name);
+  console.log(`${green ? "SURVIVED" : built ? "killed  " : "DID NOT COMPILE"}  ${name}`);
+  if (green) survivors.push(name);
+}
+run("npm", ["run", "build"]);
+const killed = MUTANTS.length - survivors.length - uncompiled.length - skipped.length;
+console.log(`\n${killed}/${MUTANTS.length} killed`);
+if (survivors.length > 0) console.log("survivors:", survivors.join(", "));
+if (uncompiled.length > 0) console.log("did not compile:", uncompiled.join(", "));
+if (skipped.length > 0) console.log("skipped — target string moved, so these scored nothing:", skipped.join(", "));

--- a/scripts/report-quality-budgets.js
+++ b/scripts/report-quality-budgets.js
@@ -1,0 +1,200 @@
+import { spawn } from "node:child_process";
+import { appendFileSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  QUALITY_BUDGET_NAMES, newestChangeBySlug, pageReviewsPath, parsePageReviews, readQualityBudgets,
+  staleFactPages, unsourcedTierAPaths,
+} from "../dist/page-reviews.js";
+import { toSlug } from "../dist/vendor-slug.js";
+import { uncitedChangesAgainstBudget } from "../dist/change-reporting.js";
+import { passedWithoutRecordingAFinding } from "../dist/source-check.js";
+import { faqAnswerCounts, faqAnswersIn, namesADigitButNoFigure } from "../dist/faq-provenance.js";
+import { budgetReportBody, measurementsFrom, overBudget } from "../dist/quality-budgets.js";
+import { measureBudgets } from "./ratchet-quality-budgets.js";
+
+const REPO = join(dirname(fileURLToPath(import.meta.url)), "..");
+
+const FAQ_PAGES_FLOOR = 25;
+
+const HELP = `Report what each quality budget in data/quality_budgets.json measures today.
+
+A budget is a ceiling on editorial debt — pages nobody has re-read, answers nobody has
+classified. Exceeding one says the reading queue is deeper than it was, not that anything we
+publish is wrong, so no assertion in the suite holds a commit on one. This is where the number
+is read instead.
+
+The three FAQ counts are measured from what a server serves, so this boots one and reads every
+registered page. Pass --skip-faq to report the rest without it.
+
+Usage: node scripts/report-quality-budgets.js [options]
+
+  --date <date>      Day to measure, YYYY-MM-DD (default: today, UTC)
+  --skip-faq         Do not boot a server; leave the three FAQ counts unmeasured
+  --json             Emit the measurement as JSON
+  --body <file>      Write the issue body to <file>
+  --github-output    Append over=true|false and over_names to $GITHUB_OUTPUT
+  --help             This text
+
+Exit status is 0 whenever the measurement was taken, including when a budget is over ceiling.
+`;
+
+function parseArgs(argv) {
+  const opts = {
+    date: new Date().toISOString().slice(0, 10),
+    skipFaq: false,
+    json: false,
+    body: null,
+    githubOutput: false,
+  };
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg === "--help" || arg === "-h") return { help: true };
+    else if (arg === "--skip-faq") opts.skipFaq = true;
+    else if (arg === "--json") opts.json = true;
+    else if (arg === "--github-output") opts.githubOutput = true;
+    else if (arg === "--body") opts.body = argv[++i];
+    else if (arg === "--date") opts.date = argv[++i];
+    else {
+      console.error(`Unknown argument: ${arg}`);
+      return { help: true, invalid: true };
+    }
+  }
+  return opts;
+}
+
+function startServer() {
+  return new Promise((resolvePort, reject) => {
+    const child = spawn("node", [join(REPO, "dist", "serve.js")], {
+      cwd: REPO,
+      stdio: ["ignore", "ignore", "pipe"],
+      env: { ...process.env, PORT: "0", BASE_URL: "http://localhost:3000" },
+    });
+    const timeout = setTimeout(() => {
+      child.kill();
+      reject(new Error("the server did not report a port within 30s"));
+    }, 30000);
+    child.stderr.on("data", buffer => {
+      const found = buffer.toString().match(/running on http:\/\/localhost:(\d+)/);
+      if (found) {
+        clearTimeout(timeout);
+        resolvePort({ proc: child, port: Number(found[1]) });
+      }
+    });
+    child.on("error", err => {
+      clearTimeout(timeout);
+      reject(err);
+    });
+  });
+}
+
+async function measureFaq(pages) {
+  const server = await startServer();
+  try {
+    const answers = [];
+    const served = new Set();
+    for (const page of pages) {
+      const html = await fetch(`http://localhost:${server.port}${page.path}`).then(r => r.text());
+      const found = faqAnswersIn(page.path, html);
+      if (found.length > 0) served.add(page.path);
+      answers.push(...found);
+    }
+    if (served.size < FAQ_PAGES_FLOOR) {
+      throw new Error(
+        `only ${served.size} of ${pages.length} registered pages served a structured FAQ, under a floor of ${FAQ_PAGES_FLOOR}. ` +
+          `That reads as a server that did not answer rather than as a catalogue with no answers in it, so nothing is reported.`,
+      );
+    }
+    return { counts: faqAnswerCounts(answers), answers };
+  } finally {
+    server.proc.kill();
+  }
+}
+
+export async function measureEverything(date, { skipFaq = false } = {}) {
+  const index = parsePageReviews(readFileSync(pageReviewsPath(), "utf-8"));
+  const changes = JSON.parse(readFileSync(join(REPO, "data", "deal_changes.json"), "utf-8")).changes;
+  const offers = JSON.parse(readFileSync(join(REPO, "data", "index.json"), "utf-8")).offers ?? [];
+  const newest = newestChangeBySlug(changes, date, toSlug);
+  const stale = staleFactPages(index.pages, date, slug => newest.get(slug) ?? null);
+
+  const measured = { ...measureBudgets(date) };
+  const cohorts = {
+    stale_fact_pages: stale.map(p => `\`${p.path}\` — ${p.facts.length} fact(s) recorded since it was last read`),
+    unsourced_tier_a: unsourcedTierAPaths(index.pages).map(path => `\`${path}\``),
+    uncited_change_records: uncitedChangesAgainstBudget(changes).map(
+      change => `${change.vendor ?? "unnamed vendor"} — ${change.date ?? "undated"}`,
+    ),
+    source_checks_ok_without_quoted_evidence: offers
+      .filter(passedWithoutRecordingAFinding)
+      .map(offer => `${offer.vendor ?? "unnamed vendor"}`),
+  };
+
+  if (!skipFaq) {
+    const faq = await measureFaq(index.pages);
+    Object.assign(measured, faq.counts);
+    cohorts.faq_answers_with_a_digit_but_no_figure = faq.answers
+      .filter(a => namesADigitButNoFigure(a.text))
+      .map(a => `\`${a.path}\` — ${a.question}`);
+  }
+
+  return { measured, cohorts };
+}
+
+async function main() {
+  const opts = parseArgs(process.argv.slice(2));
+  if (opts.help) {
+    console.log(HELP);
+    process.exit(opts.invalid ? 1 : 0);
+  }
+
+  const budgets = readQualityBudgets().budgets;
+  const { measured, cohorts } = await measureEverything(opts.date, { skipFaq: opts.skipFaq });
+  const measurements = measurementsFrom(budgets, measured, cohorts);
+  const over = overBudget(measurements);
+  const body = budgetReportBody(measurements, {
+    measured_for: opts.date,
+    run_url: process.env.GITHUB_RUN_ID
+      ? `${process.env.GITHUB_SERVER_URL ?? "https://github.com"}/${process.env.GITHUB_REPOSITORY ?? "robhunter/agentdeals"}/actions/runs/${process.env.GITHUB_RUN_ID}`
+      : undefined,
+    commit: process.env.GITHUB_SHA?.slice(0, 7),
+  });
+
+  if (opts.json) {
+    console.log(JSON.stringify({ measured_for: opts.date, budgets, measured, over }, null, 2));
+  } else {
+    console.log(`── Quality budgets, measured for ${opts.date} ──`);
+    for (const name of QUALITY_BUDGET_NAMES) {
+      const found = measurements.find(m => m.name === name);
+      if (!found) {
+        console.log(`${name}: ceiling ${budgets[name]}, not measured by this run`);
+        continue;
+      }
+      const verdict =
+        found.measured === found.budget
+          ? "at ceiling"
+          : found.measured < found.budget
+            ? `${found.budget - found.measured} under ceiling`
+            : `${found.measured - found.budget} OVER CEILING`;
+      console.log(`${name}: ceiling ${found.budget}, measured ${found.measured} — ${verdict}`);
+    }
+  }
+
+  if (opts.body) writeFileSync(opts.body, body);
+
+  if (opts.githubOutput && process.env.GITHUB_OUTPUT) {
+    appendFileSync(
+      process.env.GITHUB_OUTPUT,
+      `over=${over.length > 0}\nover_names=${over.map(m => m.name).join(" ")}\n`,
+    );
+  }
+}
+
+const isMainModule =
+  process.argv[1] && resolve(process.argv[1]) === resolve(fileURLToPath(import.meta.url));
+if (isMainModule) {
+  main().catch(err => {
+    console.error(err.message);
+    process.exit(2);
+  });
+}

--- a/scripts/report-quality-budgets.sh
+++ b/scripts/report-quality-budgets.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ "$#" -lt 2 ]; then
+  echo "usage: report-quality-budgets.sh <body-file> true|false" >&2
+  echo "  The second argument says whether any budget is over its ceiling." >&2
+  exit 2
+fi
+
+BODY="$1"
+OVER="$2"
+MARKER="quality-budget-report"
+TITLE="A quality budget is over its ceiling"
+
+case "$OVER" in
+  true|false) ;;
+  *) echo "The second argument is $OVER; it says whether a budget is over ceiling and must be true or false." >&2; exit 2 ;;
+esac
+
+if [ ! -s "$BODY" ]; then
+  echo "No body at $BODY, so there is nothing to report." >&2
+  exit 2
+fi
+
+if ! grep -qF "<!-- $MARKER -->" "$BODY"; then
+  echo "The body at $BODY carries no $MARKER marker, so the next run could not find the issue it opened." >&2
+  exit 2
+fi
+
+EXISTING="$(gh issue list --state open --limit 200 --json number,body \
+  --jq "[.[] | select(.body | contains(\"<!-- $MARKER -->\"))] | .[0].number // empty")"
+
+if [ -n "$EXISTING" ]; then
+  gh issue edit "$EXISTING" --body-file "$BODY"
+  echo "Updated issue #$EXISTING with today's measurement."
+  exit 0
+fi
+
+if [ "$OVER" = "false" ]; then
+  echo "Every budget is at or under its ceiling and no issue is open, so there is nothing to open one about."
+  exit 0
+fi
+
+gh issue create --title "$TITLE" --label "priority/medium" --label "type: chore" --body-file "$BODY"

--- a/src/faq-provenance.ts
+++ b/src/faq-provenance.ts
@@ -71,6 +71,46 @@ export function answerWithProvenance(answer: string, clause: string): string {
   return `${text} ${clause}`;
 }
 
+export interface ServedFaqAnswer {
+  path: string;
+  question: string;
+  text: string;
+}
+
+const JSON_LD_BLOCK = /<script type="application\/ld\+json">([\s\S]*?)<\/script>/g;
+
+export function faqAnswersIn(pagePath: string, html: string): ServedFaqAnswer[] {
+  const out: ServedFaqAnswer[] = [];
+  for (const block of html.matchAll(JSON_LD_BLOCK)) {
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(block[1]!);
+    } catch {
+      continue;
+    }
+    for (const entry of (Array.isArray(parsed) ? parsed : [parsed]) as any[]) {
+      if (!entry || entry["@type"] !== "FAQPage" || !Array.isArray(entry.mainEntity)) continue;
+      for (const question of entry.mainEntity) {
+        const text = question?.acceptedAnswer?.text;
+        if (typeof text === "string") out.push({ path: pagePath, question: question.name, text });
+      }
+    }
+  }
+  return out;
+}
+
+export function namesADigitButNoFigure(answer: string): boolean {
+  return !statesVendorFigure(answer) && /\d/.test(answer);
+}
+
+export function faqAnswerCounts(answers: readonly ServedFaqAnswer[]): Record<string, number> {
+  return {
+    faq_answers: answers.length,
+    faq_answers_stating_a_figure: answers.filter(a => statesVendorFigure(a.text)).length,
+    faq_answers_with_a_digit_but_no_figure: answers.filter(a => namesADigitButNoFigure(a.text)).length,
+  };
+}
+
 export function faqPageJsonLd(pagePath: string, items: FaqItem[], today = utcToday()): Record<string, unknown> {
   const clause = pageFaqProvenanceClause(pagePath, today);
   return {

--- a/src/page-reviews.ts
+++ b/src/page-reviews.ts
@@ -292,8 +292,9 @@ export function getPageReview(pagePath: string): PageReviewRecord | null {
 export function reviewStatus(record: PageReviewRecord, today: string): ReviewStatus {
   const sla = SLA_DAYS[record.tier];
   const reviewedAt = record.reviewed_at !== null && record.reviewed_at <= today ? record.reviewed_at : null;
-  const clockStarts = reviewedAt ?? record.published;
-  const daysSince = Math.max(0, daysBetween(clockStarts, today));
+  const lastRead = reviewedAt ?? record.published;
+  const clockStarts = reviewedAt !== null && record.review_outcome === "fail" ? record.published : lastRead;
+  const daysSince = Math.max(0, daysBetween(lastRead, today));
   const overdue = Math.max(0, daysSince - sla);
   let state: ReviewState;
   if (reviewedAt === null) state = "never_reviewed";
@@ -378,9 +379,7 @@ export function pageCompiledClause(pagePath: string, today = utcToday()): string
 
 export function dateModifiedFor(record: PageReviewRecord | null, fallbackPublished: string, today: string): string {
   if (!record) return fallbackPublished;
-  const status = reviewStatus(record, today);
-  if (status.review_outcome === "fail") return record.published;
-  return status.reviewed_at ?? record.published;
+  return reviewStatus(record, today).clock_starts;
 }
 
 export function pageDateModified(pagePath: string, fallbackPublished: string, today = utcToday()): string {

--- a/src/quality-budgets.ts
+++ b/src/quality-budgets.ts
@@ -1,0 +1,103 @@
+import { QUALITY_BUDGET_NAMES, aDataRunMayRaise, type QualityBudgetName } from "./page-reviews.js";
+
+export const BUDGET_REPORT_MARKER = "quality-budget-report";
+
+export const BUDGET_REPORT_TITLE = "A quality budget is over its ceiling";
+
+export interface BudgetMeasurement {
+  name: QualityBudgetName;
+  budget: number;
+  measured: number;
+  cohort: string[];
+}
+
+export interface BudgetReportContext {
+  measured_for: string;
+  run_url?: string;
+  commit?: string;
+}
+
+export const COHORT_SHOWN = 25;
+
+export function overBudget(measurements: readonly BudgetMeasurement[]): BudgetMeasurement[] {
+  return measurements.filter(m => m.measured > m.budget && !aDataRunMayRaise(m.name));
+}
+
+export function measurementsFrom(
+  budgets: Record<QualityBudgetName, number>,
+  measured: Record<string, number | undefined>,
+  cohorts: Record<string, string[] | undefined> = {},
+): BudgetMeasurement[] {
+  const out: BudgetMeasurement[] = [];
+  for (const name of QUALITY_BUDGET_NAMES) {
+    const count = measured[name];
+    if (typeof count !== "number") continue;
+    out.push({ name, budget: budgets[name], measured: count, cohort: cohorts[name] ?? [] });
+  }
+  return out;
+}
+
+function cohortLines(cohort: readonly string[]): string[] {
+  if (cohort.length === 0) return ["  The measurement names no entries."];
+  const shown = cohort.slice(0, COHORT_SHOWN);
+  const lines = shown.map(entry => `  - ${entry}`);
+  if (cohort.length > shown.length) {
+    lines.push(`  - …and ${cohort.length - shown.length} more.`);
+  }
+  return lines;
+}
+
+function verdictLine(m: BudgetMeasurement): string {
+  if (m.measured > m.budget) return `**${m.measured - m.budget} over** a ceiling of ${m.budget}`;
+  if (m.measured < m.budget) return `${m.budget - m.measured} under a ceiling of ${m.budget}`;
+  return `at its ceiling of ${m.budget}`;
+}
+
+export function budgetReportBody(
+  measurements: readonly BudgetMeasurement[],
+  context: BudgetReportContext,
+): string {
+  const over = overBudget(measurements);
+  const lines: string[] = [];
+  lines.push(
+    over.length === 0
+      ? `Every quality budget measured on ${context.measured_for} is at or under its ceiling.`
+      : `${over.length} quality ${over.length === 1 ? "budget is" : "budgets are"} over ceiling, measured on ${context.measured_for}.`,
+  );
+  lines.push("");
+  lines.push(
+    "These are counts of editorial debt: entries nobody has read yet, not entries anyone has shown to be wrong. " +
+      "A ceiling may fall on its own and rises only by a deliberate edit to `data/quality_budgets.json`. " +
+      "None of them fails the suite, so this is where the number is read.",
+  );
+  lines.push("");
+  for (const m of over) {
+    lines.push(`### \`${m.name}\` — ${verdictLine(m)}`);
+    lines.push("");
+    lines.push(...cohortLines(m.cohort));
+    lines.push("");
+  }
+  lines.push("| budget | ceiling | measured |");
+  lines.push("|---|---|---|");
+  for (const m of measurements) {
+    const flag = m.measured > m.budget ? " ⚠" : "";
+    lines.push(`| \`${m.name}\` | ${m.budget} | ${m.measured}${flag} |`);
+  }
+  const unmeasured = QUALITY_BUDGET_NAMES.filter(n => !measurements.some(m => m.name === n));
+  if (unmeasured.length > 0) {
+    lines.push("");
+    lines.push(`Not measured by this run: ${unmeasured.map(n => `\`${n}\``).join(", ")}.`);
+  }
+  lines.push("");
+  if (context.commit) lines.push(`Measured on \`${context.commit}\`.`);
+  if (context.run_url) lines.push(`The run: ${context.run_url}`);
+  if (over.length > 0) {
+    lines.push("");
+    lines.push(
+      "To clear one: fix the entries above, then `npm run ratchet:budgets` to bring the ceiling down to what the data now measures.",
+    );
+  }
+  lines.push("");
+  lines.push(`<!-- ${BUDGET_REPORT_MARKER} -->`);
+  return `${lines.join("\n")}\n`;
+}

--- a/test/budget-assertions.ts
+++ b/test/budget-assertions.ts
@@ -1,0 +1,150 @@
+import { QUALITY_BUDGET_NAMES, aDataRunMayRaise, type QualityBudgetName } from "../src/page-reviews.ts";
+
+const EQUALITY = /assert\.(?:strictEqual|deepStrictEqual|equal|deepEqual)\(/g;
+
+const BASELINE_CONSTANTS = [
+  "STALE_FACT_PAGES_BASELINE",
+  "UNSOURCED_TIER_A_BASELINE",
+  "UNCITED_CHANGE_RECORDS_BASELINE",
+  "FAQ_BASELINE",
+];
+
+const IDENTIFIER_PATH = /^[A-Za-z_$][\w$]*(?:\.[A-Za-z_$][\w$]*)*$/;
+
+export interface HeldAgainstABudget {
+  line: number;
+  text: string;
+}
+
+function operandsOf(source: string, open: number): string[] | null {
+  const operands: string[] = [];
+  let depth = 0;
+  let from = open + 1;
+  for (let at = open; at < source.length; at++) {
+    const char = source[at];
+    if (char === "(" || char === "[" || char === "{") depth++;
+    else if (char === ")" || char === "]" || char === "}") {
+      depth--;
+      if (depth === 0) {
+        operands.push(source.slice(from, at));
+        return operands;
+      }
+    } else if (char === "," && depth === 1) {
+      operands.push(source.slice(from, at));
+      from = at + 1;
+    } else if (char === '"' || char === "'" || char === "`") {
+      for (at++; at < source.length && source[at] !== char; at++) if (source[at] === "\\") at++;
+    }
+  }
+  return null;
+}
+
+export function readsTheBudgetsFile(operand: string): boolean {
+  const text = operand.trim();
+  if (!IDENTIFIER_PATH.test(text)) return false;
+  const segments = text.split(".");
+  if (BASELINE_CONSTANTS.includes(segments[0]!)) return true;
+  if (segments.includes("budgets") && segments.at(-1) !== "budgets") return true;
+  return segments[0] === "budgets" && (QUALITY_BUDGET_NAMES as readonly string[]).includes(segments.at(-1)!);
+}
+
+export function budgetsHeldAgainstAMeasurement(source: string): HeldAgainstABudget[] {
+  const found: HeldAgainstABudget[] = [];
+  for (const call of source.matchAll(EQUALITY)) {
+    const operands = operandsOf(source, call.index + call[0].length - 1);
+    if (!operands) continue;
+    const compared = operands.slice(0, 2);
+    if (!compared.some(readsTheBudgetsFile) || compared.every(readsTheBudgetsFile)) continue;
+    found.push({
+      line: source.slice(0, call.index).split("\n").length,
+      text: compared.join(",").replace(/\s+/g, " ").trim().slice(0, 90),
+    });
+  }
+  return found;
+}
+
+const TAKES_A_BUDGET_BY_DEFAULT: Record<string, number> = {
+  staleFactViolations: 4,
+  pageSourceViolations: 3,
+};
+
+export function callsThatLetTheBudgetDefault(source: string): HeldAgainstABudget[] {
+  const found: HeldAgainstABudget[] = [];
+  for (const [name, arity] of Object.entries(TAKES_A_BUDGET_BY_DEFAULT)) {
+    for (const call of source.matchAll(new RegExp(`\\b${name}\\(`, "g"))) {
+      const operands = operandsOf(source, call.index + call[0].length - 1);
+      if (!operands || operands.length >= arity) continue;
+      found.push({
+        line: source.slice(0, call.index).split("\n").length,
+        text: `${name}(${operands.join(",").replace(/\s+/g, " ").trim().slice(0, 70)})`,
+      });
+    }
+  }
+  return found.sort((a, b) => a.line - b.line);
+}
+
+const CEILING = /assert\.ok\(/g;
+
+const COMPARISON = /[<>]=?/;
+
+const NAMED_BUDGET = /\bconst\s+([A-Za-z_$][\w$]*)\s*=\s*qualityBudget\(\s*"([a-z_]+)"\s*\)/g;
+
+const INLINE_BUDGET = /\bqualityBudget\(\s*"([a-z_]+)"\s*\)/g;
+
+const BUDGET_BEHIND_A_CONSTANT: Record<string, QualityBudgetName> = {
+  STALE_FACT_PAGES_BASELINE: "stale_fact_pages",
+  UNSOURCED_TIER_A_BASELINE: "unsourced_tier_a",
+  UNCITED_CHANGE_RECORDS_BASELINE: "uncited_change_records",
+};
+
+export function ceilingsHeldAgainstABudget(source: string): HeldAgainstABudget[] {
+  const behindALocal = new Map<string, string>();
+  for (const declaration of source.matchAll(NAMED_BUDGET)) behindALocal.set(declaration[1]!, declaration[2]!);
+
+  const found: HeldAgainstABudget[] = [];
+  for (const call of source.matchAll(CEILING)) {
+    const operands = operandsOf(source, call.index + call[0].length - 1);
+    if (!operands) continue;
+    const condition = operands[0]!;
+    if (!COMPARISON.test(condition)) continue;
+    const named = new Set<string>();
+    for (const inline of condition.matchAll(INLINE_BUDGET)) named.add(inline[1]!);
+    for (const word of condition.matchAll(/[A-Za-z_$][\w$]*/g)) {
+      const behind = behindALocal.get(word[0]) ?? BUDGET_BEHIND_A_CONSTANT[word[0]];
+      if (behind) named.add(behind);
+    }
+    const holding = [...named].filter(name => !aDataRunMayRaise(name as QualityBudgetName));
+    if (holding.length === 0) continue;
+    found.push({
+      line: source.slice(0, call.index).split("\n").length,
+      text: `${condition.replace(/\s+/g, " ").trim().slice(0, 70)} — ${holding.join(", ")}`,
+    });
+  }
+  return found;
+}
+
+export const WIRING_CHECKS = `assert.strictEqual(FAQ_BASELINE.answers, budgets.faq_answers);
+assert.strictEqual(STALE_FACT_PAGES_BASELINE, shipped.budgets.stale_fact_pages);`;
+
+export const RATCHETS = `assert.strictEqual(answers.length, FAQ_BASELINE.answers);
+assert.strictEqual(frozen, FAQ_BASELINE.stating_a_figure);
+assert.strictEqual(UNSOURCED_TIER_A_BASELINE, unsourcedTierAPaths(shipped).length);`;
+
+export const MEASUREMENTS_COMPARED_TO_EACH_OTHER = `assert.strictEqual(census.records_with_superseded_terms, supersededRecords().length);
+assert.strictEqual(next.stale_fact_pages, 57);`;
+
+export const A_BUDGET_REACHED_THROUGH_A_DEFAULT = `assert.deepStrictEqual(staleFactViolations(pages, TODAY, changeDateFor), []);
+assert.deepStrictEqual(pageSourceViolations(pages, measured), []);`;
+
+export const A_BUDGET_PASSED_IN = `assert.deepStrictEqual(staleFactViolations(pages, TODAY, moved, 1), []);
+assert.deepStrictEqual(pageSourceViolations(pages, measured, unsourcedTierAPaths(pages).length), []);`;
+
+export const CEILINGS_ON_A_BUDGET_THAT_HOLDS_A_COMMIT = `const budget = qualityBudget("uncited_change_records");
+assert.ok(measured <= budget, "over budget");
+assert.ok(offers.filter(f).length <= qualityBudget("source_checks_ok_without_quoted_evidence"));
+assert.ok(unsourced.length <= UNSOURCED_TIER_A_BASELINE);`;
+
+export const CEILINGS_A_DATA_RUN_RAISES_IN_THE_SAME_COMMIT = `const budget = qualityBudget("records_with_superseded_terms");
+assert.ok(measured <= budget, "over the recorded count");
+assert.ok(atRest <= qualityBudget("ungated_pages_withholding_superseded_terms"));
+assert.ok(shipped.length > 60, "only a few pages on the register");`;

--- a/test/change-reporting.test.ts
+++ b/test/change-reporting.test.ts
@@ -26,7 +26,6 @@ import {
 import {
   QUALITY_BUDGET_NAMES,
   parseQualityBudgets,
-  qualityBudget,
   readQualityBudgets,
   serializeQualityBudgets,
 } from "../dist/page-reviews.js";
@@ -164,7 +163,7 @@ describe("the budget on records citing no source", () => {
   it("counts the records that report a vendor's offer, and says why the others are outside it", () => {
     const measured = uncitedChangesAgainstBudget(changes);
     assert.strictEqual(measured.length, uncitedChanges(changes).length - ourIndexChanges(changes).length);
-    assert.ok(measured.length <= qualityBudget("uncited_change_records"));
+    assert.ok(ourIndexChanges(changes).length > 0, "no record is outside the count, so the subtraction is not read");
     assert.ok(UNCITED_CHANGE_BUDGET_RULE.includes("our own"), "the rule does not state what it leaves out");
   });
 

--- a/test/faq-provenance.test.ts
+++ b/test/faq-provenance.test.ts
@@ -11,7 +11,8 @@ import {
   perturbTextFields, type PageReviewRecord,
 } from "../src/page-reviews.ts";
 import {
-  FAQ_BASELINE, answerWithProvenance, faqPageJsonLd, faqProvenanceClause, statesVendorFigure,
+  answerWithProvenance, faqAnswersIn, faqPageJsonLd, faqProvenanceClause, statesVendorFigure,
+  type ServedFaqAnswer,
 } from "../dist/faq-provenance.js";
 import { NEVER_REVIEWED, registerWith, reviewFailedOn, type RegisterFixture } from "./page-review-fixture.ts";
 
@@ -47,25 +48,6 @@ function startServer(env: NodeJS.ProcessEnv): Promise<{ proc: ChildProcess; port
     });
     child.on("error", (err) => { clearTimeout(timeout); reject(err); });
   });
-}
-
-interface Answer { path: string; question: string; text: string }
-
-function faqAnswersIn(pagePath: string, html: string): Answer[] {
-  const out: Answer[] = [];
-  const blocks = html.matchAll(/<script type="application\/ld\+json">([\s\S]*?)<\/script>/g);
-  for (const block of blocks) {
-    let parsed: any;
-    try { parsed = JSON.parse(block[1]); } catch { continue; }
-    for (const entry of Array.isArray(parsed) ? parsed : [parsed]) {
-      if (!entry || entry["@type"] !== "FAQPage" || !Array.isArray(entry.mainEntity)) continue;
-      for (const q of entry.mainEntity) {
-        const text = q?.acceptedAnswer?.text;
-        if (typeof text === "string") out.push({ path: pagePath, question: q.name, text });
-      }
-    }
-  }
-  return out;
 }
 
 function jsonLdBlocks(html: string): any[] {
@@ -204,8 +186,8 @@ describe("#1086 every structured answer that states a vendor figure carries the 
   let tmp: string;
   let real: { proc: ChildProcess; port: number };
   let perturbed: { proc: ChildProcess; port: number };
-  const answers: Answer[] = [];
-  const perturbedAnswers = new Map<string, Answer[]>();
+  const answers: ServedFaqAnswer[] = [];
+  const perturbedAnswers = new Map<string, ServedFaqAnswer[]>();
   const bodies = new Map<string, string>();
 
   before(async () => {
@@ -246,7 +228,7 @@ describe("#1086 every structured answer that states a vendor figure carries the 
   });
 
   it("finds structured answers on the register to check", () => {
-    assert.strictEqual(answers.length, FAQ_BASELINE.answers);
+    assertPopulationFloor(answers.length, 120, "structured answers served by the registered pages");
     const withFaq = new Set(answers.map((a) => a.path));
     assert.ok(withFaq.size > 30, `only ${withFaq.size} registered pages emit a structured FAQ`);
   });
@@ -256,14 +238,9 @@ describe("#1086 every structured answer that states a vendor figure carries the 
     assert.deepStrictEqual(bare.map((a) => `${a.path} :: ${a.question}`), []);
   });
 
-  it("holds the number of answers stating a figure, so a new one has to be looked at", () => {
+  it("finds answers stating a figure, so the rule above is not passing on an empty set", () => {
     const stating = answers.filter((a) => statesVendorFigure(a.text));
-    assert.strictEqual(stating.length, FAQ_BASELINE.stating_a_figure);
-  });
-
-  it("holds the number of answers naming a number the rule does not read as a figure", () => {
-    const unread = answers.filter((a) => !statesVendorFigure(a.text) && /\d/.test(a.text));
-    assert.strictEqual(unread.length, FAQ_BASELINE.a_digit_but_no_figure);
+    assertPopulationFloor(stating.length, 55, "served answers stating a vendor figure");
   });
 
   it("takes the dates in every clause from the register rather than from the answer", () => {
@@ -309,7 +286,7 @@ describe("#1086 every structured answer that states a vendor figure carries the 
       }
     }
     assert.deepStrictEqual(moved, []);
-    assert.strictEqual(frozen, FAQ_BASELINE.stating_a_figure);
+    assertPopulationFloor(frozen, 55, "dated answers that held still while the catalogue under them moved");
   });
 
   it("leaves the answers the catalogue does move without a compile date", () => {

--- a/test/page-data-provenance.test.ts
+++ b/test/page-data-provenance.test.ts
@@ -7,7 +7,7 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import {
-  CATALOGUE_TEXT_FIELDS, CHANGE_LOG_TEXT_FIELDS, PAGE_DATA_SOURCES, UNSOURCED_TIER_A_BASELINE,
+  CATALOGUE_TEXT_FIELDS, CHANGE_LOG_TEXT_FIELDS, PAGE_DATA_SOURCES,
   pageSourceViolations, parsePageReviews, perturbTextFields, unsourcedTierAPaths, vendorFactRows,
   type PageReviewRecord, type PageSourceMeasurement,
 } from "../src/page-reviews.ts";
@@ -146,12 +146,15 @@ describe("a page may only name the source it actually reads", () => {
       pages.filter((p) => !PAGE_DATA_SOURCES.includes(p.data_source)).map((p) => p.path),
       []
     );
-    assert.deepStrictEqual(pageSourceViolations(pages, measured).map((v) => `${v.path} ${v.problem}`), []);
+    assert.deepStrictEqual(
+      pageSourceViolations(pages, measured, unsourcedTierAPaths(pages).length).map((v) => `${v.path} ${v.problem}`),
+      []
+    );
   });
 
-  it("holds the number of tier-A pages that assert vendor facts and read no catalogue record, and cannot admit another", () => {
+  it("cannot admit one more tier-A page that asserts vendor facts and reads no catalogue record", () => {
     const unsourced = unsourcedTierAPaths(pages);
-    assert.strictEqual(unsourced.length, UNSOURCED_TIER_A_BASELINE);
+    assert.ok(unsourced.length > 0, "no page on the register is unsourced, so nothing here is exercised");
     const admitted = [...pages, {
       ...pages.find((p) => p.tier === "A")!,
       path: "/a-page-that-does-not-exist",
@@ -162,8 +165,8 @@ describe("a page may only name the source it actually reads", () => {
     const withOneMore = new Map(measured);
     withOneMore.set("/a-page-that-does-not-exist", { reads_index: false, reads_changes: false, vendor_fact_rows: 0 });
     assert.ok(
-      pageSourceViolations(admitted, withOneMore).length > 0,
-      "a forty-fourth unsourced tier-A page passed, so the ratchet allows the number to grow"
+      pageSourceViolations(admitted, withOneMore, unsourced.length).length > 0,
+      `a ${unsourced.length + 1}th unsourced tier-A page passed, so the ratchet allows the number to grow`
     );
   });
 
@@ -173,7 +176,7 @@ describe("a page may only name the source it actually reads", () => {
         ? { ...p, data_source: "editorial" as const, data_source_reason: "no vendor facts here" }
         : p
     );
-    const problems = pageSourceViolations(withFalseExemption, measured, UNSOURCED_TIER_A_BASELINE - 1);
+    const problems = pageSourceViolations(withFalseExemption, measured, unsourcedTierAPaths(pages).length - 1);
     assert.ok(
       problems.some((v) => v.path === "/storage-comparison-2026" && v.problem.includes("table rows")),
       `the exemption was accepted on a comparison page: ${JSON.stringify(problems)}`

--- a/test/page-source-ratchet.test.ts
+++ b/test/page-source-ratchet.test.ts
@@ -2,7 +2,7 @@ import { describe, it } from "node:test";
 import assert from "node:assert";
 import { readFileSync } from "node:fs";
 import {
-  CATALOGUE_TEXT_FIELDS, PERTURBATION_SENTINEL, UNSOURCED_TIER_A_BASELINE,
+  CATALOGUE_TEXT_FIELDS, PERTURBATION_SENTINEL,
   compiledClause, compiledNotice, dataProvenanceFor, freshnessSegmentFor, pageSourceViolations,
   parsePageReviews, perturbTextFields, unsourcedTierAPaths, vendorFactRows,
   type PageDataSource, type PageReviewRecord, type PageSourceMeasurement,
@@ -122,11 +122,11 @@ describe("the number of tier-A pages asserting vendor facts from nowhere only go
     assert.deepStrictEqual(unsourcedTierAPaths(pages), ["/filler-0", "/filler-1"]);
   });
 
-  it("is the number the shipped register holds", () => {
+  it("names pages on the shipped register, so the rules above read a real population", () => {
     const shipped = parsePageReviews(
       readFileSync(new URL("../data/page-reviews.json", import.meta.url), "utf-8"),
     ).pages;
-    assert.strictEqual(UNSOURCED_TIER_A_BASELINE, unsourcedTierAPaths(shipped).length);
+    assert.ok(unsourcedTierAPaths(shipped).length > 0, "no tier-A page on the register states an unsourced fact");
     assert.ok(shipped.length > 60, `only ${shipped.length} pages on the register`);
   });
 });

--- a/test/quality-budget-report.test.ts
+++ b/test/quality-budget-report.test.ts
@@ -1,0 +1,226 @@
+import { describe, it } from "node:test";
+import assert from "node:assert";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { assertPopulationFloor } from "./population-floor.ts";
+import { QUALITY_BUDGET_NAMES, readQualityBudgets, utcToday } from "../src/page-reviews.ts";
+import {
+  BUDGET_REPORT_MARKER, COHORT_SHOWN, budgetReportBody, measurementsFrom, overBudget,
+  type BudgetMeasurement,
+} from "../dist/quality-budgets.js";
+import { faqAnswerCounts, faqAnswersIn, namesADigitButNoFigure } from "../dist/faq-provenance.js";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO = path.join(__dirname, "..");
+const REPORTER = path.join(REPO, "scripts", "report-quality-budgets.js");
+const ANNOUNCER = path.join(REPO, "scripts", "report-quality-budgets.sh");
+
+const AT_CEILING: BudgetMeasurement[] = QUALITY_BUDGET_NAMES.map(name => ({
+  name,
+  budget: 10,
+  measured: 10,
+  cohort: [],
+}));
+
+function over(name: string, by: number, cohort: string[] = []): BudgetMeasurement[] {
+  return AT_CEILING.map(m => (m.name === name ? { ...m, measured: m.budget + by, cohort } : m));
+}
+
+describe("#1327 a budget over its ceiling is reported rather than asserted", () => {
+  it("names the budget, the measurement and the cohort", () => {
+    const body = budgetReportBody(over("stale_fact_pages", 3, ["`/one`", "`/two`"]), { measured_for: "2026-09-09" });
+    assert.match(body, /stale_fact_pages/);
+    assert.match(body, /\*\*3 over\*\* a ceiling of 10/);
+    assert.match(body, /- `\/one`/);
+    assert.match(body, /- `\/two`/);
+    assert.match(body, /measured on 2026-09-09/);
+  });
+
+  it("says so plainly when a budget over ceiling names no entries, rather than printing nothing", () => {
+    const body = budgetReportBody(over("faq_answers", 1), { measured_for: "2026-09-09" });
+    assert.match(body, /The measurement names no entries\./);
+  });
+
+  it("shows a bounded slice of a long cohort and says how many it left out", () => {
+    const cohort = Array.from({ length: COHORT_SHOWN + 7 }, (_, i) => `/page-${i}`);
+    const body = budgetReportBody(over("stale_fact_pages", 1, cohort), { measured_for: "2026-09-09" });
+    assert.match(body, /…and 7 more\./);
+    assert.strictEqual(body.split("\n").filter(l => l.startsWith("  - /page-")).length, COHORT_SHOWN);
+  });
+
+  it("carries a marker, so the next run edits the issue it opened rather than opening another", () => {
+    const body = budgetReportBody(AT_CEILING, { measured_for: "2026-09-09" });
+    assert.ok(body.includes(`<!-- ${BUDGET_REPORT_MARKER} -->`), body);
+  });
+
+  it("prints every budget and its ceiling whether or not any is over", () => {
+    const body = budgetReportBody(AT_CEILING, { measured_for: "2026-09-09" });
+    for (const name of QUALITY_BUDGET_NAMES) assert.ok(body.includes(`| \`${name}\` |`), `${name} is missing`);
+    assert.match(body, /is at or under its ceiling/);
+  });
+
+  it("names the budgets this run could not measure, so a silent gap does not read as a pass", () => {
+    const measurements = AT_CEILING.filter(m => !m.name.startsWith("faq_"));
+    const body = budgetReportBody(measurements, { measured_for: "2026-09-09" });
+    assert.match(body, /Not measured by this run: `faq_answers`, `faq_answers_stating_a_figure`, `faq_answers_with_a_digit_but_no_figure`\./);
+  });
+
+  it("leaves the three counts a data run may raise out of the overrun, because a run raises them by doing its job", () => {
+    assert.deepStrictEqual(overBudget(over("records_with_superseded_terms", 5)), []);
+    assert.deepStrictEqual(overBudget(over("stale_fact_pages", 5)).map(m => m.name), ["stale_fact_pages"]);
+  });
+
+  it("drops a budget nothing measured rather than reading it as zero", () => {
+    const budgets = Object.fromEntries(QUALITY_BUDGET_NAMES.map(n => [n, 5])) as Record<string, number>;
+    const measurements = measurementsFrom(budgets as never, { stale_fact_pages: 9 });
+    assert.deepStrictEqual(measurements.map(m => m.name), ["stale_fact_pages"]);
+    assert.deepStrictEqual(overBudget(measurements).map(m => m.measured), [9]);
+  });
+});
+
+describe("#1327 the reporter measures the data the site ships", () => {
+  it("reads every budget in the file, and none of them decides its exit status", () => {
+    const printed = execFileSync("node", [REPORTER, "--json"], { cwd: REPO, encoding: "utf-8" });
+    const report = JSON.parse(printed);
+    assert.strictEqual(report.measured_for, utcToday());
+    for (const name of QUALITY_BUDGET_NAMES) {
+      assert.ok(typeof report.measured[name] === "number", `${name} was not measured`);
+      assert.strictEqual(report.budgets[name], readQualityBudgets().budgets[name]);
+    }
+  });
+
+  it("leaves the three FAQ counts unmeasured when it is told not to boot a server", () => {
+    const printed = execFileSync("node", [REPORTER, "--json", "--skip-faq"], { cwd: REPO, encoding: "utf-8" });
+    const report = JSON.parse(printed);
+    assert.strictEqual(report.measured.faq_answers, undefined);
+    assert.ok(typeof report.measured.stale_fact_pages === "number");
+  });
+
+  it("refuses to report a zero it got from a server that answered nothing", () => {
+    const dir = mkdtempSync(path.join(tmpdir(), "budget-report-"));
+    try {
+      const register = path.join(dir, "page-reviews.json");
+      writeFileSync(register, JSON.stringify({
+        version: 1,
+        pages: Array.from({ length: 40 }, (_, i) => ({
+          path: `/a-page-that-does-not-exist-${i}`, published: "2026-04-03", tier: "A",
+        })),
+      }));
+      try {
+        execFileSync("node", [REPORTER], {
+          cwd: REPO,
+          encoding: "utf-8",
+          stdio: "pipe",
+          env: { ...process.env, AGENTDEALS_PAGE_REVIEWS_PATH: register },
+        });
+        assert.fail("a register of pages that serve no FAQ was reported as a measurement of zero");
+      } catch (err: any) {
+        assert.strictEqual(err.status, 2);
+        assert.match(err.stderr, /served a structured FAQ, under a floor/);
+      }
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("writes a body an announcer can post", () => {
+    const dir = mkdtempSync(path.join(tmpdir(), "budget-report-"));
+    try {
+      const file = path.join(dir, "body.md");
+      execFileSync("node", [REPORTER, "--skip-faq", "--body", file], { cwd: REPO, encoding: "utf-8" });
+      const body = readFileSync(file, "utf-8");
+      assert.ok(body.includes(`<!-- ${BUDGET_REPORT_MARKER} -->`), body);
+      assertPopulationFloor(body.length, 400, "characters of issue body the reporter wrote");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("#1327 the three FAQ counts are measured from what a page serves", () => {
+  const page = (...answers: string[]) =>
+    `<script type="application/ld+json">${JSON.stringify({
+      "@type": "FAQPage",
+      mainEntity: answers.map((text, i) => ({ "@type": "Question", name: `q${i}`, acceptedAnswer: { "@type": "Answer", text } })),
+    })}</script>`;
+
+  it("reads the answers out of a served FAQ block", () => {
+    const found = faqAnswersIn("/p", page("Vercel Pro starts at $20/month.", "We index 54 services."));
+    assert.deepStrictEqual(found.map(a => a.path), ["/p", "/p"]);
+    assert.deepStrictEqual(found.map(a => a.question), ["q0", "q1"]);
+  });
+
+  it("reads nothing out of structured data that is not an FAQ, however like one it is shaped", () => {
+    const shapedLikeOne = `<script type="application/ld+json">${JSON.stringify({
+      "@type": "ItemList",
+      mainEntity: [{ "@type": "Question", name: "q", acceptedAnswer: { "@type": "Answer", text: "$20/month." } }],
+    })}</script>`;
+    assert.deepStrictEqual(faqAnswersIn("/p", shapedLikeOne), []);
+    assert.deepStrictEqual(faqAnswersIn("/p", `<script type="application/ld+json">{"@type":"Article"}</script>`), []);
+  });
+
+  it("counts a figure, a number the rule does not read as one, and neither", () => {
+    const answers = faqAnswersIn(
+      "/p",
+      page("Vercel Pro starts at $20/month.", "We index 54 services.", "It depends on your stack."),
+    );
+    assert.deepStrictEqual(faqAnswerCounts(answers), {
+      faq_answers: 3,
+      faq_answers_stating_a_figure: 1,
+      faq_answers_with_a_digit_but_no_figure: 1,
+    });
+  });
+
+  it("names an answer carrying a digit the figure rule did not claim", () => {
+    assert.ok(namesADigitButNoFigure("We index 54 services."));
+    assert.ok(!namesADigitButNoFigure("Vercel Pro starts at $20/month."));
+    assert.ok(!namesADigitButNoFigure("It depends on your stack."));
+  });
+});
+
+describe("#1327 the announcer refuses a body it cannot find again", () => {
+  function announce(body: string, over: string): { status: number; output: string } {
+    const dir = mkdtempSync(path.join(tmpdir(), "budget-announce-"));
+    try {
+      const file = path.join(dir, "body.md");
+      writeFileSync(file, body);
+      try {
+        const output = execFileSync("bash", [ANNOUNCER, file, over], { cwd: REPO, encoding: "utf-8", stdio: "pipe" });
+        return { status: 0, output };
+      } catch (err: any) {
+        return { status: err.status, output: `${err.stdout ?? ""}${err.stderr ?? ""}` };
+      }
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  }
+
+  it("refuses a body with no marker, because the next run would open a second issue", () => {
+    const refused = announce("a budget went over\n", "true");
+    assert.strictEqual(refused.status, 2);
+    assert.match(refused.output, new RegExp(BUDGET_REPORT_MARKER));
+  });
+
+  it("refuses an empty body rather than opening an empty issue", () => {
+    assert.strictEqual(announce("", "true").status, 2);
+  });
+
+  it("refuses an overrun flag that is neither true nor false", () => {
+    const refused = announce(`body\n<!-- ${BUDGET_REPORT_MARKER} -->\n`, "maybe");
+    assert.strictEqual(refused.status, 2);
+    assert.match(refused.output, /must be true or false/);
+  });
+
+  it("looks the issue up by the literal marker rather than by a search over its words", () => {
+    const source = readFileSync(ANNOUNCER, "utf-8");
+    assert.doesNotMatch(
+      source,
+      /gh issue list[^\n]*--search/,
+      "a marker passed to --search is split into words, so any open issue holding them silences this"
+    );
+    assert.match(source, /--jq[^\n]*contains\(/);
+  });
+});

--- a/test/stale-page-facts.test.ts
+++ b/test/stale-page-facts.test.ts
@@ -1,16 +1,23 @@
 import { describe, it } from "node:test";
 import assert from "node:assert";
-import { readFileSync } from "node:fs";
+import { readFileSync, readdirSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+import { assertPopulationFloor } from "./population-floor.ts";
 import {
   QUALITY_BUDGET_NAMES, STALE_FACT_PAGES_BASELINE, UNSOURCED_TIER_A_BASELINE, factsOutdatedBy,
   newestChangeBySlug, parsePageReviews, parseQualityBudgets, qualityBudgetsPath, readQualityBudgets,
-  reviewStatus, serializeQualityBudgets, staleFactPages, staleFactViolations, unsourcedTierAPaths,
+  dateModifiedFor, reviewStatus, serializeQualityBudgets, staleFactPages, staleFactViolations,
+  unsourcedTierAPaths,
   utcToday, vendorsStatedBy,
   type PageReviewRecord,
 } from "../src/page-reviews.ts";
 import { toSlug } from "../dist/vendor-slug.js";
+import {
+  A_BUDGET_PASSED_IN, A_BUDGET_REACHED_THROUGH_A_DEFAULT, CEILINGS_A_DATA_RUN_RAISES_IN_THE_SAME_COMMIT,
+  CEILINGS_ON_A_BUDGET_THAT_HOLDS_A_COMMIT, MEASUREMENTS_COMPARED_TO_EACH_OTHER, RATCHETS, WIRING_CHECKS,
+  budgetsHeldAgainstAMeasurement, callsThatLetTheBudgetDefault, ceilingsHeldAgainstABudget,
+} from "./budget-assertions.ts";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const REPO = path.join(__dirname, "..");
@@ -162,12 +169,11 @@ describe("the number of pages resting on a record that has moved under them only
 });
 
 describe("the register the site ships", () => {
-  it("holds a cohort the baseline matches exactly", () => {
-    const stale = staleFactPages(REGISTRY.pages, TODAY, changeDateFor);
-    assert.deepStrictEqual(
-      staleFactViolations(REGISTRY.pages, TODAY, changeDateFor).map(v => v.problem),
-      [],
-      `${stale.length} pages state a vendor fact whose record has moved since the page was last read; STALE_FACT_PAGES_BASELINE is ${STALE_FACT_PAGES_BASELINE}`
+  it("names a cohort large enough for the checks below to read", () => {
+    assertPopulationFloor(
+      staleFactPages(REGISTRY.pages, TODAY, changeDateFor).length,
+      20,
+      "registered pages stating a vendor fact recorded since the page was last read"
     );
   });
 
@@ -236,6 +242,52 @@ describe("a reviewer's note survives a regeneration of what is derived", () => {
   });
 });
 
+describe("#1327 a review that found defects does not restart the staleness clock", () => {
+  const reviewed = (outcome: "pass" | "fail" | null) =>
+    page({ path: "/p", published: "2026-04-03", reviewed_at: "2026-08-27", review_outcome: outcome, vendors_asserted: ["neon"] });
+
+  it("starts the clock at publication where the review found defects, and at the review where it did not", () => {
+    assert.strictEqual(reviewStatus(reviewed("fail"), "2026-09-02").clock_starts, "2026-04-03");
+    assert.strictEqual(reviewStatus(reviewed("pass"), "2026-09-02").clock_starts, "2026-08-27");
+    assert.strictEqual(reviewStatus(reviewed(null), "2026-09-02").clock_starts, "2026-08-27");
+  });
+
+  it("gives the page the same date its structured copy publishes, from one rule", () => {
+    for (const outcome of ["fail", "pass", null] as const) {
+      const record = reviewed(outcome);
+      assert.strictEqual(
+        dateModifiedFor(record, "2026-01-01", "2026-09-02"),
+        reviewStatus(record, "2026-09-02").clock_starts,
+        `${outcome} publishes a date the staleness clock disagrees with`
+      );
+    }
+  });
+
+  it("still measures the review cadence from the day the page was last read", () => {
+    const failed = reviewStatus(reviewed("fail"), "2026-09-02");
+    assert.strictEqual(failed.reviewed_at, "2026-08-27");
+    assert.strictEqual(failed.days_since, 6);
+    assert.strictEqual(failed.state, "current");
+  });
+
+  it("counts a fact the review read past, where a passing review would have cleared it", () => {
+    const recordedBeforeTheReview = () => "2026-08-01";
+    assert.deepStrictEqual(
+      staleFactPages([reviewed("fail")], "2026-09-02", recordedBeforeTheReview).map(p => p.path),
+      ["/p"]
+    );
+    assert.deepStrictEqual(staleFactPages([reviewed("pass")], "2026-09-02", recordedBeforeTheReview), []);
+  });
+
+  it("puts the six pages the shipped register records a failed review on into the cohort", () => {
+    const failed = REGISTRY.pages.filter(p => p.reviewed_at !== null && p.review_outcome === "fail");
+    assert.ok(failed.length >= 5, `only ${failed.length} pages on the register record a failed review`);
+    for (const p of failed) {
+      assert.strictEqual(reviewStatus(p, TODAY).clock_starts, p.published, `${p.path} restarted its clock on a failed review`);
+    }
+  });
+});
+
 describe("#1321 the budgets live where whoever earns a lower one can write them", () => {
   const BUDGETS = path.join(REPO, "data", "quality_budgets.json");
 
@@ -280,8 +332,59 @@ describe("#1321 the budgets live where whoever earns a lower one can write them"
   });
 
   it("measures both budgets against the register the site ships", () => {
-    assert.strictEqual(staleFactPages(REGISTRY.pages, TODAY, changeDateFor).length, STALE_FACT_PAGES_BASELINE);
-    assert.strictEqual(unsourcedTierAPaths(REGISTRY.pages).length, UNSOURCED_TIER_A_BASELINE);
+    assertPopulationFloor(
+      staleFactPages(REGISTRY.pages, TODAY, changeDateFor).length,
+      20,
+      "pages in the stale-fact cohort measured from the shipped register"
+    );
+    assertPopulationFloor(
+      unsourcedTierAPaths(REGISTRY.pages).length,
+      10,
+      "tier-A pages asserting a vendor fact that reaches no record"
+    );
+  });
+});
+
+describe("#1327 no budget decides whether the suite passes", () => {
+  it("reads an assertion that compares one budget to another as the wiring check it is", () => {
+    assert.deepStrictEqual(budgetsHeldAgainstAMeasurement(WIRING_CHECKS), []);
+  });
+
+  it("reads a comparison between two measurements as no business of this check", () => {
+    assert.deepStrictEqual(budgetsHeldAgainstAMeasurement(MEASUREMENTS_COMPARED_TO_EACH_OTHER), []);
+  });
+
+  it("reads an assertion that holds a measurement to a budget as one, however the measurement is spelled", () => {
+    assert.deepStrictEqual(budgetsHeldAgainstAMeasurement(RATCHETS).map(f => f.line), [1, 2, 3]);
+  });
+
+  it("reads a call that lets the budget argument default as one too", () => {
+    assert.deepStrictEqual(callsThatLetTheBudgetDefault(A_BUDGET_REACHED_THROUGH_A_DEFAULT).map(f => f.line), [1, 2]);
+    assert.deepStrictEqual(callsThatLetTheBudgetDefault(A_BUDGET_PASSED_IN), []);
+  });
+
+  it("reads a ceiling on a budget that can hold a data commit, and leaves the three a run raises itself", () => {
+    assert.deepStrictEqual(ceilingsHeldAgainstABudget(CEILINGS_ON_A_BUDGET_THAT_HOLDS_A_COMMIT).map(f => f.line), [2, 3, 4]);
+    assert.deepStrictEqual(ceilingsHeldAgainstABudget(CEILINGS_A_DATA_RUN_RAISES_IN_THE_SAME_COMMIT), []);
+  });
+
+  it("holds no measurement against a budget anywhere in test/", () => {
+    const files = readdirSync(path.join(REPO, "test")).filter(f => f.endsWith(".test.ts"));
+    assertPopulationFloor(files.length, 100, "test files read for an assertion holding a budget");
+    const held: string[] = [];
+    for (const file of files) {
+      const source = readFileSync(path.join(REPO, "test", file), "utf-8");
+      for (const found of budgetsHeldAgainstAMeasurement(source)) held.push(`test/${file}:${found.line} ${found.text}`);
+      for (const found of callsThatLetTheBudgetDefault(source)) held.push(`test/${file}:${found.line} ${found.text}`);
+      for (const found of ceilingsHeldAgainstABudget(source)) held.push(`test/${file}:${found.line} ${found.text}`);
+    }
+    assert.deepStrictEqual(
+      held,
+      [],
+      "a budget counts editorial debt nobody has read yet. Asserting one makes the suite red on a day the reading " +
+        "queue got deeper, which is not a day anything we publish became wrong. Report it instead — see " +
+        "scripts/report-quality-budgets.js."
+    );
   });
 });
 
@@ -312,37 +415,37 @@ describe("#1321 a budget follows its measurement down and never up", () => {
     assert.deepStrictEqual(over.map(o => o.name), ["unsourced_tier_a"]);
   });
 
-  it("measures what the shipped budgets already hold, so a run at rest writes nothing", async () => {
+  it("raises nothing on the data the site ships, however far a measurement has run ahead", async () => {
     const { ratchet, measureBudgets } = await import("../scripts/ratchet-quality-budgets.js");
     const { aDataRunMayRaise } = await import("../dist/page-reviews.js");
-    const { lowered, raised, over } = ratchet(readQualityBudgets().budgets, measureBudgets(TODAY));
-    assert.deepStrictEqual(lowered.filter(l => !aDataRunMayRaise(l.name)), []);
+    const budgets = readQualityBudgets().budgets;
+    const measured = measureBudgets(TODAY);
+    const { next, raised } = ratchet(budgets, measured);
+    for (const name of QUALITY_BUDGET_NAMES) {
+      if (aDataRunMayRaise(name)) continue;
+      assert.ok(next[name] <= budgets[name], `${name} rose from ${budgets[name]} to ${next[name]}`);
+    }
     assert.deepStrictEqual(raised.filter(r => !aDataRunMayRaise(r.name)), []);
-    assert.deepStrictEqual(over, []);
+    assert.ok(Object.keys(measured).length > 0, "nothing was measured, so nothing was compared");
   });
 });
 
 describe("#1321 the FAQ counts are budgets too, and they live in the same file", () => {
   it("reads all three from data rather than from the code", async () => {
     const { FAQ_BASELINE } = await import("../dist/faq-provenance.js");
-    const shipped = readQualityBudgets().budgets;
-    assert.strictEqual(FAQ_BASELINE.answers, shipped.faq_answers);
-    assert.strictEqual(FAQ_BASELINE.stating_a_figure, shipped.faq_answers_stating_a_figure);
-    assert.strictEqual(FAQ_BASELINE.a_digit_but_no_figure, shipped.faq_answers_with_a_digit_but_no_figure);
+    const budgets = readQualityBudgets().budgets;
+    assert.strictEqual(FAQ_BASELINE.answers, budgets.faq_answers);
+    assert.strictEqual(FAQ_BASELINE.stating_a_figure, budgets.faq_answers_stating_a_figure);
+    assert.strictEqual(FAQ_BASELINE.a_digit_but_no_figure, budgets.faq_answers_with_a_digit_but_no_figure);
   });
 
   it("says plainly that the ratchet cannot lower a budget it does not measure", async () => {
     const { ratchet } = await import("../scripts/ratchet-quality-budgets.js");
-    const budgets = readQualityBudgets().budgets;
-    const { unmeasured, lowered, over } = ratchet(budgets, {
-      stale_fact_pages: 57,
-      unsourced_tier_a: budgets.unsourced_tier_a,
-      uncited_change_records: budgets.uncited_change_records,
-      source_checks_ok_without_quoted_evidence: budgets.source_checks_ok_without_quoted_evidence,
-      records_with_superseded_terms: budgets.records_with_superseded_terms,
-      vendor_pages_withholding_superseded_terms: budgets.vendor_pages_withholding_superseded_terms,
-      ungated_pages_withholding_superseded_terms: budgets.ungated_pages_withholding_superseded_terms,
-    });
+    const budgets = Object.fromEntries(QUALITY_BUDGET_NAMES.map(name => [name, 100]));
+    const measured = Object.fromEntries(
+      QUALITY_BUDGET_NAMES.filter(name => !name.startsWith("faq_")).map(name => [name, 100]),
+    );
+    const { unmeasured, lowered, over } = ratchet(budgets, measured);
     assert.deepStrictEqual(unmeasured, [
       "faq_answers",
       "faq_answers_stating_a_figure",

--- a/test/uncited-change-records.test.ts
+++ b/test/uncited-change-records.test.ts
@@ -22,7 +22,6 @@ import {
   vendorRiskAssessment,
 } from "../dist/data.js";
 import { vendorBadge, vendorVerdictSentence, statesRiskCause, type VendorVerdictInput } from "../dist/vendor-verdict.js";
-import { qualityBudget } from "../dist/page-reviews.js";
 import { toSlug } from "../dist/vendor-slug.js";
 import { uncitedReport } from "../scripts/uncited-changes.js";
 import type { DealChange } from "../dist/types.js";
@@ -181,16 +180,6 @@ describe("the shipped catalogue", () => {
       withheld.filter(o => o.stability === "stable" || o.stability === "improving").map(o => o.vendor),
       [],
       "a withheld rating still published a favourable stability class",
-    );
-  });
-
-  it("holds no more records citing no source than the budget allows", () => {
-    const budget = qualityBudget("uncited_change_records");
-    const measured = uncitedChangesAgainstBudget(changes).length;
-    assert.ok(
-      measured <= budget,
-      `${measured} change records report a vendor's offer and cite no source, `
-      + `over the budget of ${budget} in data/quality_budgets.json`,
     );
   });
 

--- a/test/vendor-naming.test.ts
+++ b/test/vendor-naming.test.ts
@@ -11,9 +11,9 @@ import {
 } from "../scripts/vendor-naming.js";
 import { priceSignals, MIN_PRICE_SIGNALS } from "../scripts/change-gate.js";
 import { passedOnTheUrlWeAskedFor, passedWithoutRecordingAFinding } from "../dist/source-check.js";
-import { qualityBudget } from "../dist/page-reviews.js";
 import { loadOffers } from "../dist/data.js";
 import { JOINSECRET_OFFERS_PAGE, BREX_REWARDS_PAGE } from "./vendor-page-fixture.ts";
+import { assertPopulationFloor } from "./population-floor.ts";
 
 describe("does the page state terms about THIS vendor", () => {
   describe("a marketplace page saturated with other companies' prices", () => {
@@ -261,12 +261,9 @@ describe("what data/index.json publishes as a passed source check", () => {
     );
   });
 
-  it("holds no more passes that quote nothing from the page than the budget allows", () => {
-    const budget = qualityBudget("source_checks_ok_without_quoted_evidence");
+  it("reads a real population, so the rule above is not passing on an empty catalogue", () => {
     const measured = offers.filter(passedWithoutRecordingAFinding).length;
-    assert.ok(
-      measured <= budget,
-      `${measured} offers pass a source check without quoting the page, over the budget of ${budget} in data/quality_budgets.json`,
-    );
+    assertPopulationFloor(offers.length, 1000, "offers in the catalogue this rule is read against");
+    assert.ok(measured < offers.length, `every one of ${offers.length} offers reads as quoting nothing`);
   });
 });


### PR DESCRIPTION
Refs #1327

Seven counts of editorial debt decided whether `npm test` passed. Each rises when the catalogue is re-verified and falls when somebody reads a page, so red on a pull request stopped distinguishing "this change broke something" from "the reading queue is one page deeper than yesterday".

## What replaces them

`scripts/report-quality-budgets.js` reads all ten budgets, boots a server for the three the suite used to measure, and writes an issue body naming each budget, its ceiling, its measurement and its cohort. `scripts/report-quality-budgets.sh` opens that issue once and edits it thereafter. The daily re-verification runs both after the gate.

`npm run report:budgets` runs it by hand. `--skip-faq` skips the server.

## Criterion 1 — the suite is green with a budget over its ceiling

`node scripts/demo-1327.mjs` halves every budget a data run cannot raise, runs the files that used to hold them, and asks the reporter what it would say:

```
stale_fact_pages 58 → 29 · unsourced_tier_a 22 → 11 · uncited_change_records 98 → 49
source_checks_ok_without_quoted_evidence 508 → 254 · faq_answers 166 → 83
faq_answers_stating_a_figure 77 → 38 · faq_answers_with_a_digit_but_no_figure 41 → 20

ℹ tests 224  ℹ pass 224  ℹ fail 0
7 budgets over ceiling, 7 of them reported, suite green.
```

## Criterion 3 — a ceiling still cannot rise on its own

`ratchet()` raises only the three `QUALITY_BUDGETS_A_DATA_RUN_MAY_RAISE` names, and `raises nothing on the data the site ships, however far a measurement has run ahead` holds every other budget to `next[name] <= budgets[name]` against a live measurement. `stale_fact_pages` moved 57 → 58 by a hand edit carrying its reason.

## Criterion 4 — which assertions moved

Moved out of the suite, in `test/faq-provenance.test.ts`: the answer count, the figure-stating count and the `frozen` count became population floors; the count of answers naming a digit the figure rule does not claim was deleted, since a floor on it would assert we still hold unclassified numbers.

Stayed and still block: `leaves no answer stating a figure without one`, `takes the dates in every clause from the register rather than from the answer`, `says corrections are outstanding on no page whose review is clean`, `holds the structured date of a page whose review found defects at its publication date`, the `moved` half of `only dates an answer whose figures the catalogue cannot move`, `leaves the answers the catalogue does move without a compile date`.

In `test/page-data-provenance.test.ts` the `unsourced_tier_a` equality is gone and its neighbour is restated against the measured population, so "one more than the register holds is refused" is still asserted without pinning the number. The three assertions that fire on what a page publishes are untouched.

## A guard, so the pattern cannot come back quietly

`test/budget-assertions.ts` reads every file under `test/` and refuses three shapes: a budget compared to anything that is not another budget, a call that reaches a budget through a defaulted argument, and a ceiling on a budget a data run cannot raise. It found a sixth site the issue did not name.

## The staleness clock

A review recording `review_outcome: "fail"` restarted the clock, so finding four errors on a page improved `stale_fact_pages` by more than fixing them would. `dateModifiedFor` already had the rule right; `reviewStatus` now carries it and `dateModifiedFor` reads it, so the two cannot drift again. Review cadence still measures from the day the page was last read, so no page changes state and `/api/page-reviews` reports the same totals.

Six pages moved, `/email-comparison-2026` joined the cohort, 338 stale facts became 346.

## Verification

- Suite 4,652 of 4,652. `tsc --noEmit` clean.
- `npm run mutate:1327`: 16 mutants, 16 killed.
- `npm run report:budgets` against the shipped data, and the announcer run end to end against the live repository.
- The workflow file parsed and its step order read back.