### PR TITLE
One function decides a published risk level, and all seven sites call it (#1486)

### DIFF
--- a/data/page-reviews.json
+++ b/data/page-reviews.json
@@ -389,10 +389,10 @@
       "reviewer": null,
       "review_outcome": null,
       "review_note": null,
-      "reads_index": false,
+      "reads_index": true,
       "reads_changes": true,
-      "data_source": "editorial",
-      "data_source_reason": "a cost calculator: every figure on it is arithmetic on what the reader typed in"
+      "data_source": "catalogue",
+      "data_source_reason": "the risk level beside each vendor is the level the catalogue publishes for that record, withholding included"
     },
     {
       "path": "/ci-cd-pricing",
@@ -763,7 +763,7 @@
       "reviewed_at": "2026-09-05",
       "reviewer": "coder",
       "review_outcome": "fail",
-      "review_note": "Read against resend.com/pricing, mailersend.com/pricing and mailerlite.com/pricing on 2026-09-05, after a Resend record dated 2026-09-05 moved under the 2026-09-04 review. Resend: 3,000 emails/month and the 100/day cap hold; custom domains on Free is 3, not the 1 the page published, and the catalogue record carried the same 1. MailerSend: the Free plan is 500 emails/month with 1 domain, 10 templates, 5 seats, 1,000 daily API requests and 1-day activity retention, and the 14-day Professional trial carries the same 500 \u2014 so the 3,000 the page published on three surfaces was not the trial figure either. Hobby is $7.00/month monthly, $5.60 billed yearly, for 5,000 emails. MailerLite: the Free plan is 250 subscribers and 2,500 monthly emails, below both the 1,000/12,000 the page published and the 500/12,000 in our own record; the record is the stale side and no change record holds 250. Corrected on this page: the MailerSend table row, section and 3K cost-trap cell, the MailerLite table row and section, the Resend section, and the transactional-email answer on /email-service-alternatives. Not verified in this pass: Amazon SES, Brevo, Mailtrap, Loops, Mailjet, Postmark, Maileroo, EmailOctopus, Buttondown, Substack, SMTP2GO, EmailLabs.io and the 10K/50K/100K/500K rows of the cost-trap table.",
+      "review_note": "Read against resend.com/pricing, mailersend.com/pricing and mailerlite.com/pricing on 2026-09-05, after a Resend record dated 2026-09-05 moved under the 2026-09-04 review. Resend: 3,000 emails/month and the 100/day cap hold; custom domains on Free is 3, not the 1 the page published, and the catalogue record carried the same 1. MailerSend: the Free plan is 500 emails/month with 1 domain, 10 templates, 5 seats, 1,000 daily API requests and 1-day activity retention, and the 14-day Professional trial carries the same 500 — so the 3,000 the page published on three surfaces was not the trial figure either. Hobby is $7.00/month monthly, $5.60 billed yearly, for 5,000 emails. MailerLite: the Free plan is 250 subscribers and 2,500 monthly emails, below both the 1,000/12,000 the page published and the 500/12,000 in our own record; the record is the stale side and no change record holds 250. Corrected on this page: the MailerSend table row, section and 3K cost-trap cell, the MailerLite table row and section, the Resend section, and the transactional-email answer on /email-service-alternatives. Not verified in this pass: Amazon SES, Brevo, Mailtrap, Loops, Mailjet, Postmark, Maileroo, EmailOctopus, Buttondown, Substack, SMTP2GO, EmailLabs.io and the 10K/50K/100K/500K rows of the cost-trap table.",
       "reads_index": true,
       "reads_changes": true,
       "data_source": "catalogue",

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "mutate:1481": "node scripts/mutate-1481.mjs",
     "mutate:1434": "node scripts/mutate-1434.mjs",
     "mutate:1486": "node scripts/mutate-1486.mjs",
+    "mutate:1486-round2": "node scripts/mutate-1486-round2.mjs",
     "test:gated": "node --test --test-concurrency 1 --test-reporter=spec --test-reporter-destination=stdout --test-reporter=./scripts/reporters/failing-test-files.js --test-reporter-destination=$GATE_FAILING_FILES test/**/*.test.ts",
     "ratchet:budgets": "node scripts/ratchet-quality-budgets.js --lower",
     "lastmod:pages": "node scripts/update-page-lastmod.js",

--- a/scripts/mutate-1486-round2.mjs
+++ b/scripts/mutate-1486-round2.mjs
@@ -1,0 +1,110 @@
+import { readFileSync, writeFileSync } from "node:fs";
+import { execFileSync } from "node:child_process";
+
+const SUITE = [
+  "test/one-published-risk.test.ts",
+  "test/audit-stack.test.ts",
+  "test/stacks.test.ts",
+  "test/enrich.test.ts",
+  "test/vendor-verdict.test.ts",
+];
+
+const MUTANTS = [
+  ["the-gate-stops-withholding-a-level", "src/data.ts",
+    "    gate !== null ||\n    assessment.rating_withheld !== null ||",
+    "    assessment.rating_withheld !== null ||"],
+
+  ["an-uncited-record-set-stops-withholding-a-level", "src/data.ts",
+    "    gate !== null ||\n    assessment.rating_withheld !== null ||",
+    "    gate !== null ||"],
+
+  ["an-unread-source-page-stops-withholding-a-level", "src/data.ts",
+    "    (cannotVouchForLevel(offer, link_unreachable) && assessment.level === \"stable\");",
+    "    false;"],
+
+  ["an-adverse-level-is-withheld-along-with-a-favourable-one", "src/data.ts",
+    "    (cannotVouchForLevel(offer, link_unreachable) && assessment.level === \"stable\");",
+    "    cannotVouchForLevel(offer, link_unreachable);"],
+
+  ["the-withheld-level-carries-no-statement", "src/data.ts",
+    "export function levelWithheldStatement(vendor: string, risk: PublishedRisk): string | null {\n  if (risk.risk_level !== null) return null;",
+    "export function levelWithheldStatement(vendor: string, risk: PublishedRisk): string | null {\n  if (risk.risk_level !== null) return null;\n  if (risk.gate === null) return null;"],
+
+  ["the-audit-derives-its-own-level", "src/data.ts",
+    "    const published = publishedRisk(offer, vendorChanges);\n    const riskLevel = published.risk_level;",
+    "    const published = publishedRisk(offer, vendorChanges);\n    const riskLevel = vendorRiskAssessment(vendorChanges).level;"],
+
+  ["the-audit-carries-no-gate", "src/data.ts",
+    "      gate: published.gate,\n      level_withheld_because: levelWithheldStatement(offer.vendor, published),",
+    "      gate: null,\n      level_withheld_because: levelWithheldStatement(offer.vendor, published),"],
+
+  ["a-swap-target-is-picked-without-the-withholding-rules", "src/data.ts",
+    "      return publishedRisk(o, oChanges).risk_level === \"stable\";",
+    "      return vendorRiskAssessment(oChanges).level === \"stable\";"],
+
+  ["a-withheld-vendor-counts-as-a-risk-found", "src/data.ts",
+    "    if (riskLevel === \"risky\" || riskLevel === \"caution\") risksFound++;",
+    "    if (riskLevel !== \"stable\") risksFound++;"],
+
+  ["the-stack-candidate-derives-its-own-level", "src/stacks.ts",
+    "    risk_level: published.risk_level,",
+    "    risk_level: published.history_level,"],
+
+  ["the-vendor-page-substitutes-stable-for-a-withheld-level", "src/vendor-verdict.ts",
+    "  if (level === null) return null;\n  return level === \"stable\" || cause ? level : \"stable\";",
+    "  if (level === null) return \"stable\";\n  return level === \"stable\" || cause ? level : \"stable\";"],
+
+  ["a-stack-of-nothing-we-rate-earns-a-letter", "src/stack-grade.ts",
+    "  if (rated === 0) {",
+    "  if (found < 0) {"],
+
+  ["the-grade-divides-by-the-whole-stack-again", "src/stack-grade.ts",
+    "  var riskyPct = counts.risky / rated;\n  var cautionPct = counts.caution / rated;",
+    "  var riskyPct = counts.risky / found;\n  var cautionPct = counts.caution / found;"],
+
+  ["a-withheld-vendor-counts-as-stable", "src/stack-grade.ts",
+    "  var rated = found - counts.withheld;",
+    "  var rated = found;"],
+
+  ["the-letter-travels-without-its-denominator", "src/stack-grade.ts",
+    "denominator: \"Grade based on \" + rated + \" of \" + servicesEntered + \" services.\" };",
+    "denominator: \"\" };"],
+
+  ["a-partial-stack-claims-every-service-is-stable", "src/stack-grade.ts",
+    "    description = partial ? \"Every rated service is stable, with no recent pricing concerns.\" : \"All services are stable with no recent pricing concerns.\";",
+    "    description = \"All services are stable with no recent pricing concerns.\";"],
+];
+
+function run(cmd, args) {
+  try {
+    execFileSync(cmd, args, { stdio: "pipe", encoding: "utf-8" });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+const survivors = [];
+const uncompiled = [];
+const skipped = [];
+for (const [name, file, from, to] of MUTANTS) {
+  const original = readFileSync(file, "utf-8");
+  if (!original.includes(from)) {
+    console.log(`SKIP  ${name} — the line it mutates is not in ${file}`);
+    skipped.push(name);
+    continue;
+  }
+  writeFileSync(file, original.replace(from, to));
+  const built = run("npm", ["run", "build"]);
+  const green = built && run("node", ["--test", "--test-concurrency", "1", ...SUITE]);
+  writeFileSync(file, original);
+  if (!built) uncompiled.push(name);
+  console.log(`${green ? "SURVIVED" : built ? "killed  " : "DID NOT COMPILE"}  ${name}`);
+  if (green) survivors.push(name);
+}
+run("npm", ["run", "build"]);
+const killed = MUTANTS.length - survivors.length - uncompiled.length - skipped.length;
+console.log(`\n${killed}/${MUTANTS.length} killed`);
+if (survivors.length > 0) console.log("survivors:", survivors.join(", "));
+if (uncompiled.length > 0) console.log("did not compile:", uncompiled.join(", "));
+if (skipped.length > 0) console.log("skipped — target string moved, so these scored nothing:", skipped.join(", "));

--- a/src/data.ts
+++ b/src/data.ts
@@ -444,16 +444,12 @@ export function enrichOffers(offers: Offer[]): EnrichedOffer[] {
       }
     }
 
-    const assessment = vendorRiskAssessment(vendorAllChangesList.get(key) ?? []);
-    const link_unreachable = unreachableNoticeForUrl(offer.url, now.getTime());
-    const rating_withheld = assessment.rating_withheld;
-    const risk_level =
-      rating_withheld || (cannotVouchForLevel(offer, link_unreachable) && assessment.level === "stable")
-        ? null
-        : assessment.level;
-    const risk_cause = assessment.cause
-      ? riskCauseOf(assessment.cause)
-      : null;
+    const { risk_level, risk_cause, rating_withheld, link_unreachable, gate } = publishedRisk(
+      offer,
+      vendorAllChangesList.get(key) ?? [],
+      servedOn,
+      now.getTime(),
+    );
 
     const stability = withheldStability(
       link_unreachable,
@@ -467,7 +463,7 @@ export function enrichOffers(offers: Offer[]): EnrichedOffer[] {
 
     const terms_superseded = supersededTermsRecordFor(offer, vendorAllChangesList.get(key) ?? []);
 
-    const enriched = { ...offer, recent_change, expires_soon, risk_level, risk_cause, rating_withheld, stability, days_since_verified, link_unreachable, gate: gateFor(offer, servedOn), terms_superseded };
+    const enriched = { ...offer, recent_change, expires_soon, risk_level, risk_cause, rating_withheld, stability, days_since_verified, link_unreachable, gate, terms_superseded };
     return stripReferrerValue(enriched);
   });
 }
@@ -877,8 +873,54 @@ export function riskCauseOf(cause: DealChange | null | undefined): RiskCause | n
   };
 }
 
