### PR TITLE
Read the plan table, not the lede, before a removal record withholds a free tier (#1495)

### DIFF
--- a/data/deal_changes.json
+++ b/data/deal_changes.json
@@ -4866,7 +4866,13 @@
       "category": "Monitoring",
       "alternatives": [],
       "detected_by": "reverify-ai",
-      "recorded_date": "2026-08-28"
+      "recorded_date": "2026-08-28",
+      "resolution": {
+        "state": "retracted",
+        "date": "2026-09-09",
+        "detail": "Retracted 2026-09-09: middleware.io/pricing/, the page this record cites, opens its plan ladder with \"Free Forever. $0. Free access to all features with monthly limits.\" and lists \"Up to 100GB Data. Up to 1k RUM Sessions. Up to 20k Synthetic Checks. 10 Browser Test Runs. Unlimited Users.\" Those are the terms this record withheld, figure for figure. The sentence this record read - \"We provide 14 days free trial with unlimited data ingestion\" - is an answer about trial retention further down the same page, and it is still there today beside the free plan. The page did not change; the reading did.",
+        "source_url": "https://middleware.io/pricing/"
+      }
     },
     {
       "vendor": "Harness CI",
@@ -4956,7 +4962,13 @@
       "category": "Dev Utilities",
       "alternatives": [],
       "detected_by": "reverify-ai",
-      "recorded_date": "2026-08-28"
+      "recorded_date": "2026-08-28",
+      "resolution": {
+        "state": "retracted",
+        "date": "2026-09-09",
+        "detail": "Retracted 2026-09-09: financialdata.net/pricing opens its ladder with \"Free. $ 0 /month. 300 Requests / Day. REST API & Python SDK. Symbol Lists. Market & Miscellaneous Data.\" Our withheld terms read \"Free plan allows 300 requests per day.\" The 10, 30 and 50 requests-per-second tiers this record describes are the paid rungs above it on the same page.",
+        "source_url": "https://financialdata.net/pricing"
+      }
     },
     {
       "vendor": "Penpot",
@@ -5001,7 +5013,13 @@
       "category": "Dev Utilities",
       "alternatives": [],
       "detected_by": "reverify-ai",
-      "recorded_date": "2026-08-28"
+      "recorded_date": "2026-08-28",
+      "resolution": {
+        "state": "retracted",
+        "date": "2026-09-09",
+        "detail": "Retracted 2026-09-09: advicement.io/dynamic-documents-api/pricing, linked from the homepage this record cites, publishes \"The DynamicDocs API is available on a free and paid plans\" and then \"Free Plan ... Free. 50 API Calls per Month. 0 Private LaTeX Templates. Access to JSON to PDF Templates. Dashboard Access.\" Our withheld terms read \"The free plan allows 50 API calls per month and access to a library of templates.\" The sentence this record read - \"Create documents from $0.062 per PDF\" - is a marketing line still on advicement.io today that names no plan.",
+        "source_url": "https://advicement.io/dynamic-documents-api/pricing"
+      }
     },
     {
       "vendor": "IP Geolocation API by ipwho.org",
@@ -5232,7 +5250,13 @@
       "category": "Forms",
       "alternatives": [],
       "detected_by": "reverify-ai",
-      "recorded_date": "2026-08-28"
+      "recorded_date": "2026-08-28",
+      "resolution": {
+        "state": "retracted",
+        "date": "2026-09-09",
+        "detail": "Retracted 2026-09-09: survicate.com/pricing/, the page this record cites, answers \"Is there a Free version of Survicate?\" with \"Yes! Our Free Plan is perfect for getting started with surveys at no cost. It includes: Up to 25 responses per month, 1 active survey at a time, Basic CRM integrations\", and adds \"When you sign up, you'll automatically start with a 10-day free trial of our pro features. After that, your account will switch to the Free Plan unless you choose to upgrade.\" The trial this record read converts to the free plan rather than replacing it. That answer is published only in the page's FAQPage structured markup - the visible accordion renders the questions without the answers - so re-reading the visible text of this URL can never recover it.",
+        "source_url": "https://survicate.com/pricing/"
+      }
     },
     {
       "vendor": "Zipcodestack",
@@ -5412,7 +5436,13 @@
       "category": "Monitoring",
       "alternatives": [],
       "detected_by": "reverify-ai",
-      "recorded_date": "2026-08-28"
+      "recorded_date": "2026-08-28",
+      "resolution": {
+        "state": "retracted",
+        "date": "2026-09-09",
+        "detail": "Retracted 2026-09-09: simpleobservability.com/pricing publishes \"Free. Free plan for one server. Ideal for testing, development, or low-traffic workloads.\" and prices it \"Free. for 1 server.\" with 50 metrics per server. Our withheld terms read \"Free for one server.\" The \"$3/month\" this record quotes is the paid rung above that plan and is still on the same page.",
+        "source_url": "https://simpleobservability.com/pricing"
+      }
     },
     {
       "vendor": "SweetUptime",
@@ -6429,7 +6459,13 @@
       "category": "Web Scraping",
       "alternatives": [],
       "detected_by": "reverify-ai",
-      "recorded_date": "2026-08-28"
+      "recorded_date": "2026-08-28",
+      "resolution": {
+        "state": "retracted",
+        "date": "2026-09-09",
+        "detail": "Retracted 2026-09-09: scraperapi.com/pricing/, the page this record cites, answers \"Does ScraperAPI offer a free plan?\" with \"Yes, ScraperAPI offers a free plan where you can sign up here and get 1,000 free API credits (with a maximum of 5 concurrent connections).\" Our withheld terms read \"Free plan: 1,000 API credits/month, 5 concurrent connections.\" The sentence this record read - \"Start collecting data with our 7-day trial and 5,000 API credits\" - is the banner above the paid ladder on the same page and is still there today.",
+        "source_url": "https://www.scraperapi.com/pricing/"
+      }
     },
     {
       "vendor": "Amazon ECR Public",
@@ -6820,13 +6856,13 @@
     },
     {
       "vendor": "InstallOnAir",
-      "change_type": "free_tier_removed",
+      "change_type": "limits_reduced",
       "date": "2026-08-28",
       "date_source": "discovered",
-      "summary": "The page offers a free trial of 8 days, and then requires payment to extend the expiry date.",
+      "summary": "Builds uploaded by a registered user now expire after 8 days, down from 60. Registration is still free and uploads are still free.",
       "previous_state": "Distribute iOS & Android apps over the air. Free plan: unlimited uploads, private links, 2-day expiration for guests, 60 days for registered users.",
-      "current_state": "Users can sign up and get access for 8 days. After that, they must pay to extend the expiry date: 1 Month - $1, 6 Months - $4.99, 1 Year - $9.99.",
-      "impact": "high",
+      "current_state": "www.installonair.com reads \"Register for free - Signup and get access to build for 8 days\". Expiry can then be extended for $1 (1 month), $4.99 (6 months) or $9.99 (1 year).",
+      "impact": "medium",
       "source_url": "https://www.installonair.com",
       "category": "Mobile Development",
       "alternatives": [],
@@ -6846,7 +6882,13 @@
       "category": "Server Management",
       "alternatives": [],
       "detected_by": "reverify-ai",
-      "recorded_date": "2026-08-28"
+      "recorded_date": "2026-08-28",
+      "resolution": {
+        "state": "retracted",
+        "date": "2026-09-09",
+        "detail": "Retracted 2026-09-09: ploi.io/pricing, one hop from the homepage this record cites, publishes a plan comparison whose first column is \"Free\" at \"€0 $0 /mo\", and its own FAQ reads \"After your trial ends, we will set your subscription to the free plan.\" The 5-day trial this record read is a trial of a paid plan that falls back to Free, not a replacement for it. The free plan has narrowed since we recorded it, and that narrowing is the limits_reduced record of 2026-09-07.",
+        "source_url": "https://ploi.io/pricing"
+      }
     },
     {
       "vendor": "openobserve.ai",
@@ -8805,13 +8847,13 @@
     },
     {
       "vendor": "localazy.com",
-      "change_type": "free_tier_removed",
+      "change_type": "limits_reduced",
       "date": "2026-09-07",
       "date_source": "discovered",
-      "summary": "The free tier now offers a 14-day trial with unlimited seats, projects, words, and languages. It's a trial, not a permanently free tier. Previously a free tier for 1000 source language strings.",
+      "summary": "The free plan now covers up to 200 source keys, down from 1,000 source language strings. It remains a free plan with unlimited seats and languages, not a trial.",
       "previous_state": "Free for 1000 source language strings, unlimited languages, unlimited contributors, startup and open source deals",
-      "current_state": "Offers a 14-day trial with unlimited seats, projects, words & languages. After the trial, users must subscribe to a paid plan.",
-      "impact": "high",
+      "current_state": "localazy.com/pricing publishes \"Small project = free plan! ... Up to 200 source keys, All essential localization features, Unlimited seats & languages\", prices \"Free Plan\" at 0 USD in its structured markup, and answers \"Can I use Localazy for free?\" with \"Yes, our free plan includes all core localization features\". The 14-day trial on the same page is a trial of the Business plan.",
+      "impact": "medium",
       "source_url": "https://localazy.com/pricing",
       "category": "Localization",
       "alternatives": [],

--- a/scripts/census-1495-removal-records.mjs
+++ b/scripts/census-1495-removal-records.mjs
@@ -1,0 +1,125 @@
+import { readFileSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const { freePlanStatedOn, readablePartsOf } = await import(`${root}/dist/page-free-plan.js`);
+const { isNoLongerInForce } = await import(`${root}/dist/change-resolution.js`);
+const { REMOVAL_CLASS, aFreePlanOnThePageWouldRefuteIt, removalRecordsInTheServedWindow, removalRecordsStillInForce } =
+  await import(`${root}/dist/removal-record.js`);
+
+const TIMEOUT_MS = 30000;
+const CONCURRENCY = 5;
+const AGENT = "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/125.0 Safari/537.36";
+
+const changes = JSON.parse(readFileSync(`${root}/data/deal_changes.json`, "utf8")).changes;
+const everywhere = process.argv.includes("--all");
+const inTheClass = everywhere
+  ? changes.filter((c) => REMOVAL_CLASS.has(c.change_type))
+  : removalRecordsInTheServedWindow(changes, Date.now());
+const inForce = removalRecordsStillInForce(inTheClass);
+const population = inForce.filter((c) => aFreePlanOnThePageWouldRefuteIt(c.change_type));
+const deprecations = inForce.length - population.length;
+
+async function fetched(url) {
+  const control = new AbortController();
+  const timer = setTimeout(() => control.abort(), TIMEOUT_MS);
+  try {
+    const response = await fetch(url, {
+      redirect: "follow",
+      signal: control.signal,
+      headers: { "user-agent": AGENT, accept: "text/html,application/xhtml+xml" },
+    });
+    const body = await response.text();
+    return { status: response.status, url: response.url, body };
+  } catch (error) {
+    return { status: 0, url, body: "", error: String(error?.message ?? error) };
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+async function inBatches(items, size, run) {
+  const out = [];
+  for (let at = 0; at < items.length; at += size) {
+    out.push(...(await Promise.all(items.slice(at, at + size).map(run))));
+  }
+  return out;
+}
+
+const rows = await inBatches(population, CONCURRENCY, async (change) => {
+  const url = change.source_url?.trim();
+  if (!url) return { change, url: null, reached: false, stated: null };
+  const page = await fetched(url);
+  if (page.status < 200 || page.status >= 400 || page.body === "") {
+    return { change, url, reached: false, status: page.status, error: page.error ?? null, stated: null };
+  }
+  const parts = readablePartsOf(page.body);
+  return {
+    change,
+    url,
+    landed: page.url,
+    reached: true,
+    status: page.status,
+    bytes: page.body.length,
+    stated: freePlanStatedOn(parts),
+  };
+});
+
+const refuted = rows.filter((r) => r.stated);
+const structuredOnly = refuted.filter((r) => r.stated.where === "structured");
+const unreachable = rows.filter((r) => !r.reached);
+
+console.log(`removal-class records ${everywhere ? "in the whole log" : "in the served window"}: ${inTheClass.length}`);
+console.log(`  change types counted: ${[...REMOVAL_CLASS].join(", ")}`);
+console.log(`  no longer in force, excluded: ${inTheClass.filter((c) => isNoLongerInForce(c)).length}`);
+console.log(`  deprecations, excluded — a live plan table does not refute a product ending: ${deprecations}`);
+console.log(`  read: ${population.length}`);
+console.log(`  cited page reached: ${rows.length - unreachable.length}`);
+console.log(`  cited page unreachable: ${unreachable.length}`);
+console.log(`  cited page states a free plan today: ${refuted.length}`);
+console.log(`    stated in visible text: ${refuted.length - structuredOnly.length}`);
+console.log(`    stated only in structured markup: ${structuredOnly.length}`);
+console.log("");
+
+for (const row of refuted) {
+  console.log(`${row.change.vendor} | ${row.change.change_type} | ${row.change.date} | ${row.stated.where}`);
+  console.log(`  ${row.url}`);
+  console.log(`  "${row.stated.sentence.slice(0, 240)}"`);
+}
+
+if (unreachable.length) {
+  console.log("");
+  console.log("unreachable:");
+  for (const row of unreachable) {
+    console.log(`  ${row.change.vendor} | ${row.url ?? "(no source_url)"} | status ${row.status ?? 0}${row.error ? ` | ${row.error}` : ""}`);
+  }
+}
+
+const out = process.argv.includes("--json") ? process.argv[process.argv.indexOf("--json") + 1] : null;
+if (out) {
+  writeFileSync(
+    out,
+    JSON.stringify(
+      {
+        read: new Date().toISOString().slice(0, 10),
+        population: population.length,
+        reached: rows.length - unreachable.length,
+        refuted: refuted.length,
+        structured_only: structuredOnly.length,
+        rows: rows.map((r) => ({
+          vendor: r.change.vendor,
+          change_type: r.change.change_type,
+          date: r.change.date,
+          url: r.url,
+          landed: r.landed ?? null,
+          reached: r.reached,
+          status: r.status ?? 0,
+          stated: r.stated,
+        })),
+      },
+      null,
+      2,
+    ),
+  );
+}

--- a/scripts/correct-1495-removal-records.mjs
+++ b/scripts/correct-1495-removal-records.mjs
@@ -1,0 +1,131 @@
+import { readFileSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const file = `${root}/data/deal_changes.json`;
+const READ_ON = "2026-09-09";
+
+const RETRACTIONS = [
+  {
+    vendor: "Middleware.io",
+    date: "2026-08-28",
+    source_url: "https://middleware.io/pricing/",
+    detail:
+      `Retracted ${READ_ON}: middleware.io/pricing/, the page this record cites, opens its plan ladder with "Free Forever. $0. Free access to all features with monthly limits." and lists "Up to 100GB Data. Up to 1k RUM Sessions. Up to 20k Synthetic Checks. 10 Browser Test Runs. Unlimited Users." Those are the terms this record withheld, figure for figure. The sentence this record read - "We provide 14 days free trial with unlimited data ingestion" - is an answer about trial retention further down the same page, and it is still there today beside the free plan. The page did not change; the reading did.`,
+  },
+  {
+    vendor: "ploi.io",
+    date: "2026-08-28",
+    source_url: "https://ploi.io/pricing",
+    detail:
+      `Retracted ${READ_ON}: ploi.io/pricing, one hop from the homepage this record cites, publishes a plan comparison whose first column is "Free" at "€0 $0 /mo", and its own FAQ reads "After your trial ends, we will set your subscription to the free plan." The 5-day trial this record read is a trial of a paid plan that falls back to Free, not a replacement for it. The free plan has narrowed since we recorded it, and that narrowing is the limits_reduced record of 2026-09-07.`,
+  },
+  {
+    vendor: "Simple Observability",
+    date: "2026-08-28",
+    source_url: "https://simpleobservability.com/pricing",
+    detail:
+      `Retracted ${READ_ON}: simpleobservability.com/pricing publishes "Free. Free plan for one server. Ideal for testing, development, or low-traffic workloads." and prices it "Free. for 1 server." with 50 metrics per server. Our withheld terms read "Free for one server." The "$3/month" this record quotes is the paid rung above that plan and is still on the same page.`,
+  },
+  {
+    vendor: "Financial Data",
+    date: "2026-08-28",
+    source_url: "https://financialdata.net/pricing",
+    detail:
+      `Retracted ${READ_ON}: financialdata.net/pricing opens its ladder with "Free. $ 0 /month. 300 Requests / Day. REST API & Python SDK. Symbol Lists. Market & Miscellaneous Data." Our withheld terms read "Free plan allows 300 requests per day." The 10, 30 and 50 requests-per-second tiers this record describes are the paid rungs above it on the same page.`,
+  },
+  {
+    vendor: "DynamicDocs",
+    date: "2026-08-28",
+    source_url: "https://advicement.io/dynamic-documents-api/pricing",
+    detail:
+      `Retracted ${READ_ON}: advicement.io/dynamic-documents-api/pricing, linked from the homepage this record cites, publishes "The DynamicDocs API is available on a free and paid plans" and then "Free Plan ... Free. 50 API Calls per Month. 0 Private LaTeX Templates. Access to JSON to PDF Templates. Dashboard Access." Our withheld terms read "The free plan allows 50 API calls per month and access to a library of templates." The sentence this record read - "Create documents from $0.062 per PDF" - is a marketing line still on advicement.io today that names no plan.`,
+  },
+  {
+    vendor: "Survicate",
+    date: "2026-08-28",
+    source_url: "https://survicate.com/pricing/",
+    detail:
+      `Retracted ${READ_ON}: survicate.com/pricing/, the page this record cites, answers "Is there a Free version of Survicate?" with "Yes! Our Free Plan is perfect for getting started with surveys at no cost. It includes: Up to 25 responses per month, 1 active survey at a time, Basic CRM integrations", and adds "When you sign up, you'll automatically start with a 10-day free trial of our pro features. After that, your account will switch to the Free Plan unless you choose to upgrade." The trial this record read converts to the free plan rather than replacing it. That answer is published only in the page's FAQPage structured markup - the visible accordion renders the questions without the answers - so re-reading the visible text of this URL can never recover it.`,
+  },
+  {
+    vendor: "ScraperAPI",
+    date: "2026-08-28",
+    source_url: "https://www.scraperapi.com/pricing/",
+    detail:
+      `Retracted ${READ_ON}: scraperapi.com/pricing/, the page this record cites, answers "Does ScraperAPI offer a free plan?" with "Yes, ScraperAPI offers a free plan where you can sign up here and get 1,000 free API credits (with a maximum of 5 concurrent connections)." Our withheld terms read "Free plan: 1,000 API credits/month, 5 concurrent connections." The sentence this record read - "Start collecting data with our 7-day trial and 5,000 API credits" - is the banner above the paid ladder on the same page and is still there today.`,
+  },
+];
+
+const RETYPINGS = [
+  {
+    vendor: "localazy.com",
+    date: "2026-09-07",
+    from: "free_tier_removed",
+    to: "limits_reduced",
+    impact: "medium",
+    summary:
+      "The free plan now covers up to 200 source keys, down from 1,000 source language strings. It remains a free plan with unlimited seats and languages, not a trial.",
+    current_state:
+      'localazy.com/pricing publishes "Small project = free plan! ... Up to 200 source keys, All essential localization features, Unlimited seats & languages", prices "Free Plan" at 0 USD in its structured markup, and answers "Can I use Localazy for free?" with "Yes, our free plan includes all core localization features". The 14-day trial on the same page is a trial of the Business plan.',
+  },
+  {
+    vendor: "InstallOnAir",
+    date: "2026-08-28",
+    from: "free_tier_removed",
+    to: "limits_reduced",
+    impact: "medium",
+    summary:
+      "Builds uploaded by a registered user now expire after 8 days, down from 60. Registration is still free and uploads are still free.",
+    current_state:
+      'www.installonair.com reads "Register for free - Signup and get access to build for 8 days". Expiry can then be extended for $1 (1 month), $4.99 (6 months) or $9.99 (1 year).',
+  },
+];
+
+const data = JSON.parse(readFileSync(file, "utf8"));
+const changes = data.changes;
+
+function locate(vendor, date, changeType) {
+  const at = changes.findIndex(
+    (c) => c.vendor === vendor && c.date === date && c.change_type === changeType,
+  );
+  if (at < 0) throw new Error(`no ${changeType} record for ${vendor} on ${date}`);
+  return at;
+}
+
+let retracted = 0;
+for (const entry of RETRACTIONS) {
+  const at = locate(entry.vendor, entry.date, "free_tier_removed");
+  if (changes[at].resolution?.detail === entry.detail) continue;
+  changes[at] = {
+    ...changes[at],
+    resolution: {
+      state: "retracted",
+      date: READ_ON,
+      detail: entry.detail,
+      source_url: entry.source_url,
+    },
+  };
+  retracted += 1;
+}
+
+let retyped = 0;
+for (const entry of RETYPINGS) {
+  const at = changes.findIndex(
+    (c) => c.vendor === entry.vendor && c.date === entry.date && (c.change_type === entry.from || c.change_type === entry.to),
+  );
+  if (at < 0) throw new Error(`no record for ${entry.vendor} on ${entry.date}`);
+  if (changes[at].change_type === entry.to && changes[at].summary === entry.summary) continue;
+  changes[at] = {
+    ...changes[at],
+    change_type: entry.to,
+    impact: entry.impact,
+    summary: entry.summary,
+    current_state: entry.current_state,
+  };
+  retyped += 1;
+}
+
+writeFileSync(file, `${JSON.stringify(data, null, 2)}\n`);
+console.log(`retracted ${retracted}, re-typed ${retyped}`);

--- a/src/page-free-plan.ts
+++ b/src/page-free-plan.ts
@@ -1,0 +1,120 @@
+import { offeredOutrightAndNotDenied, sentencesOf } from "./superseding-reading.js";
+
+export type WhereStated = "visible" | "structured";
+
+export const A_PLAN_PRICED_AT_NOTHING =
+  /\b(?:always\s+free|free\s+forever|forever\s+free)\b|\bfree[\s'"’-]{0,3}(?:plans?|tiers?|editions?|versions?)\b|\b(?:plans?|tiers?|editions?|versions?)\b[^.!?]{0,24}?\bis\s+free\b|[$€£]\s?0(?:[.,]0{1,2})?\s*(?:\/\s*|per\s+)(?:mo|month|user|seat|year|yr)\b|\bfree\b\s*[:=]\s*[$€£]\s?0\b/i;
+
+export const A_QUESTION = /\?\s*$/;
+
+export interface ReadableParts {
+  visible: string;
+  structured: string;
+}
+
+export interface FreePlanStatement {
+  where: WhereStated;
+  sentence: string;
+}
+
+const SCRIPT_BLOCK = /<script\b([^>]*)>([\s\S]*?)<\/script>/gi;
+const LD_JSON_TYPE = /type\s*=\s*["']?application\/ld\+json["']?/i;
+
+const ENTITIES: [RegExp, string][] = [
+  [/&nbsp;|&#160;/g, " "],
+  [/&amp;|&#38;/g, "&"],
+  [/&lt;|&#60;/g, "<"],
+  [/&gt;|&#62;/g, ">"],
+  [/&quot;|&#34;/g, '"'],
+  [/&#0?39;|&apos;|&rsquo;|&#8217;/g, "'"],
+  [/&#36;/g, "$"],
+  [/&euro;|&#8364;/g, "€"],
+  [/&pound;|&#163;/g, "£"],
+  [/&mdash;|&#8212;/g, "—"],
+  [/&ndash;|&#8211;/g, "–"],
+];
+
+function decoded(text: string): string {
+  return ENTITIES.reduce((out, [pattern, replacement]) => out.replace(pattern, replacement), text);
+}
+
+function collapsed(text: string): string {
+  return decoded(text).replace(/\s+/g, " ").trim();
+}
+
+export function visibleTextOf(html: string): string {
+  const withoutMarkup = html
+    .replace(/<script[\s\S]*?<\/script>/gi, " ")
+    .replace(/<style[\s\S]*?<\/style>/gi, " ")
+    .replace(/<noscript[\s\S]*?<\/noscript>/gi, " ")
+    .replace(/<!--[\s\S]*?-->/g, " ")
+    .replace(/<(?:br|\/p|\/div|\/li|\/h[1-6]|\/td|\/th|\/tr|\/section)\b[^>]*>/gi, ". ")
+    .replace(/<[^>]+>/g, " ");
+  return collapsed(withoutMarkup);
+}
+
+function everyStringIn(value: unknown, into: string[]): void {
+  if (typeof value === "string") {
+    if (value.trim() !== "") into.push(value.trim());
+    return;
+  }
+  if (typeof value === "number") {
+    into.push(String(value));
+    return;
+  }
+  if (Array.isArray(value)) {
+    for (const item of value) everyStringIn(item, into);
+    return;
+  }
+  if (value && typeof value === "object") {
+    for (const [key, item] of Object.entries(value as Record<string, unknown>)) {
+      if (key === "@context" || key === "@id" || key === "url" || key === "image") continue;
+      everyStringIn(item, into);
+    }
+  }
+}
+
+export function structuredTextOf(html: string): string {
+  const parts: string[] = [];
+  for (const block of html.matchAll(SCRIPT_BLOCK)) {
+    if (!LD_JSON_TYPE.test(block[1] ?? "")) continue;
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(decoded(block[2]));
+    } catch {
+      continue;
+    }
+    const strings: string[] = [];
+    everyStringIn(parsed, strings);
+    parts.push(...strings);
+  }
+  return collapsed(parts.join(". "));
+}
+
+export function readablePartsOf(html: string): ReadableParts {
+  return { visible: visibleTextOf(html), structured: structuredTextOf(html) };
+}
+
+export function statesAFreePlan(sentence: string): boolean {
+  if (A_QUESTION.test(sentence.trim())) return false;
+  return offeredOutrightAndNotDenied(sentence, A_PLAN_PRICED_AT_NOTHING);
+}
+
+export function whereAFreePlanIsStated(text: string): string | null {
+  for (const sentence of sentencesOf(text)) {
+    if (statesAFreePlan(sentence.text)) return sentence.text.trim();
+  }
+  return null;
+}
+
+export function freePlanStatedOn(parts: ReadableParts): FreePlanStatement | null {
+  const visible = whereAFreePlanIsStated(parts.visible);
+  if (visible) return { where: "visible", sentence: visible };
+  const structured = whereAFreePlanIsStated(parts.structured);
+  if (structured) return { where: "structured", sentence: structured };
+  return null;
+}
+
+export function statedOnlyInMarkupWeDiscard(parts: ReadableParts): boolean {
+  return freePlanStatedOn(parts)?.where === "structured";
+}

--- a/src/removal-record.ts
+++ b/src/removal-record.ts
@@ -1,0 +1,34 @@
+import { DEFAULT_CHANGE_WINDOW_DAYS } from "./data.js";
+import { isNoLongerInForce } from "./change-resolution.js";
+
+export const REMOVAL_CLASS = new Set(["free_tier_removed", "product_deprecated"]);
+
+export function saysAFreeTierEnded(changeType: string): boolean {
+  return REMOVAL_CLASS.has(changeType);
+}
+
+export function aFreePlanOnThePageWouldRefuteIt(changeType: string): boolean {
+  return changeType === "free_tier_removed";
+}
+
+type RemovalCandidate = {
+  change_type: string;
+  date: string;
+  resolution?: unknown;
+};
+
+export function servedWindowOpens(nowMs: number = Date.now()): string {
+  return new Date(nowMs - DEFAULT_CHANGE_WINDOW_DAYS * 24 * 60 * 60 * 1000).toISOString().slice(0, 10);
+}
+
+export function removalRecordsInTheServedWindow<T extends RemovalCandidate>(
+  changes: readonly T[],
+  nowMs: number = Date.now(),
+): T[] {
+  const opens = servedWindowOpens(nowMs);
+  return changes.filter((c) => saysAFreeTierEnded(c.change_type) && c.date >= opens);
+}
+
+export function removalRecordsStillInForce<T extends RemovalCandidate>(changes: readonly T[]): T[] {
+  return changes.filter((c) => saysAFreeTierEnded(c.change_type) && !isNoLongerInForce(c as { resolution?: never }));
+}

--- a/src/superseding-reading.ts
+++ b/src/superseding-reading.ts
@@ -13,7 +13,7 @@ export const A_TRIAL = /\btrials?\b|\bfree\s+for\s+\d+\s+(?:days?|weeks?|months?
 export const A_PLAN_PRICE = /[$€£]\s?[\d,]+(?:\.\d+)?|\b[\d,]+(?:\.\d+)?\s*(?:USD|EUR|GBP)\b/i;
 
 export const DENIES_A_FREE_PLAN =
-  /\b(?:does\s+not|doesn['’]t|do\s+not|no\s+longer|not\s+available|only\s+available|is\s+not|are\s+not|remov(?:e|es|ed|ing|al)|sunset(?:s|ting|ted)?|shutting\s+down|shut\s+down|deprecat(?:e|ed|ing|ion)|discontinu(?:e|ed|ing))\b/i;
+  /\b(?:does\s+not|doesn['’]t|do\s+not|no\s+longer|not\s+available|only\s+available|is\s+not|are\s+not|remov(?:e|es|ed|ing|al)|sunset(?:s|ting|ted)?|shutting\s+down|shut\s+down|deprecat(?:e|ed|ing|ion)|discontinu(?:e|ed|ing)|retir(?:e|es|ed|ing|ement)|phas(?:e|es|ed|ing)\s+out|wind(?:s|ing)?\s+down|winding\s+down)\b/i;
 
 const CLAUSE_BREAK = /[;:|]|,(?=\s)|\s+[-–—]\s+/g;
 
@@ -51,10 +51,14 @@ function whereItIsOfferedOutrightIn(text: string, pattern: RegExp): number {
   return -1;
 }
 
-export function namesAFreePlan(sentence: string): boolean {
-  const at = whereItIsOfferedOutrightIn(sentence, A_FREE_PLAN);
+export function offeredOutrightAndNotDenied(sentence: string, pattern: RegExp): boolean {
+  const at = whereItIsOfferedOutrightIn(sentence, pattern);
   if (at < 0) return false;
   return !DENIES_A_FREE_PLAN.test(clauseAround(sentence, at).text);
+}
+
+export function namesAFreePlan(sentence: string): boolean {
+  return offeredOutrightAndNotDenied(sentence, A_FREE_PLAN);
 }
 
 export function mentionsSomethingFree(text: string): boolean {

--- a/src/vendor-verdict.ts
+++ b/src/vendor-verdict.ts
@@ -1,6 +1,6 @@
 import type { DealChange, RatingWithheld, RiskCause, SourceCheckOutcome } from "./types.js";
 import { CHANGE_DIRECTION, isACorrectionToOurOwnRecord } from "./data.js";
-import { isNoLongerInForce } from "./change-resolution.js";
+import { isNoLongerInForce, theEventNeverHappened } from "./change-resolution.js";
 import { changeIsUncited, ratingWithheldForNoSourceSentence } from "./change-citation.js";
 import { changeDateClause } from "./change-dates.js";
 import {
@@ -158,13 +158,28 @@ export function uncitedOnlySentence(records: number): string {
     : `All ${records} records we hold cite no source, so none of them sets a rating.`;
 }
 
+export function withdrawnOnlySentence(records: number): string {
+  if (records === 0) return "";
+  return records === 1
+    ? `The one record we hold was our own error and has been withdrawn.`
+    : `All ${records} records we hold were our own errors and have been withdrawn.`;
+}
+
+export function isOurOwnBookkeeping(
+  change: Pick<DealChange, "change_type"> & { resolution?: DealChange["resolution"] },
+): boolean {
+  return isACorrectionToOurOwnRecord(change) || theEventNeverHappened(change);
+}
+
 export function narrowingSentence(changes: VendorVerdictInput["changes"]): string {
   const cited = changes.filter(c => !changeIsUncited(c));
-  const corrections = cited.filter(isACorrectionToOurOwnRecord);
-  const byTheVendor = cited.filter(c => !isACorrectionToOurOwnRecord(c));
+  const withdrawn = cited.filter(theEventNeverHappened);
+  const corrections = cited.filter(c => isACorrectionToOurOwnRecord(c) && !theEventNeverHappened(c));
+  const byTheVendor = cited.filter(c => !isOurOwnBookkeeping(c));
   const total = byTheVendor.length;
   if (total === 0) {
-    if (corrections.length === 0) return uncitedOnlySentence(changes.length);
+    if (corrections.length === 0 && withdrawn.length === 0) return uncitedOnlySentence(changes.length);
+    if (corrections.length === 0) return withdrawnOnlySentence(withdrawn.length);
     return corrections.length === 1
       ? `The one record we hold corrects our own earlier entry rather than reporting a change the vendor made.`
       : `All ${corrections.length} records we hold correct our own earlier entries rather than reporting changes the vendor made.`;

--- a/test/free-tier-removal-evidence.test.ts
+++ b/test/free-tier-removal-evidence.test.ts
@@ -186,9 +186,9 @@ describe("a free tier a record still describes has not been removed", () => {
       assert.deepStrictEqual(failing, [], `stored removals describing a free plan:\n${failing.join("\n")}`);
     });
 
-    it("still holds the removals the control set names", () => {
+    it("still holds the removals whose own page was read against them", () => {
       const kept = new Set(removals.filter(c => !c.resolution).map(c => c.vendor));
-      for (const vendor of ["Middleware.io", "Survicate", "ScraperAPI", "Burnermail"]) {
+      for (const vendor of ["Burnermail", "bonsai.io", "Unkey", "Webvizio", "Rybbit"]) {
         assert.ok(kept.has(vendor), `${vendor} keeps its free tier removal record`);
       }
     });

--- a/test/removal-record-refuted-by-its-page.test.ts
+++ b/test/removal-record-refuted-by-its-page.test.ts
@@ -1,0 +1,334 @@
+import { describe, it } from "node:test";
+import assert from "node:assert";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const {
+  A_PLAN_PRICED_AT_NOTHING,
+  freePlanStatedOn,
+  readablePartsOf,
+  statedOnlyInMarkupWeDiscard,
+  statesAFreePlan,
+  structuredTextOf,
+  visibleTextOf,
+  whereAFreePlanIsStated,
+} = await import("../dist/page-free-plan.js");
+const { REMOVAL_CLASS, aFreePlanOnThePageWouldRefuteIt, removalRecordsInTheServedWindow, removalRecordsStillInForce } =
+  await import("../dist/removal-record.js");
+const { publishedRisk } = await import("../dist/data.js");
+const { storedTermsAreSuperseded } = await import("../dist/superseded-description.js");
+const { theEventNeverHappened } = await import("../dist/change-resolution.js");
+const { isOurOwnBookkeeping, narrowingSentence } = await import("../dist/vendor-verdict.js");
+
+type Offer = import("../src/types.ts").Offer;
+type DealChange = import("../src/types.ts").DealChange;
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO = path.join(__dirname, "..");
+
+const offers: Offer[] = JSON.parse(readFileSync(path.join(REPO, "data", "index.json"), "utf-8")).offers;
+const changes: DealChange[] = JSON.parse(
+  readFileSync(path.join(REPO, "data", "deal_changes.json"), "utf-8"),
+).changes;
+
+const PLAN_LADDERS = {
+  middleware:
+    "Flexible pricing that adapts to your business growth.. Free Forever. $0. Free access to all features with monthly limits.. Sign Up Now . Up to 100GB Data. Up to 1k RUM Sessions. Up to 20k Synthetic Checks. 10 Browser Test Runs. Unlimited Users.",
+  financialData:
+    "Monthly . Yearly 30% Off . . . Free. $ 0 /month . 300 Requests / Day. REST API & Python SDK. Symbol Lists. Get Started . . . . Standard. $ 29 /month . 10 Requests / Second.",
+  simpleObservability:
+    "Stop guessing your bill at the end of the month. . . Free. Free plan for one server. Ideal for testing, development, or low-traffic workloads. . Free. for 1 server. . Start For Free ● 50 metrics per server . ● Low log volume .",
+  localazy:
+    "No credit card required! Start a 14-day trial of Business plan.. . Small project = free plan!. . Start your localization journey early with all the essentials you need.. Up to 200 source keys All essential localization features Unlimited seats & languages",
+  scraperApiAnswer:
+    "Does ScraperAPI offer a free plan? . Yes, ScraperAPI offers a free plan where you can sign up here and get 1,000 free API credits (with a maximum of 5 concurrent connections).",
+  survicateAnswer:
+    "FAQPage. Question. Answer. Yes! Our Free Plan is perfect for getting started with surveys at no cost. It includes: Up to 25 responses per month, 1 active survey at a time, Basic CRM integrations.",
+};
+
+const NOT_A_PLAN_LADDER = {
+  aCreditAllowanceInsideAPaidPlan:
+    "RBAC & audit logging . 500 free API / MCP credits per month . . Start free trial + Scale & security. Enterprise.",
+  anotherVendorsFreeKey:
+    "To keep using our API, switch to ipstack and get your free API key. Switch to ipstack .",
+  aDiscountForOpenSource:
+    "Open source Enterprise . . Free for Open Source. Chat with us -> . We come from an open-source background and are committed to supporting open-source projects.",
+  onlyTheQuestion:
+    "Is there a Free version of Survicate? . How do you count responses? . How do you count datapoints? .",
+};
+
+const WHERE_THE_RULE_IS_WRONG = {
+  aLedeThePlanTableDoesNotBackUp:
+    "Start monitoring your infrastructure in under 60 seconds. No credit card required.. Start Free Trial Talk to Sales . Free plan available • No credit card required • Setup in 60 seconds.",
+  aFictionalLadderInsideAProductDemo:
+    "replay · session 4f2a91 DE . acme Product Pricing Docs Sign in . Plans for every team. Start free, upgrade when you need to.. Free. $0 /mo . . Choose Free. . Pro. $24 /mo . . Choose Pro. . Checkout · Pro. Card number. MM / YY. . Pay now.",
+};
+
+const CORRECTED_ON = "2026-09-09";
+
+const RETRACTED = [
+  "Middleware.io",
+  "ploi.io",
+  "Simple Observability",
+  "Financial Data",
+  "DynamicDocs",
+  "Survicate",
+  "ScraperAPI",
+];
+
+const RETYPED: Record<string, { date: string; type: string }> = {
+  "localazy.com": { date: "2026-09-07", type: "limits_reduced" },
+  InstallOnAir: { date: "2026-08-28", type: "limits_reduced" },
+};
+
+const STILL_STANDS = [
+  "bonsai.io",
+  "Burner Mail",
+  "fivenines.io",
+  "IPTrace",
+  "LogRocket",
+  "Unkey",
+  "Webvizio",
+  "Xitoring.com",
+  "Rybbit",
+  "Applitools",
+  "Circum Icons",
+  "Plausible",
+  "Highlight.io",
+  "Augment Code",
+  "Momento",
+];
+
+function changesFor(vendor: string): DealChange[] {
+  return changes.filter((c) => c.vendor.toLowerCase() === vendor.toLowerCase());
+}
+
+function offerFor(vendor: string): Offer | undefined {
+  return offers.find((o) => o.vendor.toLowerCase() === vendor.toLowerCase());
+}
+
+describe("a page that prices a plan at nothing", () => {
+  for (const [vendor, ladder] of Object.entries(PLAN_LADDERS)) {
+    it(`is read off ${vendor}`, () => {
+      assert.ok(whereAFreePlanIsStated(ladder), `no free plan read from: ${ladder.slice(0, 80)}`);
+    });
+  }
+
+  for (const [shape, text] of Object.entries(NOT_A_PLAN_LADDER)) {
+    it(`is not read off ${shape}`, () => {
+      assert.equal(whereAFreePlanIsStated(text), null, `read a free plan from: ${text.slice(0, 80)}`);
+    });
+  }
+
+  it("is not read from a question on its own, and is read from the answer beneath it", () => {
+    assert.equal(whereAFreePlanIsStated(NOT_A_PLAN_LADDER.onlyTheQuestion), null);
+    assert.ok(whereAFreePlanIsStated(PLAN_LADDERS.scraperApiAnswer));
+  });
+
+  it("needs a plan word or a zero price, not the word free on its own", () => {
+    assert.equal(statesAFreePlan("Get started for free today."), false);
+    assert.equal(statesAFreePlan("Try it free."), false);
+    assert.equal(statesAFreePlan("Free. $0 /month . 300 Requests / Day."), true);
+  });
+
+  it("does not count a plan the page denies or prices only as a trial", () => {
+    assert.equal(statesAFreePlan("The free plan is no longer available."), false);
+    assert.equal(statesAFreePlan("Start your 14-day free trial of the Business plan."), false);
+  });
+
+  it("does not count the plan an announcement names as the one it is taking away", () => {
+    const announcements = [
+      "In order to focus our resources, we will be phasing out our free plan for Heroku Dynos, free plan for Heroku Postgres, and free plan for Heroku Data for Redis.",
+      "I understand completely that retiring our free tier will cause inconvenience to some of our users.",
+      "We are winding down the free tier at the end of the month.",
+      "The free plan is being sunset on 1 March.",
+    ];
+    for (const announcement of announcements) {
+      assert.equal(statesAFreePlan(announcement), false, announcement);
+    }
+  });
+
+  it("reads a currency amount of nothing however the page spaces it", () => {
+    for (const priced of ["$0 /mo", "$ 0 /month", "€0 /mo", "£0 per month", "$0.00 / user"]) {
+      assert.ok(A_PLAN_PRICED_AT_NOTHING.test(priced), priced);
+    }
+  });
+});
+
+describe("terms a page publishes only in structured markup", () => {
+  const page = `<html><body><div class="accordion">${NOT_A_PLAN_LADDER.onlyTheQuestion}</div>
+    <script type="application/ld+json">{"@type":"FAQPage","mainEntity":[{"@type":"Question","name":"Is there a Free version of Survicate?","acceptedAnswer":{"@type":"Answer","text":"Yes! Our Free Plan is perfect for getting started with surveys at no cost. It includes: Up to 25 responses per month."}}]}</script>
+    </body></html>`;
+
+  it("are invisible to a reader of the rendered text", () => {
+    assert.equal(whereAFreePlanIsStated(visibleTextOf(page)), null);
+  });
+
+  it("are recovered from the markup", () => {
+    assert.ok(structuredTextOf(page).includes("Up to 25 responses per month"));
+    assert.equal(freePlanStatedOn(readablePartsOf(page))?.where, "structured");
+    assert.equal(statedOnlyInMarkupWeDiscard(readablePartsOf(page)), true);
+  });
+
+  it("do not swallow a page whose markup will not parse", () => {
+    const broken = `<html><script type="application/ld+json">{not json}</script><body>Free. $0 /mo.</body></html>`;
+    assert.equal(structuredTextOf(broken), "");
+    assert.equal(freePlanStatedOn(readablePartsOf(broken))?.where, "visible");
+  });
+});
+
+describe("what a free plan on the page can refute", () => {
+  it("refutes a record that says the free tier was removed", () => {
+    assert.equal(aFreePlanOnThePageWouldRefuteIt("free_tier_removed"), true);
+  });
+
+  it("does not refute a record that says the product is ending", () => {
+    assert.ok(REMOVAL_CLASS.has("product_deprecated"));
+    assert.equal(aFreePlanOnThePageWouldRefuteIt("product_deprecated"), false);
+  });
+
+  it("is asked of no record we have already withdrawn", () => {
+    const withdrawn = changes.filter((c) => REMOVAL_CLASS.has(c.change_type) && c.resolution);
+    assert.ok(withdrawn.length > 0);
+    assert.equal(removalRecordsStillInForce(withdrawn).length, 0);
+  });
+});
+
+describe("the rule reads a plan table over a lede, and here is where it does not", () => {
+  it("still believes a lede that claims a free plan the plan table does not carry", () => {
+    assert.ok(whereAFreePlanIsStated(WHERE_THE_RULE_IS_WRONG.aLedeThePlanTableDoesNotBackUp));
+  });
+
+  it("still believes a plan table belonging to a fictional company inside a product demo", () => {
+    assert.ok(whereAFreePlanIsStated(WHERE_THE_RULE_IS_WRONG.aFictionalLadderInsideAProductDemo));
+  });
+});
+
+describe("records whose own pricing page sells the plan they withheld", () => {
+  for (const vendor of RETRACTED) {
+    it(`${vendor} no longer withholds a free tier`, () => {
+      const record = changesFor(vendor).find((c) => c.change_type === "free_tier_removed");
+      assert.ok(record, `${vendor} has no free_tier_removed record`);
+      assert.equal(theEventNeverHappened(record), true);
+      assert.equal(record.resolution?.date, CORRECTED_ON);
+      const cited = record.resolution?.source_url ?? "";
+      assert.ok(cited, `${vendor} withdrawal cites nothing`);
+      const detail = record.resolution?.detail ?? "";
+      assert.match(detail, /"/, `${vendor} withdrawal quotes nothing from the page`);
+      assert.ok(
+        detail.includes(new URL(cited).hostname.replace(/^www\./, "")),
+        `${vendor} withdrawal does not name the page it read`,
+      );
+    });
+  }
+
+  for (const [vendor, expected] of Object.entries(RETYPED)) {
+    it(`${vendor} records the narrowing that actually happened`, () => {
+      const record = changesFor(vendor).find((c) => c.date === expected.date);
+      assert.ok(record, `${vendor} has no record on ${expected.date}`);
+      assert.equal(record.change_type, expected.type);
+      assert.equal(REMOVAL_CLASS.has(record.change_type), false);
+    });
+  }
+
+  it("leaves none of them rated risky", () => {
+    const risky: string[] = [];
+    for (const vendor of [...RETRACTED, ...Object.keys(RETYPED)]) {
+      const offer = offerFor(vendor);
+      if (!offer) continue;
+      const risk = publishedRisk(offer, changesFor(vendor));
+      if (risk.risk_level === "risky") risky.push(vendor);
+    }
+    assert.deepEqual(risky, []);
+  });
+
+  it("restores the vendor's own terms wherever the record was withdrawn", () => {
+    const withheld: string[] = [];
+    for (const vendor of RETRACTED) {
+      const offer = offerFor(vendor);
+      if (!offer) continue;
+      const superseding = storedTermsAreSuperseded(offer, changesFor(vendor));
+      const stillNarrowed = changesFor(vendor).some(
+        (c) => !c.resolution && c.change_type === "limits_reduced",
+      );
+      if (superseding && !stillNarrowed) withheld.push(vendor);
+    }
+    assert.deepEqual(withheld, []);
+  });
+});
+
+describe("what a vendor page says once we withdraw the only record we held", () => {
+  it("does not call a withdrawn record a change the vendor made", () => {
+    for (const vendor of RETRACTED) {
+      const sentence = narrowingSentence(changesFor(vendor));
+      assert.doesNotMatch(
+        sentence,
+        /change we have recorded|recorded changes/,
+        `${vendor}: ${sentence}`,
+      );
+    }
+  });
+
+  it("says whose error it was", () => {
+    assert.equal(
+      narrowingSentence(changesFor("Middleware.io")),
+      "The one record we hold was our own error and has been withdrawn.",
+    );
+  });
+
+  it("keeps counting the changes a vendor did make", () => {
+    assert.match(narrowingSentence(changesFor("ploi.io")), /narrowed the terms/);
+  });
+
+  it("separates a withdrawal from a correction entry and from an uncited record", () => {
+    const withdrawn = { change_type: "free_tier_removed", date: "2026-01-01", source_url: "https://example.com/pricing", summary: "x", resolution: { state: "retracted", date: "2026-02-01" } };
+    const correction = { change_type: "record_corrected", date: "2026-01-01", source_url: "https://example.com/pricing", summary: "x" };
+    assert.equal(isOurOwnBookkeeping(withdrawn), true);
+    assert.equal(isOurOwnBookkeeping(correction), true);
+    assert.equal(isOurOwnBookkeeping({ change_type: "limits_reduced", date: "2026-01-01", summary: "x" }), false);
+    assert.match(narrowingSentence([withdrawn] as never), /was our own error and has been withdrawn/);
+    assert.match(narrowingSentence([correction] as never), /corrects our own earlier entry/);
+  });
+});
+
+describe("the records this correction must not move", () => {
+  for (const vendor of STILL_STANDS) {
+    it(`${vendor} keeps the verdict it had`, () => {
+      const held = changesFor(vendor).filter((c) => REMOVAL_CLASS.has(c.change_type));
+      if (held.length === 0) return;
+      for (const record of held) {
+        assert.notEqual(
+          record.resolution?.date,
+          CORRECTED_ON,
+          `${vendor} was withdrawn by this correction and should not have been`,
+        );
+      }
+    });
+  }
+
+  it("keeps every removal record we did not read", () => {
+    const read = new Set([...RETRACTED, ...Object.keys(RETYPED)].map((v) => v.toLowerCase()));
+    const withdrawnOn = changes.filter(
+      (c) => c.resolution?.date === CORRECTED_ON && !read.has(c.vendor.toLowerCase()),
+    );
+    assert.deepEqual(withdrawnOn.map((c) => c.vendor), []);
+  });
+});
+
+describe("the population a re-read has to cover", () => {
+  it("is every removal record still in force in the served window", () => {
+    const window = removalRecordsInTheServedWindow(changes);
+    assert.ok(window.length > 0);
+    for (const record of window) assert.ok(REMOVAL_CLASS.has(record.change_type));
+    const inForce = removalRecordsStillInForce(window);
+    assert.ok(inForce.length < window.length);
+  });
+
+  it("carries a source URL on every record we would re-read", () => {
+    const unciteable = removalRecordsStillInForce(removalRecordsInTheServedWindow(changes))
+      .filter((c) => aFreePlanOnThePageWouldRefuteIt(c.change_type))
+      .filter((c) => !c.source_url?.trim());
+    assert.deepEqual(unciteable.map((c) => `${c.vendor} ${c.date}`), []);
+  });
+});

--- a/test/vendor-verdict.test.ts
+++ b/test/vendor-verdict.test.ts
@@ -237,7 +237,7 @@ describe("vendor verdict — a stable rating reports direction, not volume", () 
     assert.match(narrowingSentence([standing]), /One recorded free tier removal narrowed the terms/);
 
     assert.strictEqual(establishesANarrowing(withdrawn), false);
-    assert.strictEqual(narrowingSentence([withdrawn]), "The one change we have recorded did not narrow the terms.");
+    assert.strictEqual(narrowingSentence([withdrawn]), "The one record we hold was our own error and has been withdrawn.");
     assert.doesNotMatch(
       vendorVerdictSentence(input({ level: "stable", changes: [withdrawn] })),
       /narrowed the terms/,


### PR DESCRIPTION
Nine records said a free tier ended while the page they cite sells the plan we withheld. Seven are withdrawn as our error, two are re-typed to the narrowing that actually happened, and a re-runnable census now reads the whole class against its own sources.

## The count, read off the pages rather than the summaries (AC-1)

`scripts/census-1495-removal-records.mjs` fetches every removal record's cited URL and asks whether the page prices a plan at nothing.

| | before | after |
|---|---|---|
| removal-class records in the served window | 35 | 33 |
| no longer in force, excluded | 3 | 10 |
| deprecations, excluded | 6 | 6 |
| read | 26 | 17 |
| cited page states a free plan today | 7 | 2 |
| of those, stated only in structured markup | 2 | 0 |

The two that remain are the two the rule cannot get right, and both are asserted as such in the tests rather than quietly filtered: `xitoring.com` publishes `Free plan available • No credit card required • Setup in 60 seconds` above a table that starts at €15, and `rybbit.com` renders `Free. $0 /mo` inside a session-replay demo of a fictional customer named `acme`.

## The corrections (AC-2, AC-3)

Withdrawn — each cites the page and quotes it:

| record | what the cited page publishes |
|---|---|
| Middleware.io | `Free Forever. $0.` then `Up to 100GB Data. Up to 1k RUM Sessions. Up to 20k Synthetic Checks.` |
| ploi.io | `ploi.io/pricing` column one is `Free` at `€0 $0 /mo`; its FAQ reads `After your trial ends, we will set your subscription to the free plan` |
| Simple Observability | `Free. Free plan for one server.` priced `Free. for 1 server.` |
| Financial Data | `Free. $ 0 /month . 300 Requests / Day.` |
| DynamicDocs | `Free Plan ... Free. 50 API Calls per Month.` |
| Survicate | `Yes! Our Free Plan is perfect for getting started with surveys at no cost ... Up to 25 responses per month` |
| ScraperAPI | `Yes, ScraperAPI offers a free plan ... 1,000 free API credits (with a maximum of 5 concurrent connections)` |

Re-typed to `limits_reduced`: `localazy.com` (1,000 source strings → `Up to 200 source keys`) and `InstallOnAir` (60 days → `access to build for 8 days`).

**ScraperAPI is the ninth, and it is not in the issue's eight.** The census found it. Its ladder starts at `Hobby $49 /month` and its banner reads `Start collecting data with our 7-day trial and 5,000 API credits` — which is verbatim what our `current_state` quoted. The FAQ answer beneath it names the free plan our record withheld, figure for figure.

Every one is withdrawn as `retracted` rather than `reversed`, on this evidence: **the sentence each record read is still live on the page today, beside the free plan it missed.** `advicement.io` still reads `Create documents from $0.062 per PDF`; `middleware.io/pricing/` still carries `We provide 14 days free trial with unlimited data ingestion` below `Free Forever $0`. The page did not change. Archive.org was rate-limiting throughout this work, so no capture was consulted.

Verified on a running server — `/api/offers`, `/vendor/*`, `/api/audit-stack` and the badge all agree, and none of the nine is rated `risky` on any of them.

## The rule, and where it is wrong (AC-6)

Reused, as the issue asked: `namesAFreePlan` from #1424 already qualifies a match away when a trial, credit or discount sits within 24 characters of it in the same clause, and drops it when the clause denies the plan. `offeredOutrightAndNotDenied` exposes that machinery so a page reader can run it over a different pattern.

What is new is the pattern and three tests it has to pass on a whole page rather than a curated reading:

1. **A plan word or a currency amount of nothing.** `free plan/tier/edition/version`, `free forever`, `always free`, `$0 /mo`. Not `free API key`, not `free for open source`, not `get started for free` — on a marketing page those are ledes.
2. **A question is not a statement.** `Does ScraperAPI offer a free plan?` is read as a question; the answer under it is read as an answer.
3. **An announcement does not offer the plan it is taking away.** `retire`, `phase out`, `wind down` join the existing denial words, so `we will be phasing out our free plan for Heroku Dynos` no longer reads as a free plan on offer.

Where it will be wrong, both asserted in `test/removal-record-refuted-by-its-page.test.ts` under a heading that says so:

- **A lede the plan table does not back up.** Xitoring. The rule reads sentences, so it cannot tell a claim above the table from a row in it.
- **A plan ladder that belongs to someone else.** Rybbit's homepage embeds a session replay of a fictional company's checkout, complete with `Free / Pro / Team` at `$0 / $24 / $79`. Nothing in the text says it is a demo.

A third limit worth stating: **the census reads only the page the record cites, and four of these eight state their free plan one hop away** on `/pricing`. That is #1110's work and this does not do it. Read from the cited URL alone the census finds four of the eight; the other four were confirmed by hand.

## Structured-only terms (AC-5)

`structuredTextOf` parses every `application/ld+json` block and collects its strings, so `FAQPage` answers are readable. Survicate is the worked example — the visible accordion renders `Is there a Free version of Survicate?` and stops, and the answer with the terms exists only in the markup.

**Count: two.** Read across the whole removal class — 160 records, 80 of them still in force and not a deprecation — exactly two cite a page whose free-tier terms are structured-only: **Survicate** and **Simple Observability**, whose cited homepage carries `Free Plan` in JSON-LD while its rendered text does not. Both are in the served window, so structured-only there is 2 of 26 before this change and 0 of 17 after it.

## The control set (AC-4)

The eleven correct records and the seven controls are asserted by name and none moved. Two notes on the control set itself:

- **`test/free-tier-removal-evidence.test.ts` was pinning three of the defects as controls.** Its list read `["Middleware.io", "Survicate", "ScraperAPI", "Burnermail"]` — the first three are records withdrawn here. It now names five removals whose own page was read against them: `Burnermail`, `bonsai.io`, `Unkey`, `Webvizio`, `Rybbit`. This is the concrete form of the note on #1388.
- **Highlight.io, listed in the issue's negative control, was already retracted** on 2026-09-03 with LaunchDarkly's free Developer plan cited. The control set is six live records, not seven.

## A sentence this change made wrong, fixed here

Withdrawing the only record we held for a vendor made `/vendor/middleware-io` read *"We rate it stable. The one change we have recorded did not narrow the terms."* We did not record a change and judge it benign — we withdrew our own row. `narrowingSentence` now treats a record whose event never happened as our own bookkeeping: *"The one record we hold was our own error and has been withdrawn."* A `reversed` record is untouched, because that one did happen.

## Found while reading, not fixed

Running the census over the whole log rather than the served window reads 80 records and reaches 45 — **33 of the 35 it cannot reach cite no source at all**, which is #1352's population arriving from another direction. Eleven flag before this change and four after it, all four outside the served window and none touched here:

- **LocalStack** — `blog.localstack.cloud` says the free plan exists and is restricted to non-commercial use, which reads like a `restriction` filed as a removal.
- **Brave Search API** — `brave.com/search/api/` reads `For free plans, the card is only used to confirm your identity and will not be charged.`
- **Amazon SES** and **DBOS** — the match is a nav crumb and an open-source library respectively; both look like the rule being wrong rather than the record.

Suite 4,730 of 4,730.

Refs #1495