-export function vendorRiskLevel(vendorChanges: DealChange[]): "stable" | "caution" | "risky" {
-  return vendorRiskAssessment(vendorChanges).level;
+export interface PublishedRisk {
+  risk_level: "stable" | "caution" | "risky" | null;
+  history_level: "stable" | "caution" | "risky";
+  risk_cause: RiskCause | null;
+  cause: DealChange | null;
+  rating_withheld: RatingWithheld | null;
+  link_unreachable: LinkUnreachable | null;
+  source_check: SourceCheck | null;
+  gate: Gate | null;
+}
+
+export function publishedRisk(
+  offer: Offer,
+  vendorChanges: DealChange[],
+  servedOn: string = utcDate(),
+  nowMs: number = Date.now(),
+): PublishedRisk {
+  const assessment = vendorRiskAssessment(vendorChanges, nowMs);
+  const link_unreachable = unreachableNoticeForUrl(offer.url, nowMs);
+  const gate = gateFor(offer, servedOn);
+  const withheld =
+    gate !== null ||
+    assessment.rating_withheld !== null ||
+    (cannotVouchForLevel(offer, link_unreachable) && assessment.level === "stable");
+  return {
+    risk_level: withheld ? null : assessment.level,
+    history_level: assessment.level,
+    risk_cause: riskCauseOf(assessment.cause),
+    cause: assessment.cause,
+    rating_withheld: assessment.rating_withheld,
+    link_unreachable,
+    source_check: offer.source_check ?? null,
+    gate,
+  };
+}
+
+export function vendorNotIndexedSentence(vendor: string): string {
+  return `${vendor} is not in our index, so we hold no record to rate.`;
+}
+
+export function levelWithheldStatement(vendor: string, risk: PublishedRisk): string | null {
+  if (risk.risk_level !== null) return null;
+  if (risk.gate) return gateRiskSummary(risk.gate);
+  if (risk.rating_withheld) return ratingWithheldForNoSourceSentence(vendor);
+  const reason = levelWithheldReason({ source_check: risk.source_check ?? undefined }, risk.link_unreachable);
+  if (!reason) return null;
+  const since = risk.link_unreachable?.last_reachable ? ` since ${risk.link_unreachable.last_reachable}` : "";
+  return withheldLevelSentence(reason, vendor, since);
 }
 
 export function checkVendorRisk(
@@ -896,14 +938,15 @@ export function checkVendorRisk(
 
   const offer = match.offer;
   const matchNotice = vendorMatchNotice(vendorName, match)!;
-  const gate = gateForOffer(offer);
   const allChanges = loadDealChanges();
   const vendorChanges = allChanges
     .filter((c) => c.vendor.toLowerCase() === offer.vendor.toLowerCase())
     .sort((a, b) => b.date.localeCompare(a.date));
 
+  const published = publishedRisk(offer, vendorChanges);
+  const gate = published.gate;
   const assessment = vendorRiskAssessment(vendorChanges);
-  const linkUnreachable = unreachableNoticeForUrl(offer.url);
+  const linkUnreachable = published.link_unreachable;
   const riskLevel = assessment.level;
 
   const verifiedDate = new Date(offer.verifiedDate);
@@ -925,15 +968,13 @@ export function checkVendorRisk(
     category: e.offer.category,
     tier: e.offer.tier,
     ...(() => {
-      const a = vendorRiskAssessment(allChanges.filter((c) => c.vendor.toLowerCase() === e.offer.vendor.toLowerCase()));
-      const unreachable = unreachableNoticeForUrl(e.offer.url);
-      const altGate = gateForOffer(e.offer);
+      const alt = publishedRisk(e.offer, allChanges.filter((c) => c.vendor.toLowerCase() === e.offer.vendor.toLowerCase()));
       return {
-        risk_level: altGate || a.rating_withheld || (cannotVouchForLevel(e.offer, unreachable) && a.level === "stable") ? null : a.level,
-        risk_cause: riskCauseOf(a.cause),
-        rating_withheld: a.rating_withheld,
-        link_unreachable: unreachable,
-        gate: altGate,
+        risk_level: alt.risk_level,
+        risk_cause: alt.risk_cause,
+        rating_withheld: alt.rating_withheld,
+        link_unreachable: alt.link_unreachable,
+        gate: alt.gate,
       };
     })(),
     demerits: e.demerits.map((d) => ({ code: d.code, points: d.points, reason: d.reason })),
@@ -972,11 +1013,11 @@ export function checkVendorRisk(
       vendor: offer.vendor,
       vendor_match: matchNotice,
       category: offer.category,
-      risk_level: gate || assessment.rating_withheld || (cannotVouchForLevel(offer, linkUnreachable) && riskLevel === "stable") ? null : riskLevel,
+      risk_level: published.risk_level,
       risk_cause: riskCauseOf(cause),
-      rating_withheld: assessment.rating_withheld,
+      rating_withheld: published.rating_withheld,
       link_unreachable: linkUnreachable,
-      source_check: offer.source_check ?? null,
+      source_check: published.source_check,
       gate,
       free_tier_longevity_days: gate && GATES_WITHOUT_A_LONGEVITY_REFERENT.has(gate.code) ? null : longevityDays,
       changes: vendorChanges,
@@ -997,7 +1038,13 @@ export interface AuditServiceResult {
   status: "found" | "not_found";
   category?: string;
   tier?: string;
-  risk_level?: "stable" | "caution" | "risky";
+  risk_level?: "stable" | "caution" | "risky" | null;
+  risk_cause?: RiskCause | null;
+  rating_withheld?: RatingWithheld | null;
+  link_unreachable?: LinkUnreachable | null;
+  source_check?: SourceCheck | null;
+  gate?: Gate | null;
+  level_withheld_because?: string | null;
   recent_changes?: DealChange[];
   cheaper_alternative?: { vendor: string; tier: string; category: string };
   suggestions?: string[];
@@ -1046,19 +1093,19 @@ export function auditStack(serviceNames: string[]): AuditResult {
       .filter((c) => c.vendor.toLowerCase() === offer.vendor.toLowerCase())
       .sort((a, b) => b.date.localeCompare(a.date));
 
-    const riskLevel = vendorRiskLevel(vendorChanges);
-    if (riskLevel !== "stable") risksFound++;
+    const published = publishedRisk(offer, vendorChanges);
+    const riskLevel = published.risk_level;
+    if (riskLevel === "risky" || riskLevel === "caution") risksFound++;
 
     let cheaperAlternative: AuditServiceResult["cheaper_alternative"];
     const sameCat = offers.filter(
       (o) => o.category === offer.category && o.vendor !== offer.vendor && o.tier.toLowerCase().includes("free")
     );
-    if (sameCat.length > 0) {
-      const stableAlt = sameCat.find((o) => {
-        const oChanges = allChanges.filter((c) => c.vendor.toLowerCase() === o.vendor.toLowerCase());
-        return vendorRiskLevel(oChanges) === "stable";
-      });
-      const alt = stableAlt || sameCat[0];
+    const alt = sameCat.find((o) => {
+      const oChanges = allChanges.filter((c) => c.vendor.toLowerCase() === o.vendor.toLowerCase());
+      return publishedRisk(o, oChanges).risk_level === "stable";
+    });
+    if (alt) {
       cheaperAlternative = { vendor: alt.vendor, tier: alt.tier, category: alt.category };
       savingsOpportunities++;
     }
@@ -1069,6 +1116,12 @@ export function auditStack(serviceNames: string[]): AuditResult {
       category: offer.category,
       tier: offer.tier,
       risk_level: riskLevel,
+      risk_cause: published.risk_cause,
+      rating_withheld: published.rating_withheld,
+      link_unreachable: published.link_unreachable,
+      source_check: published.source_check,
+      gate: published.gate,
+      level_withheld_because: levelWithheldStatement(offer.vendor, published),
       ...(vendorChanges.length > 0 ? { recent_changes: vendorChanges } : {}),
       ...(cheaperAlternative ? { cheaper_alternative: cheaperAlternative } : {}),
     };

--- a/src/openapi.ts
+++ b/src/openapi.ts
@@ -355,10 +355,31 @@ const DOCUMENTED_OPERATIONS: Record<string, Record<string, any>> = {
                 type: "object",
                 properties: {
                   services_analyzed: { type: "number" },
-                  risks_found: { type: "number" },
+                  risks_found: { type: "number", description: "Services carrying a published caution or risky level. A service whose level is withheld is not counted here — it is unrated, not safe (#1486)." },
                   savings_opportunities: { type: "number" },
                   gaps: { type: "array", items: { type: "object" } },
-                  services: { type: "array", items: { type: "object" } },
+                  services: {
+                    type: "array",
+                    items: {
+                      type: "object",
+                      properties: {
+                        vendor: { type: "string" },
+                        status: { type: "string", enum: ["found", "not_found"] },
+                        category: { type: "string" },
+                        tier: { type: "string" },
+                        risk_level: { type: "string", enum: ["stable", "caution", "risky"], nullable: true, description: "The same level /api/offers publishes for the record this name resolved to, from the same function (#1486) — null wherever any rule withholds it, and never substituted with a favourable default." },
+                        risk_cause: { type: "object", nullable: true, description: "The single dated record that produced a non-stable risk_level." },
+                        gate: { type: "object", nullable: true, description: "Non-null for an offer we have decided not to list (#1241). The caller named this vendor, so the gate is reported whether or not a level would have been published." },
+                        rating_withheld: { type: "object", nullable: true, description: "Non-null where the only records that would rate this vendor cite no source (#1352)." },
+                        link_unreachable: { type: "object", nullable: true, description: "Non-null where the offer's own link is confirmed unreachable (#1046)." },
+                        source_check: { type: "object", nullable: true, description: "Our last read of the page we cite. An outcome other than ok withholds a favourable level." },
+                        level_withheld_because: { type: "string", nullable: true, description: "The sentence naming the rule that withheld the level, or null where a level is published. A null risk_level always arrives with one." },
+                        recent_changes: { type: "array", items: { type: "object" } },
+                        cheaper_alternative: { type: "object", nullable: true, description: "A same-category free offer we publish a stable level for. Chosen with the same function as risk_level, so a vendor we decline to rate is never offered as the safer swap (#1486)." },
+                        suggestions: { type: "array", items: { type: "string" } }
+                      }
+                    }
+                  },
                   recommendations: { type: "array", items: { type: "string" } }
                 }
               }
@@ -410,7 +431,7 @@ const DOCUMENTED_OPERATIONS: Record<string, Record<string, any>> = {
                         vendor: { type: "string" },
                         category: { type: "string" },
                         tier: { type: "string" },
-                        risk_level: { type: "string", enum: ["stable", "caution", "risky"], nullable: true, description: "Null where this alternative's own link is confirmed unreachable (#1046), and null where its gate is non-null (#1241) — rankForListing demotes a gated record to the tail rather than dropping it, so an alternative can be one we do not list." },
+                        risk_level: { type: "string", enum: ["stable", "caution", "risky"], nullable: true, description: "Null where this alternative's own link is confirmed unreachable (#1046), null where its rating_withheld is non-null (#1352), and null where its gate is non-null (#1241) — rankForListing demotes a gated record to the tail rather than dropping it, so an alternative can be one we do not list. The same function decides this as decides the level on the offer itself (#1486)." },
                         link_unreachable: { type: "object", nullable: true, properties: { last_reachable: { type: "string", format: "date", nullable: true }, checked: { type: "string", format: "date" }, terminal: { type: "boolean" } } },
                         gate: { $ref: "#/components/schemas/Gate" },
                         risk_cause: { type: "object", nullable: true, description: "The single dated record that produced a non-stable risk_level. Never null when risk_level is caution or risky (#1038) — a client that renders the level must be able to render the reason.", properties: { vendor: { type: "string" }, date: { type: "string" }, change_type: { type: "string" }, summary: { type: "string" }, source_url: { type: "string", nullable: true, description: "The page this record was read from, or null where we hold none. Carried on the cause so a client rendering the reason can cite it." }, current_state: { type: "string" }, resolution: { $ref: "#/components/schemas/ChangeResolution" } } },
@@ -666,8 +687,11 @@ const DOCUMENTED_OPERATIONS: Record<string, Record<string, any>> = {
                               description: { type: "string" },
                               url: { type: "string", format: "uri" },
                               verified_date: { type: "string", format: "date" },
-                              risk_level: { type: "string", enum: ["stable", "caution", "risky"], nullable: true, description: "Null where we withhold the level rather than publish a favourable one we cannot stand behind. A null always arrives with the field naming the rule that withheld it." },
+                              risk_level: { type: "string", enum: ["stable", "caution", "risky"], nullable: true, description: "The same level /api/offers publishes for this record, from the same function (#1486). Null where we withhold it rather than publish a favourable one we cannot stand behind. A null always arrives with the field naming the rule that withheld it, and with level_withheld_because." },
                               rating_withheld: { type: "object", nullable: true, description: "Non-null where every record that would have set a non-stable risk_level carries an empty source_url (#1352). The level is withheld rather than reported as stable.", properties: { reason: { type: "string", enum: ["no_source"] }, records: { type: "number" } } },
+                              gate: { type: "object", nullable: true, description: "Non-null for an offer we have decided not to list (#1241). A candidate set is drawn from ungated offers, so this is null in practice and is carried because the level's rules are one set." },
+                              source_check: { type: "object", nullable: true, description: "Our last read of the page we cite. An outcome other than ok withholds a favourable level." },
+                              level_withheld_because: { type: "string", nullable: true, description: "The sentence naming the rule that withheld the level, or null where a level is published." },
                               stability: { type: "string", enum: ["stable", "watch", "volatile", "improving"], nullable: true, description: "Null where a favourable class would rest on records we cannot stand behind. A null always arrives with stability_withheld or link_unreachable set." },
                               stability_withheld: { type: "object", nullable: true, description: "Non-null where a standing narrowing for this vendor cites no source, so a favourable stability class is withheld rather than published.", properties: { reason: { type: "string", enum: ["no_source"] }, records: { type: "number" } } },
                               link_unreachable: { type: "object", nullable: true, description: "Non-null where the offer's own link has not resolved for us (#1046).", properties: { last_reachable: { type: "string", nullable: true }, checked: { type: "string" }, terminal: { type: "boolean" } } },
@@ -1477,6 +1501,7 @@ export const openapiSpec = {
           verifiedDate: { type: "string", format: "date", description: "Date the offer was last verified (YYYY-MM-DD)" },
           eligibility: { $ref: "#/components/schemas/Eligibility" },
           gate: { $ref: "#/components/schemas/Gate" },
+          risk_level: { type: "string", enum: ["stable", "caution", "risky"], nullable: true, description: "Our published pricing-risk verdict, or null where a rule withholds it: gate is non-null (#1241, #1260), rating_withheld is non-null (#1352), or the page we cite could not confirm the record — link_unreachable, or a source_check outcome of does_not_name_vendor, states_no_terms or unreadable (#1046). One function applies all three rules and every surface that publishes a level calls it, so /api/audit-stack, /api/stack, /stack-check and MCP plan_stack answer the same as this field for the same record on the same day (#1486)." },
           source_check: { $ref: "#/components/schemas/SourceCheck" }
         },
         required: ["vendor", "category", "description", "tier", "url", "tags", "verifiedDate"]

--- a/src/serve.ts
+++ b/src/serve.ts
@@ -5,13 +5,14 @@ import { fileURLToPath } from "node:url";
 import { dirname, join } from "node:path";
 import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
 import { createServer, getServerCard } from "./server.js";
-import { oldestVerifiedDateForSlug, vendorRiskAssessment, riskCauseOf, freeTierEndingRecord, NEGATIVE_CHANGE_TYPES, POSITIVE_CHANGE_TYPES, SEVERE_CHANGE_TYPES, loadOffers, getCategories, getNewOffers, getNewestDeals, searchOffers, enrichOffers, gateForOffer, loadDealChanges, getDealChanges, changeContext, DEFAULT_CHANGE_WINDOW_DAYS, getOfferDetails, compareServices, checkVendorRisk, auditStack, getExpiringDeals, getWeeklyDigest, getFormattedWeeklyDigest, getFreshnessMetrics, getStabilityMap, getVendorReferral, sanitizeQuery, getChangeLogFreshness, isEventDated, partitionByDateProvenance } from "./data.js";
+import { oldestVerifiedDateForSlug, vendorRiskAssessment, publishedRisk, levelWithheldStatement, vendorNotIndexedSentence, riskCauseOf, freeTierEndingRecord, NEGATIVE_CHANGE_TYPES, POSITIVE_CHANGE_TYPES, SEVERE_CHANGE_TYPES, loadOffers, getCategories, getNewOffers, getNewestDeals, searchOffers, enrichOffers, gateForOffer, loadDealChanges, getDealChanges, changeContext, DEFAULT_CHANGE_WINDOW_DAYS, getOfferDetails, compareServices, checkVendorRisk, auditStack, getExpiringDeals, getWeeklyDigest, getFormattedWeeklyDigest, getFreshnessMetrics, getStabilityMap, getVendorReferral, sanitizeQuery, getChangeLogFreshness, isEventDated, partitionByDateProvenance } from "./data.js";
 import { getStackRecommendation } from "./stacks.js";
 import { estimateCosts } from "./costs.js";
 import { classifyRequest } from "./client-class.js";
 import { acceptSignal, ackMissing, checkRateLimit, clientAddress, RATE_LIMIT_PER_MINUTE, SIGNAL_ACK_PARAM, SIGNAL_BODY_MAX, SIGNAL_DOC_PATH, SIGNAL_PATH, type SignalInput } from "./signal.js";
 import { agentBlock, DEFERENCE, signalExampleSlug, signalHeaderValue, signalHtmlBlock, signalLlmsSection, SIGNAL_HEADER_NAME } from "./signal-copy.js";
 import { BASE_URL } from "./base-url.js";
+import { RATED_LEVELS, isRated, gradeForStack } from "./stack-grade.js";
 import { provenanceBlock } from "./provenance.js";
 import { recordApiHit, recordSessionConnect, recordSessionDisconnect, recordLandingPageView, getStats, getConnectionStats, loadTelemetry, flushTelemetry, flushPending, FLUSH_INTERVAL_SECONDS, logRequest, getPublicRequestLogResult, getTelemetryHealth, recordPageView, getPageViews, recordReferralListingCall, recordReferralVendorLookup, getReferralMarketplaceStats, getSessionClassification, recordSearchQuery, getSearchAnalytics, getApiHitsByEndpoint, recordTraffic, getTrafficReport, getSignalReport, publicSignalReport, getRollupDaySource, getRollupDatesAvailable, setDurableRollupCoverage, redisJsonGet, redisJsonMget, redisJsonSet, redisJsonSetWithoutExpiry, useRedis } from "./stats.js";
 import { buildDailyRollup, readRollups, coverageOf, ROLLUP_DATE_PATTERN } from "./analytics-rollup.js";
@@ -676,6 +677,7 @@ function stabilityCellHtml(
     return `<span style="color:var(--text-dim)" title="${escHtmlServer(why.charAt(0).toUpperCase() + why.slice(1))}">source unconfirmed</span>`;
   }
   const published = publishedVendorLevel(level ?? null, cause ?? null);
+  if (published === null) return `<span style="color:var(--text-dim)">unrated</span>`;
   const color = RISK_COLORS[published] ?? "#8b949e";
   const title = published === "stable" || !cause
     ? ""
@@ -967,6 +969,7 @@ function buildVendorVerdictContext(vendorName: string, servedOn: string): Vendor
     input: {
       vendor: vendorName,
       level: enriched.risk_level ?? null,
+      historyLevel: publishedRisk(primary, vendorChanges, servedOn).history_level,
       cause: enriched.risk_cause,
       changes: vendorChanges,
       levelWithheld,
@@ -4626,7 +4629,9 @@ function buildVendorPage(slug: string): string | null {
   const riskColors: Record<string, string> = { stable: "#3fb950", caution: "#d29922", risky: "#f85149" };
   const riskCause = enriched.risk_cause;
   const riskLevel = publishedVendorLevel(enriched.risk_level ?? null, riskCause);
-  const riskColor = riskColors[riskLevel] ?? "#8b949e";
+  const historyLevel = verdictInput.historyLevel;
+  const levelWithheldBecause = levelWithheldStatement(vendorName, publishedRisk(primary, vendorChanges, servedOn));
+  const riskColor = (riskLevel ? riskColors[riskLevel] : null) ?? "#8b949e";
 
   const discontinuedOn = discontinuedOnOrBefore(vendorChanges, servedOn);
 
@@ -5095,6 +5100,8 @@ ${allCompareLinks.join("\n")}
     ? endedReliabilitySentence(vendorName)
     : levelWithheld
     ? `We cannot say. ${withheldLevelSentence(levelWithheld, vendorName, unconfirmableSince)} Nothing we have read describes these terms, so we are not publishing a stability judgement for this vendor until that is fixed.`
+    : riskLevel === null
+    ? `${levelWithheldBecause}`
     : riskLevel === "stable"
     ? `${vendorName}'s free tier is considered stable.${vendorChanges.length > 0 ? ` ${narrowingSentence(vendorChanges)} See the pricing history below.` : ""}`
     : riskLevel === "caution"
@@ -5109,10 +5116,10 @@ ${allCompareLinks.join("\n")}
     : eligibilityGateSentence + (levelWithheld
     ? `${withheldLevelSentence(levelWithheld, vendorName, unconfirmableSince)} We cannot confirm what this offer provides today, so we are not recommending it for production or for anything else until we can.`
     : hasFree
-    ? (riskLevel === "stable"
+    ? (riskLevel === "stable" || (primaryGate && historyLevel === "stable")
       ? `${vendorName}'s free tier can be suitable for small production workloads and side projects. ${primaryGate ? "It" : "We rate it stable and it"} offers ${escHtmlServer(keyLimit)}, so it's a reasonable starting point.${vendorChanges.length > 0 ? ` ${narrowingSentence(vendorChanges)}` : ""} Monitor your usage against the limits and have an upgrade plan ready.`
-      : primaryGate
-      ? `${vendorName}'s free tier is usable for prototyping and development. ${vendorHistorySentence(vendorName, riskLevel, riskCause)}`
+      : riskLevel === null
+      ? `${vendorName}'s free tier is usable for prototyping and development. ${primaryGate ? vendorHistorySentence(vendorName, historyLevel, riskCause) : levelWithheldBecause}`
       : `${vendorName}'s free tier is usable for prototyping and development, but we rate it ${riskLevel}${riskCause ? ` because of one recorded ${changeKindNoun(riskCause.change_type)}, ${changeDateClause(riskCause)}` : ""}. Consider alternatives with more stable pricing for critical services.`)
     : `${vendorName} does not offer a free tier for production use. Consider free alternatives in ${primary.category}.`);
   const faqChangedAnswer = vendorChanges.length > 0
@@ -5384,8 +5391,10 @@ function buildAlternativesPage(slug: string): string | null {
   const altWithheldClause = altLevelWithheld
     ? withheldLevelClause(altLevelWithheld, altUnconfirmableSince)
     : "";
-  const riskLevel = enriched.risk_level && (enriched.risk_level === "stable" || riskCause) ? enriched.risk_level : "stable";
-  const riskColor = riskColors[riskLevel] ?? "#8b949e";
+  const altPublished = publishedRisk(primary, vendorChanges);
+  const altWithheldBecause = levelWithheldStatement(vendorName, altPublished) ?? "";
+  const riskLevel = publishedVendorLevel(enriched.risk_level ?? null, riskCause);
+  const riskColor = (riskLevel ? riskColors[riskLevel] : null) ?? "#8b949e";
 
   const substitutes = vendorSubstitutes(vendorName, vendorOffers, allChanges);
   const vendorCategories = substitutes.categories;
@@ -5429,9 +5438,9 @@ function buildAlternativesPage(slug: string): string | null {
         : `<div class="risk-row"><span class="risk-label">Risk Level:</span> <span class="risk-badge-inline" style="background:${riskColor}20;color:${riskColor};border:1px solid ${riskColor}40">${riskLevel}</span></div>`
     );
     if (enriched.risk_level === null) {
-      parts.push(`<div class="risk-row"><span class="risk-label">Why:</span> ${escHtmlServer(altWithheldSentence)} We are not publishing a stability judgement for it until that is fixed.</div>`);
+      parts.push(`<div class="risk-row"><span class="risk-label">Why:</span> ${escHtmlServer(altWithheldBecause)} We are not publishing a stability judgement for it until that is fixed.</div>`);
     }
-    if (riskLevel !== "stable" && riskCause) {
+    if (riskLevel !== null && riskLevel !== "stable" && riskCause) {
       parts.push(`<div class="risk-row"><span class="risk-label">Why:</span> <span class="risk-cause-date" style="font-family:var(--mono)">${escHtmlServer(changeEntryDateLabel(riskCause))}</span> &mdash; ${changeSummaryHtml(riskCause, escHtmlServer)}</div>`);
     }
     parts.push(`<div class="risk-row"><span class="risk-label">Category:</span> ${vendorCategories.map(c => `<a href="/category/${toSlug(c)}" class="cat-pill">${escHtmlServer(c)}</a>`).join(" ")}</div>`);
@@ -5541,6 +5550,8 @@ ${renderAuditBlock(altRanking.tie_break)}
     ? `${altNotAFreeOffer.reason}${altLevelWithheld ? ` ${altWithheldSentence}` : ""} ${storedTermsOf(primary)}`
     : altLevelWithheld
     ? `We cannot confirm that today. ${altWithheldSentence} Our stored record says ${vendorName} offers a free tier (${primary.tier}), but we have not confirmed those terms against the source we cite.`
+    : riskLevel === null
+    ? `${altWithheldBecause} Our stored record says ${vendorName} offers a free tier (${primary.tier}), and we are not publishing a stability judgement over it.`
     : riskLevel === "stable"
     ? `Yes, ${vendorName} currently offers a free tier (${primary.tier}). ${vendorChanges.length === 0 ? "No pricing changes have been recorded." : narrowingSentence(vendorChanges)}`
     : riskLevel === "caution"
@@ -47320,7 +47331,7 @@ function buildStackCheckPage(): string {
   const totalOffers = allOffers.length;
   const totalChanges = allChanges.length;
 
-  const vendorLookup: Record<string, { vendor: string; category: string; description: string; tier: string; slug: string; risk_level: string; risk_cause: CitedRiskCause | null; stability: string; recent_changes: Array<{ vendor: string; date: string; change_type: string; summary: string; source_url: string | null; citation_html: string; impact: string; resolved: boolean }> }> = {};
+  const vendorLookup: Record<string, { vendor: string; category: string; description: string; tier: string; slug: string; risk_level: string | null; level_withheld_because: string | null; risk_cause: CitedRiskCause | null; stability: string; recent_changes: Array<{ vendor: string; date: string; change_type: string; summary: string; source_url: string | null; citation_html: string; impact: string; resolved: boolean }> }> = {};
   for (const offer of allOffers) {
     const slug = toSlug(offer.vendor);
     const allVendorChanges = allChanges
@@ -47328,16 +47339,17 @@ function buildStackCheckPage(): string {
       .sort((a, b) => b.date.localeCompare(a.date));
     const vendorChanges = allVendorChanges.slice(0, 3);
     const stability = stabilityMap.get(slug) || "stable";
-    const assessment = vendorRiskAssessment(allVendorChanges);
+    const published = publishedRisk(offer, allVendorChanges);
     vendorLookup[slug] = {
       vendor: offer.vendor,
       category: offer.category,
       description: publishedTermsText(offer),
       tier: offer.tier,
       slug,
-      risk_level: assessment.level,
-      risk_cause: assessment.cause
-        ? { ...riskCauseOf(assessment.cause)!, date: changeEntryDateLabel(assessment.cause), citation_html: changeCitationHtml(assessment.cause, escHtmlServer) }
+      risk_level: published.risk_level,
+      level_withheld_because: levelWithheldStatement(offer.vendor, published),
+      risk_cause: published.cause
+        ? { ...published.risk_cause!, date: changeEntryDateLabel(published.cause), citation_html: changeCitationHtml(published.cause, escHtmlServer) }
         : null,
       stability,
       recent_changes: vendorChanges.map(c => ({ vendor: c.vendor, date: changeEntryDateLabel(c), change_type: c.change_type, summary: c.summary, source_url: c.source_url?.trim() ? c.source_url.trim() : null, citation_html: changeCitationHtml(c, escHtmlServer), impact: c.impact, resolved: isNoLongerInForce(c) })),
@@ -47435,14 +47447,16 @@ function buildStackCheckPage(): string {
     .grade-F{background:rgba(248,81,73,.15);color:var(--red);border:3px solid var(--red)}
     .grade-label{font-size:1rem;color:var(--text);font-weight:600;margin-bottom:.25rem}
     .grade-desc{font-size:.85rem;color:var(--text-muted)}
+    .grade-denominator{font-size:.85rem;color:var(--text-muted);margin-top:.4rem}
 
-    .risk-summary{display:grid;grid-template-columns:repeat(3,1fr);gap:.75rem;margin:1.5rem 0}
+    .risk-summary{display:grid;grid-template-columns:repeat(4,1fr);gap:.75rem;margin:1.5rem 0}
     .risk-stat{text-align:center;padding:1rem;background:var(--bg-elevated);border:1px solid var(--border);border-radius:10px}
     .risk-stat .count{font-size:1.8rem;font-weight:700}
     .risk-stat .label{font-size:.8rem;color:var(--text-muted);text-transform:uppercase;letter-spacing:.04em}
     .risk-low .count{color:var(--green)}
     .risk-moderate .count{color:var(--yellow)}
     .risk-high .count{color:var(--red)}
+    .risk-unrated .count{color:var(--text-dim)}
 
     .service-cards{display:grid;gap:.75rem;margin:1.5rem 0}
     .service-card{background:var(--bg-elevated);border:1px solid var(--border);border-radius:10px;padding:1.25rem;transition:border-color .15s}
@@ -47457,6 +47471,8 @@ function buildStackCheckPage(): string {
     .risk-badge.caution{background:rgba(210,153,34,.12);color:var(--yellow)}
     .risk-badge.risky{background:rgba(248,81,73,.12);color:var(--red)}
     .risk-badge.not-found{background:rgba(148,163,184,.1);color:var(--text-dim)}
+    .risk-badge.unrated{background:rgba(148,163,184,.14);color:var(--text-dim)}
+    .card-unrated{font-size:.85rem;color:var(--text-muted);margin:.4rem 0;border-left:2px solid var(--border);padding-left:.6rem}
     .card-tier{font-size:.85rem;color:var(--text-muted);margin:.25rem 0}
     .card-changes{margin:.5rem 0}
     .change-item{font-size:.8rem;color:var(--text-dim);padding:.25rem 0;border-top:1px solid var(--border)}
@@ -47581,6 +47597,10 @@ function buildStackCheckPage(): string {
     ${mcpCtaScript()}
     var VENDOR_LOOKUP = ${JSON.stringify(vendorLookup)};
 
+    var RATED_LEVELS = ${JSON.stringify(RATED_LEVELS)};
+    ${isRated.toString()}
+    ${gradeForStack.toString()}
+
     function usePreset(services) {
       document.getElementById('stack-input').value = services;
       checkStack();
@@ -47615,35 +47635,23 @@ function buildStackCheckPage(): string {
       document.getElementById('results').style.display = 'block';
       document.getElementById('check-btn').disabled = false;
 
-      var riskCounts = { stable: 0, caution: 0, risky: 0, not_found: 0 };
+      var riskCounts = { stable: 0, caution: 0, risky: 0, withheld: 0, not_found: 0 };
       var totalFound = 0;
       for (var i = 0; i < data.services.length; i++) {
         var svc = data.services[i];
         if (svc.status === 'not_found') { riskCounts.not_found++; continue; }
         totalFound++;
-        var rl = svc.risk_level || 'stable';
-        if (riskCounts[rl] !== undefined) riskCounts[rl]++;
-        else riskCounts.stable++;
+        if (isRated(svc.risk_level)) riskCounts[svc.risk_level]++;
+        else riskCounts.withheld++;
       }
+      var assessment = gradeForStack(riskCounts, data.services.length);
 
-      var grade, gradeLabel, gradeDesc;
-      if (totalFound === 0) {
-        grade = '?'; gradeLabel = 'Unknown'; gradeDesc = 'None of the entered services were found in our database.';
-      } else {
-        var riskyPct = riskCounts.risky / totalFound;
-        var cautionPct = riskCounts.caution / totalFound;
-        if (riskyPct === 0 && cautionPct === 0) { grade = 'A'; gradeLabel = 'Excellent'; gradeDesc = 'All services are stable with no recent pricing concerns.'; }
-        else if (riskyPct === 0 && cautionPct <= 0.3) { grade = 'B'; gradeLabel = 'Good'; gradeDesc = 'Mostly stable stack with minor items to monitor.'; }
-        else if (riskyPct <= 0.2 && cautionPct <= 0.5) { grade = 'C'; gradeLabel = 'Fair'; gradeDesc = 'Some services at moderate risk — review alternatives for flagged items.'; }
-        else if (riskyPct <= 0.4) { grade = 'D'; gradeLabel = 'Poor'; gradeDesc = 'Multiple high-risk services detected — migration planning recommended.'; }
-        else { grade = 'F'; gradeLabel = 'Critical'; gradeDesc = 'Significant free tier risk across your stack — immediate action recommended.'; }
-      }
-
-      var gradeClass = grade === '?' ? 'C' : grade;
+      var gradeClass = (assessment.grade === '?' || assessment.grade === '—') ? 'C' : assessment.grade;
       document.getElementById('grade-section').innerHTML =
-        '<div class="grade-badge grade-' + gradeClass + '">' + grade + '</div>' +
-        '<div class="grade-label">' + gradeLabel + '</div>' +
-        '<div class="grade-desc">' + gradeDesc + '</div>';
+        '<div class="grade-badge grade-' + gradeClass + '">' + assessment.grade + '</div>' +
+        '<div class="grade-label">' + esc(assessment.label) + '</div>' +
+        '<div class="grade-desc">' + esc(assessment.description) + '</div>' +
+        (assessment.denominator ? '<div class="grade-denominator">' + esc(assessment.denominator) + '</div>' : '');
 
       var shareUrl = window.location.origin + '/stack-check?s=' + encodeURIComponent(inputServices.join(','));
       document.getElementById('share-url').textContent = shareUrl;
@@ -47652,7 +47660,8 @@ function buildStackCheckPage(): string {
       document.getElementById('risk-summary').innerHTML =
         '<div class="risk-stat risk-low"><div class="count">' + riskCounts.stable + '</div><div class="label">Stable</div></div>' +
         '<div class="risk-stat risk-moderate"><div class="count">' + riskCounts.caution + '</div><div class="label">Caution</div></div>' +
-        '<div class="risk-stat risk-high"><div class="count">' + riskCounts.risky + '</div><div class="label">High Risk</div></div>';
+        '<div class="risk-stat risk-high"><div class="count">' + riskCounts.risky + '</div><div class="label">High Risk</div></div>' +
+        '<div class="risk-stat risk-unrated"><div class="count">' + riskCounts.withheld + '</div><div class="label">Unrated</div></div>';
 
       var cardsHtml = '';
       var negTypes = ['free_tier_removed','limits_reduced','restriction','product_deprecated','open_source_killed','pricing_model_change','pricing_restructured'];
@@ -47668,13 +47677,13 @@ function buildStackCheckPage(): string {
           cardsHtml += '</div>';
           continue;
         }
-        var rl = svc.risk_level || 'stable';
+        var rl = svc.risk_level;
         var rc = svc.risk_cause || null;
-        if (rl !== 'stable' && !rc) rl = 'stable';
         var slug = toSlug(svc.vendor);
         cardsHtml += '<div class="service-card"><div class="card-header"><span class="card-vendor"><a href="/vendor/' + esc(slug) + '">' + esc(svc.vendor) + '</a></span>';
-        cardsHtml += '<div style="display:flex;gap:.5rem;align-items:center"><span class="card-category">' + esc(svc.category) + '</span><span class="risk-badge ' + esc(rl) + '">' + esc(rl) + '</span></div></div>';
-        if (rl !== 'stable' && rc) cardsHtml += '<p class="card-risk-cause"><strong>Why ' + esc(rl) + ':</strong> ' + esc(rc.date) + ' &mdash; ' + esc(rc.summary) + '</p>';
+        cardsHtml += '<div style="display:flex;gap:.5rem;align-items:center"><span class="card-category">' + esc(svc.category) + '</span><span class="risk-badge ' + (isRated(rl) ? esc(rl) : 'unrated') + '">' + (isRated(rl) ? esc(rl) : 'Unrated') + '</span></div></div>';
+        if (isRated(rl) && rl !== 'stable' && rc) cardsHtml += '<p class="card-risk-cause"><strong>Why ' + esc(rl) + ':</strong> ' + esc(rc.date) + ' &mdash; ' + esc(rc.summary) + '</p>';
+        if (!isRated(rl)) cardsHtml += '<p class="card-unrated">' + esc(svc.level_withheld_because || '') + '</p>';
         cardsHtml += '<p class="card-tier">' + esc(svc.tier) + '</p>';
 
         if (svc.recent_changes && svc.recent_changes.length > 0) {
@@ -48446,13 +48455,19 @@ function buildBudgetBuilderPage(): string {
   const totalOffers = allOffers.length;
   const totalChanges = allChanges.length;
 
-  const categoryVendors: Record<string, Array<{ slug: string; name: string; free: string; starter: number; growth: number; scale: number; notes: string; risk_level: string; risk_cause: CitedRiskCause | null }>> = {};
+  const categoryVendors: Record<string, Array<{ slug: string; name: string; free: string; starter: number; growth: number; scale: number; notes: string; risk_level: string | null; level_withheld_because: string | null; rank_penalty: number; risk_cause: CitedRiskCause | null }>> = {};
+  const rankPenaltyFor = (level: "stable" | "caution" | "risky", cause: DealChange | null) =>
+    cause ? (level === "risky" ? 100 : level === "caution" ? 30 : 0) : 0;
   for (const cat of estimatorData) {
     categoryVendors[cat.id] = cat.vendors.map(v => {
       const vendorChanges = allChanges.filter(c => toSlug(c.vendor) === v.slug || c.vendor.toLowerCase() === v.name.toLowerCase());
-      const assessment = vendorRiskAssessment(vendorChanges);
-      return { slug: v.slug, name: v.name, free: v.free, starter: v.starter, growth: v.growth, scale: v.scale, notes: v.notes, risk_level: assessment.level,
-        risk_cause: assessment.cause ? { ...riskCauseOf(assessment.cause)!, date: changeEntryDateLabel(assessment.cause), citation_html: changeCitationHtml(assessment.cause, escHtmlServer) } : null };
+      const offer = allOffers.find(o => toSlug(o.vendor) === v.slug || o.vendor.toLowerCase() === v.name.toLowerCase());
+      const published = offer ? publishedRisk(offer, vendorChanges) : null;
+      return { slug: v.slug, name: v.name, free: v.free, starter: v.starter, growth: v.growth, scale: v.scale, notes: v.notes,
+        risk_level: published ? published.risk_level : null,
+        level_withheld_because: published ? levelWithheldStatement(v.name, published) : vendorNotIndexedSentence(v.name),
+        rank_penalty: published ? rankPenaltyFor(published.history_level, published.cause) : 0,
+        risk_cause: published?.cause ? { ...published.risk_cause!, date: changeEntryDateLabel(published.cause), citation_html: changeCitationHtml(published.cause, escHtmlServer) } : null };
     });
   }
 
@@ -48557,6 +48572,7 @@ function buildBudgetBuilderPage(): string {
     + '    .risk-badge.low{background:rgba(63,185,80,.15);color:var(--green)}\n'
     + '    .risk-badge.medium{background:rgba(210,153,34,.15);color:var(--yellow)}\n'
     + '    .risk-badge.high{background:rgba(248,81,73,.15);color:var(--red)}\n'
+    + '    .risk-badge.unrated{background:rgba(148,163,184,.14);color:var(--text-dim)}\n'
     + '    .alternatives{margin-top:.75rem;padding-top:.75rem;border-top:1px solid var(--border)}\n'
     + '    .alternatives-label{font-size:.7rem;color:var(--text-dim);text-transform:uppercase;letter-spacing:.05em;margin-bottom:.5rem}\n'
     + '    .alt-row{display:flex;justify-content:space-between;align-items:center;font-size:.8rem;color:var(--text-muted);padding:.2rem 0}\n'
@@ -48719,6 +48735,13 @@ function buildBudgetBuilderPage(): string {
     + '  buildStack();\n'
     + '}\n'
     + '\n'
+    + 'var RATED_LEVELS = ' + JSON.stringify(RATED_LEVELS) + ';\n'
+    + 'function isRated(level) { return RATED_LEVELS.indexOf(level) >= 0; }\n'
+    + 'function vendorRiskBadge(v) {\n'
+    + '  if (!isRated(v.risk_level)) return v.level_withheld_because ? \'<span class="risk-badge unrated" title="\' + v.level_withheld_because + \'">Unrated</span>\' : "";\n'
+    + '  if (!v.risk_cause) return "";\n'
+    + '  return \'<span class="risk-badge \' + v.risk_level + \'" title="\' + v.risk_cause.date + \': \' + v.risk_cause.summary + \'">\' + v.risk_level + \'</span>\';\n'
+    + '}\n'
     + 'function recommendVendor(catId, budget) {\n'
     + '  var vendors = CATEGORY_VENDORS[catId] || [];\n'
     + '  if (vendors.length === 0) return null;\n'
@@ -48727,8 +48750,7 @@ function buildBudgetBuilderPage(): string {
     + '    if (budget === 0) {\n'
     + '      cost = 0;\n'
     + '    }\n'
-    + '    var riskPenalty = v.risk_cause ? (v.risk_level === "risky" ? 100 : v.risk_level === "caution" ? 30 : 0) : 0;\n'
-    + '    var score = cost + riskPenalty - (v.free !== "" && cost === 0 ? 50 : 0);\n'
+    + '    var score = cost + v.rank_penalty - (v.free !== "" && cost === 0 ? 50 : 0);\n'
     + '    return { vendor: v, cost: cost, score: score };\n'
     + '  });\n'
     + '  scored.sort(function(a, b) { return a.score - b.score; });\n'
@@ -48740,7 +48762,7 @@ function buildBudgetBuilderPage(): string {
     + '  var results = document.getElementById("results");\n'
     + '  results.style.display = "block";\n'
     + '  var totalCost = 0;\n'
-    + '  var riskCounts = { stable: 0, caution: 0, risky: 0 };\n'
+    + '  var riskCounts = { stable: 0, caution: 0, risky: 0, withheld: 0 };\n'
     + '  var stackHtml = "";\n'
     + '  var catKeys = Array.from(selectedCategories);\n'
     + '  var paidEquivalent = 0;\n'
@@ -48750,7 +48772,7 @@ function buildBudgetBuilderPage(): string {
     + '    if (!rec) return;\n'
     + '    var cost = selectedBudget === 0 ? 0 : rec.starter;\n'
     + '    totalCost += cost;\n'
-    + '    if (riskCounts[rec.risk_level] !== undefined) riskCounts[rec.risk_level]++;\n'
+    + '    if (isRated(rec.risk_level)) riskCounts[rec.risk_level]++; else riskCounts.withheld++;\n'
     + '    paidEquivalent += rec.growth > 0 ? rec.growth : rec.starter > 0 ? rec.starter : 25;\n'
     + '\n'
     + '    var vendors = CATEGORY_VENDORS[catId] || [];\n'
@@ -48761,8 +48783,9 @@ function buildBudgetBuilderPage(): string {
     + '    stackHtml += \'<span class="stack-card-category">\' + (CATEGORY_LABELS[catId] || catId) + \'</span>\';\n'
     + '    stackHtml += \'<span class="stack-card-cost">\' + (cost === 0 ? "FREE" : "$" + cost + "/mo") + \'</span>\';\n'
     + '    stackHtml += \'</div>\';\n'
-    + '    stackHtml += \'<div class="stack-card-vendor"><a href="/vendor/\' + rec.slug + \'">\' + rec.name + \'</a>\' + (rec.risk_cause ? \' <span class="risk-badge \' + rec.risk_level + \'">\' + rec.risk_level + \'</span>\' : "") + \'</div>\';\n'
-    + '    if (rec.risk_cause) stackHtml += \'<div class="stack-card-risk-cause">Why \' + rec.risk_level + \': \' + rec.risk_cause.date + \' — \' + rec.risk_cause.summary + \'</div>\';\n'
+    + '    stackHtml += \'<div class="stack-card-vendor"><a href="/vendor/\' + rec.slug + \'">\' + rec.name + \'</a>\' + vendorRiskBadge(rec) + \'</div>\';\n'
+    + '    if (isRated(rec.risk_level) && rec.risk_cause) stackHtml += \'<div class="stack-card-risk-cause">Why \' + rec.risk_level + \': \' + rec.risk_cause.date + \' — \' + rec.risk_cause.summary + \'</div>\';\n'
+    + '    if (!isRated(rec.risk_level)) stackHtml += \'<div class="stack-card-risk-cause">\' + (rec.level_withheld_because || "") + \'</div>\';\n'
     + '    stackHtml += \'<div class="stack-card-free">\' + rec.free + \'</div>\';\n'
     + '    if (rec.notes) stackHtml += \'<div style="color:var(--text-dim);font-size:.8rem">\' + rec.notes + \'</div>\';\n'
     + '\n'
@@ -48772,7 +48795,7 @@ function buildBudgetBuilderPage(): string {
     + '      alts.forEach(function(alt) {\n'
     + '        var altCost = selectedBudget === 0 ? 0 : alt.starter;\n'
     + '        stackHtml += \'<div class="alt-row"><a href="/vendor/\' + alt.slug + \'">\' + alt.name + \'</a>\';\n'
-    + '        stackHtml += \'<span>\' + (altCost === 0 ? "FREE" : "$" + altCost + "/mo") + (alt.risk_cause ? \' · <span class="risk-badge \' + alt.risk_level + \'" title="\' + alt.risk_cause.date + \': \' + alt.risk_cause.summary + \'">\' + alt.risk_level + \'</span>\' : "") + \'</span></div>\';\n'
+    + '        stackHtml += \'<span>\' + (altCost === 0 ? "FREE" : "$" + altCost + "/mo") + (vendorRiskBadge(alt) ? " · " + vendorRiskBadge(alt) : "") + \'</span></div>\';\n'
     + '      });\n'
     + '      stackHtml += \'</div>\';\n'
     + '    }\n'
@@ -48811,14 +48834,15 @@ function buildBudgetBuilderPage(): string {
     + '    document.getElementById("savings-callout").style.display = "none";\n'
     + '  }\n'
     + '\n'
-    + '  var total = riskCounts.stable + riskCounts.caution + riskCounts.risky;\n'
+    + '  var total = riskCounts.stable + riskCounts.caution + riskCounts.risky + riskCounts.withheld;\n'
     + '  var riskHtml = \'<h3>Stack Risk Assessment</h3>\';\n'
     + '  riskHtml += \'<div class="risk-meter">\';\n'
     + '  for (var i = 0; i < riskCounts.stable; i++) riskHtml += \'<div class="risk-meter-segment" style="background:var(--green)"></div>\';\n'
     + '  for (var j = 0; j < riskCounts.caution; j++) riskHtml += \'<div class="risk-meter-segment" style="background:var(--yellow)"></div>\';\n'
     + '  for (var k = 0; k < riskCounts.risky; k++) riskHtml += \'<div class="risk-meter-segment" style="background:var(--red)"></div>\';\n'
+    + '  for (var u = 0; u < riskCounts.withheld; u++) riskHtml += \'<div class="risk-meter-segment" style="background:var(--text-dim)"></div>\';\n'
     + '  riskHtml += \'</div>\';\n'
-    + '  riskHtml += \'<p style="color:var(--text-muted);font-size:.85rem;margin-top:.5rem">\' + riskCounts.stable + \' stable, \' + riskCounts.caution + \' caution, \' + riskCounts.risky + \' risky</p>\';\n'
+    + '  riskHtml += \'<p style="color:var(--text-muted);font-size:.85rem;margin-top:.5rem">\' + riskCounts.stable + \' stable, \' + riskCounts.caution + \' caution, \' + riskCounts.risky + \' risky, \' + riskCounts.withheld + \' unrated</p>\';\n'
     + '  if (riskCounts.risky > 0) riskHtml += \'<p style="color:var(--red);font-size:.85rem;margin-top:.25rem">&#x26a0; \' + riskCounts.risky + \' service(s) have removed a free tier or changed an open-source licence in the last 12 months. Consider alternatives.</p>\';\n'
     + '  document.getElementById("risk-summary").innerHTML = riskHtml;\n'
     + '\n'

--- a/src/stack-grade.ts
+++ b/src/stack-grade.ts
@@ -1,0 +1,50 @@
+export const RATED_LEVELS = ["stable", "caution", "risky"];
+
+export interface StackRiskCounts {
+  stable: number;
+  caution: number;
+  risky: number;
+  withheld: number;
+  not_found: number;
+}
+
+export interface StackGrade {
+  grade: string;
+  label: string;
+  description: string;
+  denominator: string;
+}
+
+export function isRated(level: unknown): boolean {
+  return RATED_LEVELS.indexOf(level as string) >= 0;
+}
+
+export function gradeForStack(counts: StackRiskCounts, servicesEntered: number): StackGrade {
+  var found = counts.stable + counts.caution + counts.risky + counts.withheld;
+  if (found === 0) {
+    return { grade: "?", label: "Unknown", description: "None of the entered services were found in our database.", denominator: "" };
+  }
+  var rated = found - counts.withheld;
+  if (rated === 0) {
+    return { grade: "—", label: "No grade", description: "None of the services you entered carries a risk rating. Each row below says why.", denominator: "" };
+  }
+
+  var riskyPct = counts.risky / rated;
+  var cautionPct = counts.caution / rated;
+  var partial = rated < servicesEntered;
+  var grade, label, description;
+  if (riskyPct === 0 && cautionPct === 0) {
+    grade = "A"; label = "Excellent";
+    description = partial ? "Every rated service is stable, with no recent pricing concerns." : "All services are stable with no recent pricing concerns.";
+  } else if (riskyPct === 0 && cautionPct <= 0.3) {
+    grade = "B"; label = "Good"; description = "Mostly stable stack with minor items to monitor.";
+  } else if (riskyPct <= 0.2 && cautionPct <= 0.5) {
+    grade = "C"; label = "Fair"; description = "Some services at moderate risk — review alternatives for flagged items.";
+  } else if (riskyPct <= 0.4) {
+    grade = "D"; label = "Poor"; description = "Multiple high-risk services detected — migration planning recommended.";
+  } else {
+    grade = "F"; label = "Critical";
+    description = partial ? "Significant free tier risk across the rated services." : "Significant free tier risk across your stack — immediate action recommended.";
+  }
+  return { grade: grade, label: label, description: description, denominator: "Grade based on " + rated + " of " + servicesEntered + " services." };
+}

--- a/src/stacks.ts
+++ b/src/stacks.ts
@@ -1,9 +1,8 @@
-import { searchOffers, loadDealChanges, vendorRiskAssessment, classifyStability, withheldStability, standingNarrowingsCitingNoSource } from "./data.js";
+import { searchOffers, loadDealChanges, publishedRisk, levelWithheldStatement, classifyStability, withheldStability, standingNarrowingsCitingNoSource } from "./data.js";
 import { rankOffers, utcDate, CRITERIA_PATH, DEMOTE_ONLY_POLICY, NOT_MODELLED_NOTICE } from "./ranking.js";
-import type { Demerit, Disclosure, TieBreak } from "./ranking.js";
-import { unreachableNoticeForUrl } from "./link-health.js";
+import type { Demerit, Disclosure, Gate, TieBreak } from "./ranking.js";
 import { verificationLedger } from "./verification-state.js";
-import type { Offer, StabilityClass, DealChange, RatingWithheld, LinkUnreachable } from "./types.js";
+import type { Offer, StabilityClass, DealChange, RatingWithheld, LinkUnreachable, SourceCheck } from "./types.js";
 import { partitionRoleCandidates, MEMBERSHIP_GATE_RULES } from "./product-role.js";
 
 export interface StackCandidate {
@@ -14,6 +13,9 @@ export interface StackCandidate {
   verified_date: string;
   risk_level: "stable" | "caution" | "risky" | null;
   rating_withheld: RatingWithheld | null;
+  source_check: SourceCheck | null;
+  gate: Gate | null;
+  level_withheld_because: string | null;
   stability: StabilityClass | null;
   stability_withheld: RatingWithheld | null;
   link_unreachable: LinkUnreachable | null;
@@ -218,8 +220,8 @@ function toCandidate(
   disclosures: Disclosure[],
   vendorChanges: DealChange[],
 ): StackCandidate {
-  const assessment = vendorRiskAssessment(vendorChanges);
-  const linkUnreachable = unreachableNoticeForUrl(offer.url);
+  const published = publishedRisk(offer, vendorChanges);
+  const linkUnreachable = published.link_unreachable;
   const uncitedNarrowings = standingNarrowingsCitingNoSource(vendorChanges);
   return {
     vendor: offer.vendor,
@@ -227,8 +229,11 @@ function toCandidate(
     description: offer.description.length > 200 ? offer.description.slice(0, 197) + "..." : offer.description,
     url: offer.url,
     verified_date: offer.verifiedDate,
-    risk_level: assessment.rating_withheld ? null : assessment.level,
-    rating_withheld: assessment.rating_withheld,
+    risk_level: published.risk_level,
+    rating_withheld: published.rating_withheld,
+    source_check: published.source_check,
+    gate: published.gate,
+    level_withheld_because: levelWithheldStatement(offer.vendor, published),
     stability: withheldStability(linkUnreachable, classifyStability(vendorChanges), vendorChanges),
     stability_withheld: uncitedNarrowings.length > 0 ? { reason: "no_source", records: uncitedNarrowings.length } : null,
     link_unreachable: linkUnreachable,

--- a/src/vendor-verdict.ts
+++ b/src/vendor-verdict.ts
@@ -40,6 +40,7 @@ export function changeKindNoun(changeType: string): string {
 export interface VendorVerdictInput {
   vendor: string;
   level: PublishedRiskLevel | null;
+  historyLevel: PublishedRiskLevel;
   cause: RiskCause | null;
   changes: Array<Pick<DealChange, "date" | "date_source" | "change_type"> & { source_url?: string | null } & { resolution?: DealChange["resolution"] }>;
   levelWithheld: LevelWithheldReason | null;
@@ -64,8 +65,9 @@ export type VendorBadge =
 export function publishedVendorLevel(
   level: PublishedRiskLevel | null,
   cause: RiskCause | null,
-): PublishedRiskLevel {
-  return level && (level === "stable" || cause) ? level : "stable";
+): PublishedRiskLevel | null {
+  if (level === null) return null;
+  return level === "stable" || cause ? level : "stable";
 }
 
 function capitalise(text: string): string {
@@ -81,8 +83,13 @@ function narrowingChanges(
     .sort((a, b) => b.date.localeCompare(a.date));
 }
 
+function noAdverseLevelToPublish(input: VendorVerdictInput): boolean {
+  const level = publishedVendorLevel(input.level, input.cause);
+  return level === null || level === "stable";
+}
+
 export function ratingWithheldForNoSource(input: VendorVerdictInput): boolean {
-  return Boolean(input.ratingWithheld) && publishedVendorLevel(input.level, input.cause) === "stable";
+  return Boolean(input.ratingWithheld) && noAdverseLevelToPublish(input);
 }
 
 export function termsUnconfirmedBySource(input: VendorVerdictInput): TermsUnconfirmedReason | null {
@@ -95,7 +102,7 @@ export function unconfirmedTermsMetaSentence(reason: TermsUnconfirmedReason): st
 
 export function withholdingDecides(input: VendorVerdictInput): boolean {
   return (input.levelWithheld !== null || ratingWithheldForNoSource(input))
-    && publishedVendorLevel(input.level, input.cause) === "stable";
+    && noAdverseLevelToPublish(input);
 }
 
 export function vendorVerdictWord(input: VendorVerdictInput): PublishedRiskLevel | null {
@@ -120,7 +127,9 @@ export function vendorBadge(input: VendorVerdictInput): VendorBadge {
   if (input.offerEnded) return { kind: "ended" };
   const withheld = badgeWithholding(input);
   if (withheld) return { kind: "none", because: withheld };
-  return { kind: "rating", word: publishedVendorLevel(input.level, input.cause) };
+  const word = publishedVendorLevel(input.level, input.cause);
+  if (word === null) return { kind: "none", because: { reason: input.levelWithheld ?? "no_source" } };
+  return { kind: "rating", word };
 }
 
 export type FreeTierClaim =
@@ -180,7 +189,7 @@ export function vendorVerdictSentence(input: VendorVerdictInput): string {
     return `${clause.charAt(0).toUpperCase()}${clause.slice(1)}, so we cannot confirm these terms today.`;
   }
   const level = publishedVendorLevel(input.level, input.cause);
-  if (input.gate) return vendorHistorySentence(input.vendor, level, input.cause);
+  if (input.gate || level === null) return vendorHistorySentence(input.vendor, input.historyLevel, input.cause);
 
   if (level !== "stable" && input.cause) {
     const unconfirmed = input.levelWithheld

--- a/test/audit-stack.test.ts
+++ b/test/audit-stack.test.ts
@@ -21,7 +21,10 @@ describe("auditStack logic", () => {
     for (const svc of result.services) {
       assert.strictEqual(svc.status, "found");
       assert.ok(svc.category);
-      assert.ok(svc.risk_level);
+      assert.ok(
+        ["stable", "caution", "risky"].includes(svc.risk_level) || svc.level_withheld_because,
+        `${svc.vendor} audits as ${svc.risk_level} and nothing says why`,
+      );
     }
   });
 
@@ -46,18 +49,24 @@ describe("auditStack logic", () => {
   });
 
   it("detects risk from deal changes", async () => {
-    const { auditStack, loadOffers, loadDealChanges, vendorRiskLevel } = await import("../dist/data.js");
+    const { auditStack, loadOffers, loadDealChanges, findVendor, publishedRisk } = await import("../dist/data.js");
     const changes = loadDealChanges();
-    const demoted = [...new Set(loadOffers().map(o => o.vendor))]
-      .filter(v => vendorRiskLevel(changes.filter(c => c.vendor.toLowerCase() === v.toLowerCase())) !== "stable")
+    const offers = loadOffers();
+    const demoted = [...new Set(offers.map(o => o.vendor))]
+      .filter(v => {
+        const match = findVendor(offers, v);
+        if (match.type !== "exact") return false;
+        const level = publishedRisk(match.offer, changes.filter(c => c.vendor.toLowerCase() === v.toLowerCase())).risk_level;
+        return level === "caution" || level === "risky";
+      })
       .slice(0, 2);
-    assert.strictEqual(demoted.length, 2, "the index holds fewer than two vendors the risk scale demotes");
+    assert.strictEqual(demoted.length, 2, "the index holds fewer than two vendors we publish a demoted level for");
     const result = auditStack(demoted);
     assert.ok(result.risks_found >= 2, `Should find at least 2 risks, got ${result.risks_found}`);
     for (const vendor of demoted) {
       const service = result.services.find(s => s.vendor === vendor);
       assert.ok(service, `${vendor} is missing from the audit`);
-      assert.notStrictEqual(service.risk_level, "stable", `${vendor} audits as stable`);
+      assert.ok(["caution", "risky"].includes(service.risk_level), `${vendor} audits as ${service.risk_level}`);
     }
   });
 

--- a/test/enrich.test.ts
+++ b/test/enrich.test.ts
@@ -79,6 +79,7 @@ describe("enrichOffers", () => {
       if (!offer) continue;
       const enriched = enrichOffers([offer])[0];
       if (levelWithheldReason(offer, enriched.link_unreachable)) continue;
+      if (enriched.gate) continue;
       assert.strictEqual(
         enriched.risk_level,
         "stable",
@@ -117,8 +118,8 @@ describe("enrichOffers", () => {
     const { levelWithheldReason } = await import("../dist/source-check.js");
     const withheld = enrichOffers(loadOffers()).filter((o: { risk_level: string | null }) => o.risk_level === null);
     const unexplained = withheld.filter(
-      (o: { link_unreachable: unknown; rating_withheld: unknown }) =>
-        !levelWithheldReason(o as never, o.link_unreachable) && !o.rating_withheld
+      (o: { link_unreachable: unknown; rating_withheld: unknown; gate: unknown }) =>
+        !levelWithheldReason(o as never, o.link_unreachable) && !o.rating_withheld && !o.gate
     );
     assert.strictEqual(unexplained.length, 0, `${unexplained.length} offers publish no level and no reason for withholding it`);
   });

--- a/test/mcp-risk-indicators.test.ts
+++ b/test/mcp-risk-indicators.test.ts
@@ -158,11 +158,11 @@ describe("MCP risk_level/stability indicators (issue #969)", () => {
       assert.ok(Array.isArray(role.candidates) && role.candidates.length > 0, `${role.role} should have candidates`);
       for (const c of role.candidates) {
         assert.ok(
-          ["stable", "caution", "risky"].includes(c.risk_level) || c.rating_withheld,
+          ["stable", "caution", "risky"].includes(c.risk_level) || c.level_withheld_because,
           `candidate ${c.vendor} has risk_level ${c.risk_level} and no field says why`
         );
         assert.ok(
-          !(c.risk_level && c.rating_withheld),
+          !(c.risk_level && c.level_withheld_because),
           `candidate ${c.vendor} publishes both a level and a reason it was withheld`
         );
         assert.ok(

--- a/test/one-published-risk.test.ts
+++ b/test/one-published-risk.test.ts
@@ -1,0 +1,374 @@
+import { describe, it, before, after } from "node:test";
+import assert from "node:assert";
+import fs from "node:fs";
+import path from "node:path";
+import { spawn, type ChildProcess } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import { assertPopulationFloor } from "./population-floor.ts";
+import {
+  auditStack,
+  checkVendorRisk,
+  enrichOffers,
+  findVendor,
+  levelWithheldStatement,
+  loadDealChanges,
+  loadOffers,
+  publishedRisk,
+  vendorRiskAssessment,
+} from "../dist/data.js";
+import { cannotVouchForLevel } from "../dist/source-check.js";
+import { getStackRecommendation } from "../dist/stacks.js";
+import { gradeForStack, isRated, RATED_LEVELS } from "../dist/stack-grade.js";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO = path.join(__dirname, "..");
+
+const RECORDS_FLOOR = 1000;
+const NAMES_FLOOR = 1000;
+const WITHHELD_FLOOR = 400;
+const CANDIDATE_SLOTS_FLOOR = 500;
+
+function changesFor(vendor: string) {
+  return loadDealChanges().filter(c => c.vendor.toLowerCase() === vendor.toLowerCase());
+}
+
+describe("one function decides a published risk level", () => {
+  it("withholds the level for a gated offer, an uncited record and an unread source page", () => {
+    const offers = loadOffers();
+    const changes = loadDealChanges();
+    const withheld = { gate: 0, rating_withheld: 0, source: 0 };
+    for (const offer of offers) {
+      const risk = publishedRisk(offer, changes.filter(c => c.vendor.toLowerCase() === offer.vendor.toLowerCase()));
+      if (risk.risk_level !== null) continue;
+      if (risk.gate) withheld.gate++;
+      else if (risk.rating_withheld) withheld.rating_withheld++;
+      else withheld.source++;
+    }
+    for (const [rule, count] of Object.entries(withheld)) {
+      assert.ok(count > 0, `no record in the catalogue has its level withheld by ${rule}, so that rule is untested here`);
+    }
+  });
+
+  it("a level is published only when no rule withholds it", () => {
+    const offers = loadOffers();
+    const changes = loadDealChanges();
+    let rated = 0;
+    for (const offer of offers) {
+      const risk = publishedRisk(offer, changes.filter(c => c.vendor.toLowerCase() === offer.vendor.toLowerCase()));
+      if (risk.risk_level === null) continue;
+      rated++;
+      assert.strictEqual(risk.gate, null, `${offer.vendor} publishes ${risk.risk_level} on a gated offer`);
+      assert.strictEqual(risk.rating_withheld, null, `${offer.vendor} publishes ${risk.risk_level} from records that cite no source`);
+      assert.ok(RATED_LEVELS.includes(risk.risk_level), `${offer.vendor} publishes ${risk.risk_level}`);
+    }
+    assertPopulationFloor(rated, RECORDS_FLOOR / 2, "records carry a published level");
+  });
+
+  it("withholds a favourable level against an unread source page, and publishes an adverse one", () => {
+    const offers = loadOffers();
+    const changes = loadDealChanges();
+    let adverse = 0;
+    for (const offer of offers) {
+      const vendorChanges = changes.filter(c => c.vendor.toLowerCase() === offer.vendor.toLowerCase());
+      const risk = publishedRisk(offer, vendorChanges);
+      if (risk.gate || risk.rating_withheld) continue;
+      if (!cannotVouchForLevel(offer, risk.link_unreachable)) continue;
+      const recorded = vendorRiskAssessment(vendorChanges).level;
+      if (recorded === "stable") {
+        assert.strictEqual(risk.risk_level, null, `${offer.vendor} publishes stable over a page we could not read`);
+        continue;
+      }
+      adverse++;
+      assert.strictEqual(
+        risk.risk_level,
+        recorded,
+        `${offer.vendor}: a page we could not read withheld the ${recorded} its own records earned`,
+      );
+    }
+    assert.ok(adverse > 0, "no record carries an adverse level beside a source we cannot vouch for, so that half of the rule is untested here");
+  });
+
+  it("every withheld level states the rule that withheld it", () => {
+    const offers = loadOffers();
+    const changes = loadDealChanges();
+    let withheld = 0;
+    for (const offer of offers) {
+      const risk = publishedRisk(offer, changes.filter(c => c.vendor.toLowerCase() === offer.vendor.toLowerCase()));
+      if (risk.risk_level !== null) {
+        assert.strictEqual(levelWithheldStatement(offer.vendor, risk), null, `${offer.vendor} carries a level and a reason it was withheld`);
+        continue;
+      }
+      withheld++;
+      const statement = levelWithheldStatement(offer.vendor, risk);
+      assert.ok(statement && statement.length > 0, `${offer.vendor} has no level and nothing says why`);
+    }
+    assertPopulationFloor(withheld, WITHHELD_FLOOR, "records have their level withheld");
+  });
+});
+
+describe("every surface publishes the level /api/offers publishes", () => {
+  it("the enriched catalogue row is the published risk of its own record", () => {
+    const offers = loadOffers();
+    const changes = loadDealChanges();
+    const enriched = enrichOffers(offers);
+    assert.strictEqual(enriched.length, offers.length);
+    for (let at = 0; at < offers.length; at++) {
+      const expected = publishedRisk(offers[at], changes.filter(c => c.vendor.toLowerCase() === offers[at].vendor.toLowerCase()));
+      assert.strictEqual(
+        enriched[at].risk_level,
+        expected.risk_level,
+        `${offers[at].vendor} (${offers[at].url}) reads ${enriched[at].risk_level} on /api/offers and ${expected.risk_level} from the one function`,
+      );
+    }
+    assertPopulationFloor(offers.length, RECORDS_FLOOR, "records were compared");
+  });
+
+  it("/api/audit-stack answers for the record it resolved, exactly as /api/vendor-risk does", () => {
+    const offers = loadOffers();
+    const names = [...new Set(offers.map(o => o.vendor))];
+    const audit = auditStack(names);
+    let compared = 0;
+    for (const name of names) {
+      const svc = audit.services.find(s => s.vendor === name);
+      assert.ok(svc, `${name} is missing from the audit`);
+      assert.strictEqual(svc.status, "found", `${name} is in the index and the audit did not find it`);
+      const match = findVendor(offers, name);
+      assert.strictEqual(match.type, "exact", `${name} did not resolve to one record`);
+      const expected = publishedRisk(match.offer, changesFor(match.offer.vendor));
+      assert.strictEqual(svc.risk_level, expected.risk_level, `${name} audits as ${svc.risk_level} and the catalogue publishes ${expected.risk_level}`);
+      const viaVendorRisk = checkVendorRisk(name);
+      assert.ok(viaVendorRisk.result, `/api/vendor-risk did not answer for ${name}`);
+      assert.strictEqual(svc.risk_level, viaVendorRisk.result.risk_level ?? null, `${name} disagrees between /api/audit-stack and /api/vendor-risk`);
+      compared++;
+    }
+    assertPopulationFloor(compared, NAMES_FLOOR, "vendor names were compared across the two endpoints");
+  });
+
+  it("an audited service carries the withholding fields, and a withheld one says why", () => {
+    const offers = loadOffers();
+    const names = [...new Set(offers.map(o => o.vendor))];
+    const audit = auditStack(names);
+    let withheld = 0;
+    for (const svc of audit.services) {
+      if (svc.status !== "found") continue;
+      for (const field of ["gate", "rating_withheld", "link_unreachable", "source_check"]) {
+        assert.ok(field in svc, `${svc.vendor} carries no ${field} field`);
+      }
+      if (isRated(svc.risk_level)) {
+        assert.strictEqual(svc.gate, null, `${svc.vendor} is gated and audits as ${svc.risk_level}`);
+        continue;
+      }
+      withheld++;
+      assert.strictEqual(svc.risk_level, null, `${svc.vendor} audits as ${svc.risk_level}, which is not a level we publish`);
+      assert.ok(svc.level_withheld_because, `${svc.vendor} audits with no level and nothing says why`);
+    }
+    assertPopulationFloor(withheld, WITHHELD_FLOOR, "audited services have their level withheld");
+  });
+
+  it("an audited service we do not list carries the gate that says so", () => {
+    const offers = loadOffers();
+    const gatedNames = [...new Set(
+      offers.filter(o => publishedRisk(o, changesFor(o.vendor)).gate).map(o => o.vendor),
+    )];
+    const audit = auditStack(gatedNames);
+    let carried = 0;
+    for (const name of gatedNames) {
+      const match = findVendor(offers, name);
+      if (match.type !== "exact" || !publishedRisk(match.offer, changesFor(match.offer.vendor)).gate) continue;
+      const svc = audit.services.find(s => s.vendor === name);
+      assert.ok(svc, `${name} is missing from the audit`);
+      assert.ok(svc.gate, `${name} is an offer we do not list and the audit reports no gate`);
+      carried++;
+    }
+    assertPopulationFloor(carried, 40, "gated vendors were audited");
+  });
+
+  it("counts a vendor we decline to rate as unrated rather than as a risk found", () => {
+    const offers = loadOffers();
+    const withheld = offers
+      .filter(o => publishedRisk(o, changesFor(o.vendor)).risk_level === null)
+      .map(o => o.vendor)
+      .slice(0, 8);
+    assert.ok(withheld.length > 0, "no record has its level withheld, so nothing here is exercised");
+    assert.strictEqual(auditStack(withheld).risks_found, 0, "a stack of vendors we decline to rate reports risks");
+
+    const adverse = offers
+      .filter(o => ["caution", "risky"].includes(publishedRisk(o, changesFor(o.vendor)).risk_level as string))
+      .map(o => o.vendor)
+      .slice(0, 2);
+    assert.strictEqual(adverse.length, 2, "the catalogue holds fewer than two vendors we publish an adverse level for");
+    assert.strictEqual(auditStack(adverse).risks_found, 2, "a published adverse level is not counted as a risk found");
+  });
+
+  it("a recommended swap is a vendor we are willing to rate", () => {
+    const offers = loadOffers();
+    const names = [...new Set(offers.map(o => o.vendor))];
+    const audit = auditStack(names);
+    const targets = [...new Set(audit.services.filter(s => s.cheaper_alternative).map(s => s.cheaper_alternative!.vendor))];
+    for (const target of targets) {
+      const match = findVendor(offers, target);
+      assert.strictEqual(match.type, "exact", `the swap target ${target} does not resolve to one record`);
+      const risk = publishedRisk(match.offer, changesFor(match.offer.vendor));
+      assert.strictEqual(risk.risk_level, "stable", `${target} is offered as a swap and the catalogue publishes ${risk.risk_level}`);
+    }
+    assert.ok(targets.length > 0, "no swap was offered anywhere in the catalogue");
+  });
+
+  it("a stack candidate publishes the level its own record does, on every day of the rotation", () => {
+    const offers = loadOffers();
+    let slots = 0;
+    let withheld = 0;
+    for (let day = 0; day < 14; day++) {
+      const date = new Date(Date.UTC(2026, 0, 1) + day * 24 * 60 * 60 * 1000).toISOString().slice(0, 10);
+      for (const useCase of ["Next.js SaaS app", "AI startup", "mobile backend"]) {
+        for (const role of getStackRecommendation(useCase, undefined, date).stack) {
+          for (const candidate of role.candidates) {
+            slots++;
+            const record = offers.find(o => o.vendor === candidate.vendor && o.url === candidate.url);
+            assert.ok(record, `${candidate.vendor} is a candidate and is not a record in the index`);
+            const expected = publishedRisk(record, changesFor(record.vendor));
+            assert.strictEqual(candidate.risk_level, expected.risk_level, `${candidate.vendor} is offered as ${candidate.risk_level} and the catalogue publishes ${expected.risk_level}`);
+            if (candidate.risk_level !== null) continue;
+            withheld++;
+            assert.ok(candidate.level_withheld_because, `${candidate.vendor} is offered with no level and nothing says why`);
+          }
+        }
+      }
+    }
+    assertPopulationFloor(slots, CANDIDATE_SLOTS_FLOOR, "candidate slots were compared");
+    assert.ok(withheld > 0, "no candidate in the rotation has its level withheld, so the reason is untested here");
+  });
+});
+
+describe("no surface derives a level of its own", () => {
+  const DERIVES_A_LEVEL = /vendorRiskAssessment\s*\([^)]*\)\s*\.\s*level|assessment\s*\.\s*level|\bvendorRiskLevel\s*\(/;
+
+  it("only the one function reads a level off a raw assessment", () => {
+    const files = fs.readdirSync(path.join(REPO, "src")).filter(f => f.endsWith(".ts"));
+    const offenders: string[] = [];
+    for (const file of files) {
+      const source = fs.readFileSync(path.join(REPO, "src", file), "utf-8");
+      source.split("\n").forEach((line, at) => {
+        if (!DERIVES_A_LEVEL.test(line)) return;
+        if (file === "data.ts" && line.includes("const assessment = vendorRiskAssessment")) return;
+        if (file === "data.ts" && line.includes("assessment.level")) return;
+        offenders.push(`src/${file}:${at + 1} ${line.trim()}`);
+      });
+    }
+    assert.deepStrictEqual(offenders, [], "a surface reads a risk level without applying the rules that withhold one");
+    assertPopulationFloor(files.length, 20, "source files were scanned");
+  });
+
+  it("the withholding rule is written once", () => {
+    const source = fs.readFileSync(path.join(REPO, "src", "data.ts"), "utf-8");
+    const occurrences = source.split("cannotVouchForLevel(").length - 1;
+    assert.strictEqual(occurrences, 1, "cannotVouchForLevel is applied in more than one place in data.ts");
+  });
+});
+
+describe("a stack grade counts a vendor we decline to rate as unrated", () => {
+  const none = { stable: 0, caution: 0, risky: 0, withheld: 0, not_found: 0 };
+
+  it("a stack of nothing we rate earns no letter", () => {
+    const graded = gradeForStack({ ...none, withheld: 4 }, 4);
+    assert.strictEqual(graded.label, "No grade");
+    assert.ok(!/^[A-F]$/.test(graded.grade), `a stack we cannot rate was graded ${graded.grade}`);
+  });
+
+  it("an unrated vendor never earns the grade a stable one would", () => {
+    const allStable = gradeForStack({ ...none, stable: 4 }, 4);
+    const oneWithheld = gradeForStack({ ...none, stable: 3, withheld: 1 }, 4);
+    assert.strictEqual(allStable.grade, "A");
+    assert.strictEqual(oneWithheld.grade, "A");
+    assert.notStrictEqual(oneWithheld.description, allStable.description, "a partial stack claims the same thing about itself as a whole one");
+    assert.strictEqual(oneWithheld.denominator, "Grade based on 3 of 4 services.");
+  });
+
+  it("a withheld vendor does not dilute a risk it cannot vouch for", () => {
+    const overFour = gradeForStack({ ...none, risky: 1, stable: 3 }, 4);
+    const overTwo = gradeForStack({ ...none, risky: 1, stable: 1, withheld: 2 }, 4);
+    assert.strictEqual(overFour.grade, "D");
+    assert.strictEqual(overTwo.grade, "F", "one risky service in two rated ones was graded on a denominator of four");
+  });
+
+  it("every letter travels with the denominator it was computed over", () => {
+    const shapes = [
+      { stable: 4 }, { caution: 4 }, { risky: 4 }, { stable: 2, caution: 2 },
+      { stable: 1, risky: 3 }, { stable: 3, withheld: 1 }, { risky: 1, stable: 1, withheld: 2 },
+    ];
+    for (const shape of shapes) {
+      const counts = { ...none, ...shape };
+      const entered = counts.stable + counts.caution + counts.risky + counts.withheld;
+      const graded = gradeForStack(counts, entered);
+      assert.ok(/^[A-F]$/.test(graded.grade), `${JSON.stringify(shape)} earned no letter`);
+      assert.ok(graded.denominator.includes(`of ${entered} services`), `the ${graded.grade} for ${JSON.stringify(shape)} carries no denominator`);
+    }
+  });
+
+  it("a service not in the index is not counted as rated", () => {
+    const graded = gradeForStack({ ...none, stable: 1, not_found: 3 }, 4);
+    assert.strictEqual(graded.denominator, "Grade based on 1 of 4 services.");
+  });
+});
+
+describe("the stack check page ships the withholding", () => {
+  let proc: ChildProcess | null = null;
+  let port = 0;
+  let page = "";
+
+  before(async () => {
+    proc = await new Promise<ChildProcess>((resolve, reject) => {
+      const child = spawn("node", [path.join(REPO, "dist", "serve.js")], {
+        stdio: ["pipe", "pipe", "pipe"],
+        env: { ...process.env, PORT: "0", BASE_URL: "http://localhost" },
+      });
+      const timeout = setTimeout(() => { child.kill(); reject(new Error("Server startup timeout")); }, 30000);
+      child.stderr!.on("data", (data: Buffer) => {
+        const m = data.toString().match(/running on http:\/\/localhost:(\d+)/);
+        if (m) { port = parseInt(m[1], 10); clearTimeout(timeout); resolve(child); }
+      });
+      child.on("error", (err) => { clearTimeout(timeout); reject(err); });
+    });
+    const res = await fetch(`http://localhost:${port}/stack-check`);
+    assert.strictEqual(res.status, 200);
+    page = await res.text();
+  });
+
+  after(() => { if (proc) proc.kill(); });
+
+  it("the lookup it ships carries the level the catalogue publishes, and says why when there is none", () => {
+    const match = page.match(/var VENDOR_LOOKUP = (\{.*?\});\n/s);
+    assert.ok(match, "the page ships no vendor lookup");
+    const lookup = JSON.parse(match[1]) as Record<string, { vendor: string; risk_level: string | null; level_withheld_because: string | null }>;
+    const offers = loadOffers();
+    let compared = 0;
+    let withheld = 0;
+    for (const entry of Object.values(lookup)) {
+      const match = findVendor(offers, entry.vendor);
+      if (match.type !== "exact") continue;
+      compared++;
+      if (entry.risk_level === null) {
+        withheld++;
+        assert.ok(entry.level_withheld_because, `${entry.vendor} ships with no level and nothing says why`);
+        continue;
+      }
+      assert.ok(RATED_LEVELS.includes(entry.risk_level), `${entry.vendor} ships as ${entry.risk_level}`);
+      const expected = publishedRisk(match.offer, changesFor(match.offer.vendor));
+      assert.strictEqual(entry.risk_level, expected.risk_level, `${entry.vendor} ships as ${entry.risk_level} and the catalogue publishes ${expected.risk_level}`);
+    }
+    assertPopulationFloor(compared, NAMES_FLOOR, "lookup entries were compared against the catalogue");
+    assert.ok(withheld > 0, "the lookup withholds no level, so the reason is untested here");
+  });
+
+  it("the client substitutes no level of its own", () => {
+    for (const coercion of ["risk_level || 'stable'", "!== 'stable' && !rc"]) {
+      assert.ok(!page.includes(coercion), `the page still coerces a missing level: ${coercion}`);
+    }
+  });
+
+  it("the grade the page computes is the grade this module computes", () => {
+    assert.ok(page.includes("function gradeForStack"), "the page carries its own copy of the grading rule");
+    assert.ok(page.includes("gradeForStack(riskCounts, data.services.length)"), "the page does not call the shared rule");
+    assert.ok(page.includes(">Unrated<"), "the risk summary has no unrated stat");
+  });
+});

--- a/test/risk-badge.test.ts
+++ b/test/risk-badge.test.ts
@@ -164,28 +164,38 @@ describe("#1038 — the level is checkable", () => {
   });
 
   it("the vendor page publishes the dated cause beside the badge in the <h1>", async () => {
-    const { enrichOffers, loadOffers } = await import("../dist/data.js");
+    const { enrichOffers, loadOffers, loadDealChanges, vendorRiskAssessment } = await import("../dist/data.js");
     const { gateFor, utcDate } = await import("../dist/ranking.js");
+    const changes = loadDealChanges();
     const seen = new Set<string>();
-    const warned = enrichOffers(loadOffers())
+    const oneRecordEach = enrichOffers(loadOffers())
       .filter((o: { vendor: string }) => {
         if (seen.has(o.vendor)) return false;
         seen.add(o.vendor);
         return true;
-      })
-      .filter((o: { risk_level: string | null }) => o.risk_level && o.risk_level !== "stable");
-    const listed = warned.filter((o: object) => gateFor(o, utcDate()) === null).slice(0, 6);
-    const gated = warned.filter((o: object) => gateFor(o, utcDate()) !== null).slice(0, 6);
+      });
+    const listed = oneRecordEach
+      .filter((o: { risk_level: string | null }) => o.risk_level && o.risk_level !== "stable")
+      .slice(0, 6);
+    const wouldWarn = (o: { vendor: string }) =>
+      vendorRiskAssessment(changes.filter(c => c.vendor.toLowerCase() === o.vendor.toLowerCase())).level !== "stable";
+    const gated = oneRecordEach
+      .filter((o: object) => gateFor(o, utcDate()) !== null)
+      .filter(wouldWarn)
+      .slice(0, 6);
     assert.ok(listed.length > 0, "expected at least one warned vendor the ranker lists");
-    assert.ok(gated.length > 0, "no warned vendor is gated, so the withheld badge is unchecked here");
+    assert.ok(gated.length > 0, "no gated vendor holds records that would warn, so the withheld badge is unchecked here");
 
     for (const offer of gated) {
+      assert.strictEqual(offer.risk_level, null, `${offer.vendor} is gated and /api/offers publishes ${offer.risk_level}`);
       const { text } = await get(`/vendor/${toSlug(offer.vendor)}`);
       const h1 = text.match(/<h1>[\s\S]*?<\/h1>/)?.[0] ?? "";
-      assert.ok(
-        !new RegExp(offer.risk_level!).test(h1),
-        `${offer.vendor}: the <h1> of a ${gateFor(offer, utcDate())!.code} record reads ${offer.risk_level}`,
-      );
+      for (const level of ["stable", "caution", "risky"]) {
+        assert.ok(
+          !new RegExp(level).test(h1),
+          `${offer.vendor}: the <h1> of a ${gateFor(offer, utcDate())!.code} record reads ${level}`,
+        );
+      }
     }
 
     for (const offer of listed) {
@@ -377,7 +387,7 @@ describe("#1038 — risk does not rank", () => {
   it("src/ranking.ts does not read risk_level or stability", () => {
     const src = readFileSync(path.join(REPO, "src", "ranking.ts"), "utf8");
     const executable = src.split("\n").filter((l) => !/^\s*(\*|\/\/|\/\*|\*\/)/.test(l)).join("\n");
-    for (const token of ["risk_level", "vendorRiskLevel", "vendorRiskAssessment", "classifyStability", "stability"]) {
+    for (const token of ["risk_level", "vendorRiskLevel", "publishedRisk", "vendorRiskAssessment", "classifyStability", "stability"]) {
       assert.ok(!executable.includes(token), `src/ranking.ts reads ${token}`);
     }
   });

--- a/test/stacks.test.ts
+++ b/test/stacks.test.ts
@@ -94,13 +94,15 @@ describe("stack recommendation logic", () => {
     assert.ok(result.stack.length > 0);
     for (const role of result.stack) {
       for (const c of role.candidates) {
-        assert.ok("rating_withheld" in c, `${c.vendor} carries no rating_withheld field`);
+        for (const field of ["rating_withheld", "gate", "source_check", "link_unreachable"]) {
+          assert.ok(field in c, `${c.vendor} carries no ${field} field`);
+        }
         assert.ok(
-          ["stable", "caution", "risky"].includes(c.risk_level) || c.rating_withheld !== null,
+          ["stable", "caution", "risky"].includes(c.risk_level) || c.level_withheld_because,
           `${c.vendor} risk_level is ${c.risk_level} and no field says why`
         );
         assert.ok(
-          c.risk_level === null || c.rating_withheld === null,
+          c.risk_level === null || c.level_withheld_because === null,
           `${c.vendor} publishes both a level and a reason it was withheld`
         );
         assert.ok(
@@ -112,10 +114,11 @@ describe("stack recommendation logic", () => {
     }
   });
 
-  it("a candidate's level is withheld on exactly the days its own records are uncited", async () => {
+  it("a candidate publishes the level its own record does, on every day of the rotation", async () => {
     const { getStackRecommendation } = await import("../dist/stacks.js");
-    const { loadDealChanges, vendorRiskAssessment, standingNarrowingsCitingNoSource, classifyStability, withheldStability } = await import("../dist/data.js");
+    const { loadOffers, loadDealChanges, publishedRisk, standingNarrowingsCitingNoSource, classifyStability, withheldStability } = await import("../dist/data.js");
     const { unreachableNoticeForUrl } = await import("../dist/link-health.js");
+    const offers = loadOffers();
     const changesByVendor = new Map<string, unknown[]>();
     for (const c of loadDealChanges()) {
       const key = c.vendor.toLowerCase();
@@ -127,7 +130,9 @@ describe("stack recommendation logic", () => {
       const date = new Date(Date.UTC(2026, 8, 9) + day * 86400000).toISOString().slice(0, 10);
       for (const role of getStackRecommendation("Next.js SaaS app", undefined, date).stack) {
         for (const c of role.candidates) {
-          const expected = vendorRiskAssessment(changesByVendor.get(c.vendor.toLowerCase()) ?? []);
+          const record = offers.find(o => o.vendor === c.vendor && o.url === c.url);
+          assert.ok(record, `${date} ${c.vendor}: the candidate is not a record in the index`);
+          const expected = publishedRisk(record, changesByVendor.get(c.vendor.toLowerCase()) ?? []);
           assert.deepStrictEqual(
             c.rating_withheld,
             expected.rating_withheld,
@@ -135,7 +140,7 @@ describe("stack recommendation logic", () => {
           );
           assert.strictEqual(
             c.risk_level,
-            expected.rating_withheld ? null : expected.level,
+            expected.risk_level,
             `${date} ${c.vendor}: candidate level does not match the catalogue's`
           );
           const vendorChanges = changesByVendor.get(c.vendor.toLowerCase()) ?? [];

--- a/test/uncited-change-records.test.ts
+++ b/test/uncited-change-records.test.ts
@@ -104,6 +104,7 @@ describe("the verdict engine, given a withheld rating", () => {
   const input = (over: Partial<VendorVerdictInput> = {}): VendorVerdictInput => ({
     vendor: "Fixture Vendor",
     level: null,
+    historyLevel: "caution",
     cause: null,
     changes: [record({ source_url: "" })],
     levelWithheld: null,

--- a/test/vendor-verdict.test.ts
+++ b/test/vendor-verdict.test.ts
@@ -14,7 +14,7 @@ import {
   vendorVerdictWord,
   type VendorVerdictInput,
 } from "../dist/vendor-verdict.js";
-import { CHANGE_DIRECTION, enrichOffers, loadDealChanges, loadOffers, vendorRiskAssessment, classifyStability } from "../dist/data.js";
+import { CHANGE_DIRECTION, enrichOffers, loadDealChanges, loadOffers, publishedRisk, vendorRiskAssessment, classifyStability } from "../dist/data.js";
 import { vendorSlugMap } from "../dist/vendor-slug.js";
 import { isNoLongerInForce } from "../dist/change-resolution.js";
 import { levelWithheldReason } from "../dist/source-check.js";
@@ -34,6 +34,7 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const REPO = path.join(__dirname, "..");
 
 const STABILITY_SCALE_WORDS = /\b(volatile|improving)\b|on our watch list/i;
+const RATES_THE_TIER = /is considered (stable|risky)|requires caution/i;
 const OTHER_SCALE_ON_A_SURFACE_THAT_EMBEDS_SUMMARIES = /\bvolatile\b|on our watch list/i;
 const COUNT_AS_EVIDENCE = /\b\d+ pricing changes? recorded/;
 const CLAIMS_A_NARROWING = /(?:One recorded [^.]*|(?<!None of the )\d+ recorded changes) narrowed the terms/;
@@ -60,7 +61,7 @@ function causeOf(c: DealChange): RiskCause {
 }
 
 function input(over: Partial<VendorVerdictInput> = {}): VendorVerdictInput {
-  return { vendor: "Vendor A", level: "stable", cause: null, changes: [], levelWithheld: null, unconfirmableSince: "", ...over };
+  return { vendor: "Vendor A", level: "stable", historyLevel: "stable", cause: null, changes: [], levelWithheld: null, unconfirmableSince: "", ...over };
 }
 
 describe("vendor verdict — one rating word, and it carries its cause", () => {
@@ -86,9 +87,13 @@ describe("vendor verdict — one rating word, and it carries its cause", () => {
   it("falls back to stable when a level arrives with no record to show for it", () => {
     assert.strictEqual(publishedVendorLevel("caution", null), "stable");
     assert.strictEqual(publishedVendorLevel("risky", null), "stable");
-    assert.strictEqual(publishedVendorLevel(null, null), "stable");
     const c = change();
     assert.strictEqual(publishedVendorLevel("caution", causeOf(c)), "caution");
+  });
+
+  it("substitutes no level where the catalogue publishes none", () => {
+    assert.strictEqual(publishedVendorLevel(null, null), null);
+    assert.strictEqual(publishedVendorLevel(null, causeOf(change())), null);
   });
 
   it("withholds the rating entirely when we cannot read the page we cite", () => {
@@ -294,7 +299,8 @@ describe("vendor verdict — the prose table covers the data", () => {
 interface VendorRow {
   slug: string;
   vendor: string;
-  expected: "stable" | "caution" | "risky";
+  expected: "stable" | "caution" | "risky" | null;
+  historyLevel: "stable" | "caution" | "risky";
   badge: string;
   ended: boolean;
   withheld: ReturnType<typeof levelWithheldReason>;
@@ -327,6 +333,7 @@ function vendorRows(): VendorRow[] {
       slug,
       vendor,
       expected,
+      historyLevel: publishedRisk(primary, vendorChanges).history_level,
       ended,
       badge: ended ? ENDED_BADGE_LABEL : expected,
       withheld,
@@ -334,6 +341,7 @@ function vendorRows(): VendorRow[] {
       sentence: vendorVerdictSentence({
         vendor,
         level: enriched.risk_level ?? null,
+        historyLevel: publishedRisk(primary, vendorChanges).history_level,
         cause: enriched.risk_cause ?? null,
         changes: vendorChanges,
         levelWithheld: withheld,
@@ -365,14 +373,14 @@ describe("vendor verdict — corpus invariant, computed offline", () => {
         }
         continue;
       }
-      if (row.withheld && row.expected === "stable") {
+      if (row.expected === null && row.withheld) {
         if (/\bWe rate it\b/.test(row.sentence)) wrong.push(`${row.slug}: rates a vendor whose level we withhold`);
         continue;
       }
       if (row.gate) {
         if (row.badgeRendered) wrong.push(`${row.slug}: rates a gated record ${row.badge} beside its name`);
-        if (!row.sentence.includes(`${row.vendor} ${GATED_LEVEL_PHRASE[row.expected]}`)) {
-          wrong.push(`${row.slug}: gated verdict says ${row.sentence}, over a history we read as ${row.expected}`);
+        if (!row.sentence.includes(`${row.vendor} ${GATED_LEVEL_PHRASE[row.historyLevel]}`)) {
+          wrong.push(`${row.slug}: gated verdict says ${row.sentence}, over a history we read as ${row.historyLevel}`);
         }
         continue;
       }
@@ -551,11 +559,17 @@ describe("vendor verdict — as rendered", () => {
           wrong.push(`${row.slug}: no longer asks whether its free tier is reliable`);
         }
         if (answers.reliable !== null && !row.withheld && !row.ended) {
-          if (!answers.reliable.includes(row.expected)) {
-            wrong.push(`${row.slug}: the reliability answer does not carry the ${row.expected} rating`);
-          }
-          if (row.expected === "stable" && !answers.reliable.includes(narrowingSentence(row.changes))) {
-            wrong.push(`${row.slug}: the reliability answer does not say what the records it holds did — ${answers.reliable}`);
+          if (row.expected === null) {
+            if (RATES_THE_TIER.test(answers.reliable)) {
+              wrong.push(`${row.slug}: the reliability answer rates a vendor whose level we withhold — ${answers.reliable}`);
+            }
+          } else {
+            if (!answers.reliable.includes(row.expected)) {
+              wrong.push(`${row.slug}: the reliability answer does not carry the ${row.expected} rating`);
+            }
+            if (row.expected === "stable" && !answers.reliable.includes(narrowingSentence(row.changes))) {
+              wrong.push(`${row.slug}: the reliability answer does not say what the records it holds did — ${answers.reliable}`);
+            }
           }
         }
         const productionRating = answers.production.match(/we rate it (stable|caution|risky)\b/)?.[1];


### PR DESCRIPTION
Refs #1486. Completes the issue after the `stacks.ts` slice in #1489.

`publishedRisk(offer, vendorChanges, servedOn, nowMs)` in `src/data.ts` applies every rule that withholds a level — the gate (#1241/#1260), an uncited record set (#1352), and a source page we could not read or that names no terms (#1046) — and returns the level beside the four fields that say why there is none. `vendorRiskLevel()` is deleted. `levelWithheldStatement()` turns those fields into the sentence we already publish on the vendor page, so no surface writes its own.

All seven sites call it: `enrichOffers` (`/api/offers`, `search_deals`), `checkVendorRisk` and its alternatives list (`/api/vendor-risk`), `auditStack` (`/api/audit-stack`), `toCandidate` (`/api/stack`, MCP `plan_stack`), `/stack-check`'s lookup and `/budget-builder`.

## Measured, whole catalogue, on this branch

| | before | after |
|---|---|---|
| records `/api/offers` rates | 864 | 810 |
| gated records carrying a level | 54 | 0 |
| vendor names where `/api/audit-stack` disagrees with the record it resolved | 715 | 0 |
| audit rows carrying a `gate` field | 0 | 1,572 (161 non-null) |
| audit rows with no level and nothing saying why | — | 0 |
| swap targets we decline to rate | 49 | 0 |
| `plan_stack` slots disagreeing with the catalogue (21 roles × 30 days, 2,640 slots) | — | 0 |

The 54 gated records are AC-1 against AC-6, and this takes #1260's ruling, as stated on the issue. AC-6 holds as its positive control was written: no surface's rated population grows, and the 810 keep the level they had.

`/api/audit-stack` for the four vendors in the issue's opening now returns `risk_level: null` with a different stated reason for each — `offer_retired` for GitHub Models and Oaysus, the uncited record for Plunk, the unreadable source page for mailchannels.com. That stack scored **grade A, "Excellent — All services are stable"**; it now scores **No grade**, with each row saying why.

## AC-4, amended

`VENDOR_LOOKUP` carries the withholding: 835 stable, 255 caution, 54 risky, 1,165 null, and every null carries the sentence. Both client coercions are gone rather than made unreachable.

The grading rule is one function, `src/stack-grade.ts`, injected into the page by `toString()` so the browser and the tests run the same code. A withheld service lands in a fourth bucket; percentages are taken over `rated = found - withheld`; `rated === 0` renders **No grade** and no letter; and **every letter renders with "Grade based on N of M services." inside the block that carries it** — not only a partial one, so the denominator always travels with a screenshot.

The four ruled strings ship verbatim. One note: the F description for a partial stack is exactly *"Significant free tier risk across the rated services."*, which drops the *"— immediate action recommended"* tail the full-stack F keeps. Say if you want the tail back.

## Three things the issue did not name

**The vendor page substituted `stable` for a withheld level.** `publishedVendorLevel(level, cause)` returned `"stable"` when `level` was null — the same coercion as `svc.risk_level || 'stable'`, on a bigger surface. Applying the gate to `/api/offers` made it fire: `/vendor/digitalocean` read *"DigitalOcean has a stable pricing history"* over an `offer_expired` record whose own history is `caution`. It now reads *"DigitalOcean warrants caution — …"*. The function returns null for a withheld level and callers state the recorded history or the reason instead. This was a regression this branch would otherwise have shipped, so it is fixed here rather than reported.

**`/budget-builder` recommends four vendors we hold no record for** — PlanetScale, UploadThing, Mailgun, Plausible — and rated all four `stable`, because an empty change list assesses as stable. 40 of its 46 are rated, 2 are indexed and withheld, 4 are not in the index. The page now says so. Its ranking is unchanged: the ordering input moved to a server-computed `rank_penalty`, so no level drives it and none is published that we withhold.

**A non-gated vendor whose only records cite no source was recommended for production.** The production FAQ took the stable branch through the same coercion — *"We rate it stable and it offers …, so it's a reasonable starting point."* — for records #1352 exists to withhold.

## AC-7, and one thing to decide

`/api/audit-stack` carries the gate now, and `cheaper_alternative` is chosen with the same function.

**Nothing reads `VENDOR_LOOKUP`.** `/stack-check` renders from `/api/audit-stack`; the lookup is assigned and never referenced. It is **1,688,232 bytes — 97.9% of the 1.72 MB page** every visitor downloads. It is correct now, so this is not urgent, but deleting it would remove 1.6 MB from a share surface. Not done here because removing published data is your call, and doing it would satisfy the amended AC-4 vacuously.

Two smaller notes: `vendorLookup[slug]` is last-write-wins, so for the 7 vendor names with more than one record the lookup holds whichever record sorts last — pre-existing, and why the catalogue property is asserted per record rather than per name. And `auditStack`'s gap recommendation still picks `offers.filter(category && free)[0]` with no rule at all; no gated or withheld offer reaches it today, but nothing stops one.

## Verification

- Suite 4,674 of 4,674. `tsc --noEmit` clean.
- `npm run mutate:1486-round2`: 16 mutants, 16 killed. Three survived the first pass — an adverse level withheld alongside a favourable one (20 records), a missing gate on an audit row, and a withheld vendor counted in `risks_found`. All three input classes were non-empty, so each got a test rather than a deleted mutant.
- `test/one-published-risk.test.ts`: 21 tests. The catalogue property is asserted over all 1,580 records and all 1,572 names, not a fixture list, and a source scan refuses any file outside `data.ts` that reads a level off a raw assessment.
- Verified over HTTP on `/api/audit-stack`, `/stack-check` and `/budget-builder`, by screenshot on all three, and over a real MCP session — `initialize` → `tools/call` `plan_stack`, 32 candidates, 8 withheld, every one carrying its reason.