### PR TITLE
Check the product half of a vendor name against the page we cite

### DIFF
--- a/artifacts/free-llm-api-index/README.md
+++ b/artifacts/free-llm-api-index/README.md
@@ -1,6 +1,6 @@
 # Free tiers for AI and LLM APIs, with the date we read each one
 
-84 records for AI, LLM and AI-coding vendors, each one carrying the date we last read the vendor's own page and the URL we read it on. There is no single freshness stamp for this file, because a single stamp for a list nobody re-read is worth nothing.
+83 records for AI, LLM and AI-coding vendors, each one carrying the date we last read the vendor's own page and the URL we read it on. There is no single freshness stamp for this file, because a single stamp for a list nobody re-read is worth nothing.
 
 Generated from the free-tier catalogue at https://agentdeals.dev, which is where each row's record lives. It is regenerated whenever those records move, so editing it by hand is pointless — the next run overwrites it.
 
@@ -12,8 +12,8 @@ Rows are ordered alphabetically by vendor. That is not a ranking: we publish no 
 
 | | |
 | --- | --- |
-| Records | 84 |
-| Carrying a rating | 56 |
+| Records | 83 |
+| Carrying a rating | 55 |
 | Recorded as ended | 2 |
 | Publishing a reason instead of a rating | 26 — `states_no_terms` 9, `unreadable` 9, `gate:not_a_free_offer` 4, `link_unreachable` 4 |
 | Showing the terms they replaced | 15 |
@@ -29,7 +29,7 @@ Those counts are generated with the rows. If most of a column carries a caveat, 
 
 - `stable`, `caution` or `risky` — always printed beside the single dated record that produced it;
 - `ended` — a free tier we recorded going away. The row stays for the record;
-- `unrated` — we are publishing no rating, and the next column says why. 26 of 84 rows are unrated. A record whose page we could not read, that names no terms we can read, that is not a free offer, or whose link has stopped resolving gets the reason instead of a verdict. We would rather print why we cannot say than guess.
+- `unrated` — we are publishing no rating, and the next column says why. 26 of 83 rows are unrated. A record whose page we could not read, that names no terms we can read, that is not a free offer, or whose link has stopped resolving gets the reason instead of a verdict. We would rather print why we cannot say than guess.
 
 **Record verified** is the day we last confirmed that record against the page. Where the link has not resolved for 14 days, we withhold that date and print the day the link last worked instead: a recent date over a destination that no longer answers is the most confident-looking thing on a page and the least true.
 
@@ -70,7 +70,7 @@ A change is one dated record about one vendor, carrying the terms before, the te
 
 A rating is decided by the *type* of the most recent narrowing record, never by how many records we hold. A vendor we have never had cause to examine reads the same as one with a long clean history — `stable` is a statement about our records, not a clean bill of health.
 
-## AI / ML — 69 records
+## AI / ML — 68 records
 
 | Vendor | The terms, and where they came from | Rating | What we can say | Record verified |
 | --- | --- | --- | --- | --- |
@@ -98,7 +98,6 @@ A rating is decided by the *type* of the most recent narrowing record, never by 
 | [GitHub Models](https://agentdeals.dev/vendor/github-models)<br>Retired | Our record, read from [docs.github.com/en/github-models/about-github-models](https://docs.github.com/en/github-models/about-github-models) on 2026-08-20: GitHub retired GitHub Models on 2026-07-30, so there is no free tier. GitHub's own documentation states "GitHub Models has been retired." The former offer was free access to 100+ models via GitHub Marketplace at 10-15 RPM and 50-150 requests/day. | `ended` | This offer has ended — we keep the page for the record and no longer rate it. | 2026-08-20 |
 | [Google Gemini API](https://agentdeals.dev/vendor/google-gemini-api)<br>Free (Reduced) | Our record, read from [ai.google.dev/pricing](https://ai.google.dev/pricing) on 2026-08-18: Free tier covers Gemini 2.5 Pro plus the Flash-tier models: Gemini 2.5 Flash (10 RPM), Gemini 2.5 Flash-Lite (15 RPM), Gemini 3.0 Flash Preview, Gemini 3.1 Flash-Lite Preview, Gemini Embedding, and Gemma 4. 3.1 Pro Preview is paid-only. Per-model paid pricing: Gemini 3.1 Pro Preview $2/$12 per MTok (≤200K ctx, doubles above), Gemini 3.0 Flash Preview $0.50/$3, Gemini 3.1 Flash-Lite Preview $0.25/$1.50, Gemini 2.5 Pro $1.25/$10 (≤200K, doubles above), Gemini 2.5 Flash $0.30/$2.50. Gemini 2.0 Flash and 2.0 Flash-Lite deprecated June 1, 2026 — migrate to 2.5 Flash or 3.x Flash. All models support Batch/Flex at 50% discount. Mandatory spend caps enforced since April 1, 2026. | `caution` | We rate it caution — one recorded pricing restructure, discovered 2026-09-03. | 2026-08-18 |
 | [Google Gemini Embedding 2](https://agentdeals.dev/vendor/google-gemini-embedding-2)<br>Pay-as-you-go | Our record, read from [cloud.google.com/vertex-ai/docs/generative-ai/embeddings/get-text-embeddings](https://cloud.google.com/vertex-ai/docs/generative-ai/embeddings/get-text-embeddings) on 2026-08-17: First natively multimodal embedding model — text, images, video, audio, and documents in a single embedding space. Enables cross-modal similarity search and retrieval. Available via Vertex AI and Gemini API. | `unrated` | Tier "Pay-as-you-go" is usage-billed from the first request. We do not rate an offer we do not list. | 2026-08-17 |
-| [Google GLM 5](https://agentdeals.dev/vendor/google-glm-5)<br>Experimental Preview | Our record, read from [cloud.google.com/vertex-ai/docs/generative-ai/model-reference/overview](https://cloud.google.com/vertex-ai/docs/generative-ai/model-reference/overview) on 2026-08-19: Experimental model optimized for complex systems engineering and agentic tasks. Designed for multi-step reasoning, code generation, and autonomous agent workflows. Preview access via Vertex AI. | `stable` | It's stable — zero pricing changes recorded. | 2026-08-19 |
 | [Google Vector Search 2.0](https://agentdeals.dev/vendor/google-vector-search-2-0)<br>Pay-as-you-go | Our record, read from [cloud.google.com/vertex-ai/docs/vector-search/overview](https://cloud.google.com/vertex-ai/docs/vector-search/overview) on 2026-08-15: Vector Search 2.0 now GA on Vertex AI. High-performance approximate nearest neighbor (ANN) vector similarity search for AI/RAG applications. Supports billion-scale indexes. | `unrated` | The page we cite for Google Vector Search 2.0 states no terms we can read. | 2026-08-15 |
 | [Google Vertex AI Agent Engine](https://agentdeals.dev/vendor/google-vertex-ai-agent-engine)<br>Pay-as-you-go | Our record, read from [cloud.google.com/vertex-ai/docs/agent-builder](https://cloud.google.com/vertex-ai/docs/agent-builder) while that link still resolved: Vertex AI Agent Builder with sessions and memory now GA. Build, deploy, and manage AI agents with persistent memory, multi-turn sessions, and tool governance. Part of the Vertex AI platform. | `unrated` | Google Vertex AI Agent Engine's pricing page has not resolved for us since 2026-04-15. | link last resolved 2026-04-15 |
 | [GPU-Bridge](https://agentdeals.dev/vendor/gpu-bridge)<br>Pay-per-use | Our record, read from [gpu-bridge.com](https://gpu-bridge.com) while that link still resolved: Multi-provider GPU inference API — 30+ AI services (LLM, image generation, embeddings, speech) accessible via x402 micropayments. Unified API across providers, no accounts needed. Pay per inference call. | `unrated` | GPU-Bridge's pricing page has not resolved for us since 2026-04-14. | link last resolved 2026-04-14 |

--- a/data/deal_changes.json
+++ b/data/deal_changes.json
@@ -9399,6 +9399,20 @@
       "alternatives": [],
       "detected_by": "reverify-ai",
       "recorded_date": "2026-09-09"
+    },
+    {
+      "vendor": "Google GLM 5",
+      "change_type": "record_corrected",
+      "date": "2026-09-09",
+      "summary": "Data correction - our own entry for Google GLM 5 was incorrect. Google publishes no model called GLM 5; GLM is Zhipu AI's model family, and the catalogue's separate Zhipu AI record already lists the GLM-4 series. The Vertex AI model reference this record cited never writes GLM: that URL redirects to a live Google page of 73,312 readable characters in which GLM appears zero times, and the terms we published from it - '10 frames per second' - are a video sampling rate from the Gemini API documentation.",
+      "previous_state": "Listed as Google GLM 5, tier Experimental Preview, rated stable with zero pricing changes recorded: experimental model for complex systems engineering and agentic tasks, preview access via Vertex AI",
+      "current_state": "Withdrawn from the catalogue. No Google page we can read names this product. GLM models are published by Zhipu AI, which the catalogue holds under its own record.",
+      "impact": "medium",
+      "source_url": "https://cloud.google.com/vertex-ai/docs/generative-ai/model-reference/overview",
+      "category": "AI / ML",
+      "alternatives": [],
+      "recorded_date": "2026-09-09",
+      "date_source": "hand_written"
     }
   ]
 }

--- a/data/index.json
+++ b/data/index.json
@@ -6178,9 +6178,9 @@
       ],
       "verifiedDate": "2026-07-29",
       "source_check": {
-        "checked": "2026-09-05",
-        "outcome": "ok",
-        "detail": "the page writes \"amazon\", the domain we cite Amazon ECR Public from, and states \"$200\""
+        "checked": "2026-09-09",
+        "outcome": "does_not_name_product",
+        "detail": "the page names the platform in the domain we cite Amazon ECR Public from and never names ECR Public"
       }
     },
     {
@@ -9372,9 +9372,9 @@
       ],
       "verifiedDate": "2026-08-01",
       "source_check": {
-        "checked": "2026-09-07",
-        "outcome": "ok",
-        "detail": "the page writes \"zoho\", the domain we cite Zoho Docs from, and states \"₹ 720\""
+        "checked": "2026-09-09",
+        "outcome": "does_not_name_product",
+        "detail": "the page names the platform in the domain we cite Zoho Docs from and never names Docs"
       }
     },
     {
@@ -16485,9 +16485,9 @@
       ],
       "verifiedDate": "2026-07-10",
       "source_check": {
-        "checked": "2026-09-02",
-        "outcome": "states_no_terms",
-        "detail": "the page names OntarioNet.ca CN Test but states no amount, tier or rate we can read"
+        "checked": "2026-09-09",
+        "outcome": "does_not_name_product",
+        "detail": "the page names the platform in the domain we cite OntarioNet.ca CN Test from and never names CN Test"
       },
       "product_subtypes": {
         "taxonomy": "Monitoring",
@@ -23721,9 +23721,9 @@
       ],
       "verifiedDate": "2026-07-20",
       "source_check": {
-        "checked": "2026-09-02",
-        "outcome": "states_no_amount",
-        "detail": "the page names Mockplus iDoc and says \"free plan\" but states no amount, rate or price we can read"
+        "checked": "2026-09-09",
+        "outcome": "does_not_name_product",
+        "detail": "the page names the platform in the domain we cite Mockplus iDoc from and never names iDoc"
       }
     },
     {
@@ -27385,9 +27385,9 @@
       ],
       "verifiedDate": "2026-09-02",
       "source_check": {
-        "checked": "2026-09-02",
-        "outcome": "states_no_terms",
-        "detail": "the page names Freshworks for Startups but states no amount, tier or rate we can read"
+        "checked": "2026-09-09",
+        "outcome": "does_not_name_product",
+        "detail": "the page names the platform in the domain we cite Freshworks for Startups from and never names for Startups"
       }
     },
     {
@@ -27404,9 +27404,9 @@
       ],
       "verifiedDate": "2026-09-02",
       "source_check": {
-        "checked": "2026-09-02",
-        "outcome": "states_no_terms",
-        "detail": "the page names Startup with IBM but states no amount, tier or rate we can read"
+        "checked": "2026-09-09",
+        "outcome": "does_not_name_product",
+        "detail": "the page names the platform in the domain we cite Startup with IBM from and never names Startup with"
       }
     },
     {
@@ -27788,9 +27788,9 @@
         "program": "Chargebee for Startups"
       },
       "source_check": {
-        "checked": "2026-09-02",
-        "outcome": "ok",
-        "detail": "text"
+        "checked": "2026-09-09",
+        "outcome": "does_not_name_product",
+        "detail": "the page names the platform in the domain we cite Chargebee Launch Programme from and never names Launch Programme"
       }
     },
     {
@@ -33840,38 +33840,6 @@
             "subtype": "vector_store",
             "source_url": "https://cloud.google.com/vertex-ai/docs/vector-search/overview",
             "source_quote": "Vector Search is a powerful vector search engine built on groundbreaking technology"
-          }
-        ],
-        "reviewed": "2026-09-01"
-      }
-    },
-    {
-      "vendor": "Google GLM 5",
-      "category": "AI / ML",
-      "description": "Experimental model optimized for complex systems engineering and agentic tasks. Designed for multi-step reasoning, code generation, and autonomous agent workflows. Preview access via Vertex AI.",
-      "tier": "Experimental Preview",
-      "url": "https://cloud.google.com/vertex-ai/docs/generative-ai/model-reference/overview",
-      "tags": [
-        "ai",
-        "llm",
-        "google cloud",
-        "vertex-ai",
-        "agentic",
-        "experimental"
-      ],
-      "verifiedDate": "2026-08-19",
-      "source_check": {
-        "checked": "2026-09-05",
-        "outcome": "ok",
-        "detail": "the page writes \"google\", the domain we cite Google GLM 5 from, and states \"10 frames per second\""
-      },
-      "product_subtypes": {
-        "taxonomy": "AI / ML",
-        "labels": [
-          {
-            "subtype": "llm_api",
-            "source_url": "https://cloud.google.com/vertex-ai/docs/generative-ai/model-reference/overview",
-            "source_quote": "Use the Model API for Gemini in Gemini Enterprise Agent Platform to create custom applications"
           }
         ],
         "reviewed": "2026-09-01"

--- a/data/page-lastmod.json
+++ b/data/page-lastmod.json
@@ -3,7 +3,7 @@
   "generated": "2026-09-09",
   "pages": {
     "/agent-payments": {
-      "hash": "d7e4e6df469ed092",
+      "hash": "0a07251fc158fd85",
       "changed": "2026-09-09"
     },
     "/agent-stack": {
@@ -11,23 +11,23 @@
       "changed": "2026-09-09"
     },
     "/ai-coding-pricing-2026": {
-      "hash": "3639615921a267a9",
+      "hash": "fb9ca683afab6fcd",
       "changed": "2026-09-09"
     },
     "/ai-coding-tools-pricing": {
-      "hash": "6703999879da540a",
+      "hash": "9dcbe66f343a9ebf",
       "changed": "2026-09-09"
     },
     "/ai-free-tiers": {
-      "hash": "5f0b4f8bfe7b109c",
+      "hash": "cfcac67a8b3ee58b",
       "changed": "2026-09-09"
     },
     "/ai-ml-alternatives": {
-      "hash": "38403249440342f1",
+      "hash": "87db8660cd9d1484",
       "changed": "2026-09-09"
     },
     "/alternatives": {
-      "hash": "98e85331062326a7",
+      "hash": "e44e480d96b65d46",
       "changed": "2026-09-09"
     },
     "/amplitude-vs-mixpanel": {
@@ -39,19 +39,19 @@
       "changed": "2026-09-09"
     },
     "/analytics-alternatives": {
-      "hash": "508301d78789c537",
+      "hash": "e6a749a109281735",
       "changed": "2026-09-09"
     },
     "/analytics-free-tier-comparison-2026": {
-      "hash": "55904818a39ffa40",
+      "hash": "420dc21307dc9b3c",
       "changed": "2026-09-09"
     },
     "/api-development-alternatives": {
-      "hash": "28500596ed9034ae",
+      "hash": "54d3c8fe62c3f59f",
       "changed": "2026-09-09"
     },
     "/api-development-free-tier-comparison-2026": {
-      "hash": "482006c0946a45f1",
+      "hash": "6b111c5bc65687a5",
       "changed": "2026-09-09"
     },
     "/api/docs": {
@@ -59,11 +59,11 @@
       "changed": "2026-09-05"
     },
     "/auth-comparison-2026": {
-      "hash": "2c9ebfaf488d685d",
+      "hash": "f7f2d91a51507bdc",
       "changed": "2026-09-09"
     },
     "/auth0-alternatives": {
-      "hash": "c9b58a2ac5282892",
+      "hash": "aa827073a1ec250c",
       "changed": "2026-09-09"
     },
     "/auth0-vs-clerk": {
@@ -75,15 +75,15 @@
       "changed": "2026-09-09"
     },
     "/aws-app-runner-migration": {
-      "hash": "40f8e0369ce46ca0",
+      "hash": "626b875e96d5a488",
       "changed": "2026-09-09"
     },
     "/aws-free-tier-2026": {
-      "hash": "c2676bae1ff1ac6a",
+      "hash": "728faa9b1683e531",
       "changed": "2026-09-09"
     },
     "/azure-free-tier-2026": {
-      "hash": "2dc087828043e4b6",
+      "hash": "f0637a63906410ac",
       "changed": "2026-09-09"
     },
     "/backblaze-b2-vs-cloudflare-r2": {
@@ -91,7 +91,7 @@
       "changed": "2026-09-09"
     },
     "/badges": {
-      "hash": "7dc3872aa1eb67c6",
+      "hash": "7ab7a3bf76709cb5",
       "changed": "2026-09-09"
     },
     "/brevo-vs-resend": {
@@ -99,19 +99,19 @@
       "changed": "2026-09-09"
     },
     "/budget-builder": {
-      "hash": "0f0863281c89b163",
+      "hash": "a45166dfc63f5cd3",
       "changed": "2026-09-09"
     },
     "/ci-cd-alternatives": {
-      "hash": "3d8d297c64059e23",
+      "hash": "66052ffcb6fb953c",
       "changed": "2026-09-09"
     },
     "/ci-cd-pricing": {
-      "hash": "09a1f4d7c5cc232c",
+      "hash": "ac3ffa1f1ef30fbc",
       "changed": "2026-09-09"
     },
     "/cicd-free-tier-comparison-2026": {
-      "hash": "8df98781a4f772b5",
+      "hash": "6b0defd18d6aae48",
       "changed": "2026-09-09"
     },
     "/circleci-vs-github-actions": {
@@ -119,7 +119,7 @@
       "changed": "2026-09-09"
     },
     "/cloud-free-tier-comparison-2026": {
-      "hash": "515b6d57cda6e158",
+      "hash": "ba4b45cbf9952884",
       "changed": "2026-09-09"
     },
     "/cloudflare-pages-vs-vercel": {
@@ -135,11 +135,11 @@
       "changed": "2026-09-09"
     },
     "/compare": {
-      "hash": "29ea9b7a11a4ad15",
+      "hash": "097c9594e1173746",
       "changed": "2026-09-09"
     },
     "/compare-tool": {
-      "hash": "7b84ccf21bde3d99",
+      "hash": "f4ba201e59dad648",
       "changed": "2026-09-09"
     },
     "/compare/10minutemail-vs-emaillabs-io": {
@@ -159,11 +159,11 @@
       "changed": "2026-09-09"
     },
     "/compare/amazon-ecr-public-vs-container-registry-service": {
-      "hash": "0d66c6e1da0baadf",
+      "hash": "f91681cc0f33e971",
       "changed": "2026-09-09"
     },
     "/compare/amazon-ecr-public-vs-docker-hub": {
-      "hash": "7f751dea484bcbf5",
+      "hash": "5c080dc8658f02dd",
       "changed": "2026-09-09"
     },
     "/compare/amazon-kiro-vs-openai-codex": {
@@ -486,14 +486,6 @@
       "hash": "0489fa9690ea435b",
       "changed": "2026-09-09"
     },
-    "/compare/cohere-vs-exa": {
-      "hash": "c360613729141aa4",
-      "changed": "2026-09-09"
-    },
-    "/compare/cohere-vs-scale-ai": {
-      "hash": "d9881ec039ab99e5",
-      "changed": "2026-09-09"
-    },
     "/compare/configcat-vs-harness-feature-flags": {
       "hash": "d6130cbf8fe217a5",
       "changed": "2026-09-09"
@@ -643,7 +635,7 @@
       "changed": "2026-09-09"
     },
     "/compare/digitalocean-vs-startup-with-ibm": {
-      "hash": "bb15154d28518df6",
+      "hash": "de09d91683bf0a90",
       "changed": "2026-09-09"
     },
     "/compare/digitalocean-vs-zoom": {
@@ -724,14 +716,6 @@
     },
     "/compare/emaillabs-io-vs-resend": {
       "hash": "a5e5331b54dc8766",
-      "changed": "2026-09-09"
-    },
-    "/compare/exa-vs-openai": {
-      "hash": "07a6f4cdf636b9d1",
-      "changed": "2026-09-09"
-    },
-    "/compare/exa-vs-scale-ai": {
-      "hash": "2dbc5cf69c62c4c1",
       "changed": "2026-09-09"
     },
     "/compare/expo-vs-loadly": {
@@ -1011,7 +995,7 @@
       "changed": "2026-09-09"
     },
     "/compare/heroku-for-startups-program-vs-startup-with-ibm": {
-      "hash": "027bb89b2ece5ce5",
+      "hash": "41fb6d0b6f642ef3",
       "changed": "2026-09-09"
     },
     "/compare/highlight-io-vs-logz-io": {
@@ -1162,6 +1146,14 @@
       "hash": "d6c19aa34a395a06",
       "changed": "2026-09-09"
     },
+    "/compare/maxim-ai-vs-parseur": {
+      "hash": "8738c3dcc8053584",
+      "changed": "2026-09-09"
+    },
+    "/compare/maxim-ai-vs-zenable": {
+      "hash": "f34a3f4cce20a2ad",
+      "changed": "2026-09-09"
+    },
     "/compare/microsoft-ajax-vs-bootstrapcdn-com": {
       "hash": "f468db63949b278f",
       "changed": "2026-09-09"
@@ -1258,10 +1250,6 @@
       "hash": "5d554f54fb1a2471",
       "changed": "2026-09-09"
     },
-    "/compare/openai-vs-scale-ai": {
-      "hash": "c735f2866995aeba",
-      "changed": "2026-09-09"
-    },
     "/compare/opencagedata-com-vs-osmnames": {
       "hash": "edd4a5b3b1a97737",
       "changed": "2026-09-09"
@@ -1316,6 +1304,14 @@
     },
     "/compare/parityvend-vs-qonversion": {
       "hash": "6d16d92a3df1e6dd",
+      "changed": "2026-09-09"
+    },
+    "/compare/parseur-vs-roboflow": {
+      "hash": "4a26035fe4b00a28",
+      "changed": "2026-09-09"
+    },
+    "/compare/parseur-vs-zenable": {
+      "hash": "790255fd66c4fe79",
       "changed": "2026-09-09"
     },
     "/compare/payload-cms-vs-wpjack": {
@@ -1430,6 +1426,10 @@
       "hash": "83043515b35c21eb",
       "changed": "2026-09-09"
     },
+    "/compare/roboflow-vs-zenable": {
+      "hash": "eb8326d9931a87eb",
+      "changed": "2026-09-09"
+    },
     "/compare/rollbar-vs-memfault-com": {
       "hash": "be0d0b822ed86a36",
       "changed": "2026-09-09"
@@ -1535,27 +1535,27 @@
       "changed": "2026-09-09"
     },
     "/cursor-alternatives": {
-      "hash": "9251f58aa3ea4d58",
+      "hash": "1d9e99cb4029f0bb",
       "changed": "2026-09-09"
     },
     "/dall-e-shutdown": {
-      "hash": "3d5f0f161dfecbed",
+      "hash": "8ba6911b8d2466ed",
       "changed": "2026-09-09"
     },
     "/database-alternatives": {
-      "hash": "79c6e7dd13d9e01d",
+      "hash": "a36b7e2d3c350d7e",
       "changed": "2026-09-09"
     },
     "/database-free-tier-comparison-2026": {
-      "hash": "71ae5ab9da52c97f",
+      "hash": "86f158412f061c50",
       "changed": "2026-09-09"
     },
     "/database-pricing": {
-      "hash": "5da0070f6b63e0fd",
+      "hash": "a590a2f8f28fa174",
       "changed": "2026-09-09"
     },
     "/datadog-alternatives": {
-      "hash": "b94bc6843aa92983",
+      "hash": "191289c17d71eeae",
       "changed": "2026-09-09"
     },
     "/datadog-vs-grafana-cloud": {
@@ -1563,7 +1563,7 @@
       "changed": "2026-09-09"
     },
     "/datadog-vs-new-relic": {
-      "hash": "3ed536a52af58a81",
+      "hash": "99fe478c19db5be1",
       "changed": "2026-09-09"
     },
     "/datadog-vs-sentry": {
@@ -1571,31 +1571,31 @@
       "changed": "2026-09-09"
     },
     "/design-alternatives": {
-      "hash": "b06a8f92f639b17a",
+      "hash": "86454c778d1bbb78",
       "changed": "2026-09-09"
     },
     "/developers": {
-      "hash": "a48aec5ca24a7a95",
+      "hash": "2969f74c1cd5dd73",
       "changed": "2026-09-09"
     },
     "/digitalocean-free-tier-2026": {
-      "hash": "de51043c7ca62a09",
+      "hash": "802f23a9e232c1fd",
       "changed": "2026-09-09"
     },
     "/disclosure": {
-      "hash": "d94e0186113010b0",
+      "hash": "88c67853638c1680",
       "changed": "2026-09-09"
     },
     "/email-alternatives": {
-      "hash": "7ea2ace2a91d8f66",
+      "hash": "6687d168d7263e7e",
       "changed": "2026-09-09"
     },
     "/email-comparison-2026": {
-      "hash": "20ec622c68b3212c",
+      "hash": "e9c1985986fd5ce9",
       "changed": "2026-09-09"
     },
     "/email-service-alternatives": {
-      "hash": "842c7c7d539948ce",
+      "hash": "3110d644f8718601",
       "changed": "2026-09-09"
     },
     "/embed": {
@@ -1607,15 +1607,15 @@
       "changed": "2026-09-09"
     },
     "/events": {
-      "hash": "077e78339a0903c5",
+      "hash": "29996567b64947f0",
       "changed": "2026-09-09"
     },
     "/events/google-cloud-next-2026": {
-      "hash": "476af229b1055cdc",
+      "hash": "c9d03ac6eb04ac89",
       "changed": "2026-09-09"
     },
     "/events/google-io-2026": {
-      "hash": "711aa041c9732dba",
+      "hash": "474c5424f759f251",
       "changed": "2026-09-09"
     },
     "/events/microsoft-build-2026": {
@@ -1623,79 +1623,79 @@
       "changed": "2026-09-09"
     },
     "/firebase-alternatives": {
-      "hash": "89ab73e6f43b15ea",
+      "hash": "153301ac4c32fc54",
       "changed": "2026-09-09"
     },
     "/firebase-studio-shutdown": {
-      "hash": "696d98557435b292",
+      "hash": "86df7d1e1dda97ec",
       "changed": "2026-09-09"
     },
     "/free-ai-stack": {
-      "hash": "ef7e81b1e6856e12",
+      "hash": "b4a367dc2db9fb3d",
       "changed": "2026-09-09"
     },
     "/free-devops-stack": {
-      "hash": "d9c8137c531fd635",
+      "hash": "50289a0ce4ab2e68",
       "changed": "2026-09-09"
     },
     "/free-django-stack": {
-      "hash": "730a4b5a71938507",
+      "hash": "64c4af9f1a2d76b9",
       "changed": "2026-09-09"
     },
     "/free-fastapi-stack": {
-      "hash": "37564359ab43e441",
+      "hash": "f233574317bf915b",
       "changed": "2026-09-09"
     },
     "/free-frontend-stack": {
-      "hash": "7594d853b985e4b6",
+      "hash": "acb872a03600331c",
       "changed": "2026-09-09"
     },
     "/free-go-stack": {
-      "hash": "8ab914bf203fe207",
+      "hash": "d0a07355152d4674",
       "changed": "2026-09-09"
     },
     "/free-llm-apis": {
-      "hash": "90fe5848fc7c219b",
+      "hash": "3afebbd665c5e6ca",
       "changed": "2026-09-09"
     },
     "/free-nextjs-stack": {
-      "hash": "892359ca3ce20ede",
+      "hash": "3c53f8938a592815",
       "changed": "2026-09-09"
     },
     "/free-saas-stack": {
-      "hash": "1c533fe764074510",
+      "hash": "62103b14987160eb",
       "changed": "2026-09-09"
     },
     "/free-startup-stack": {
-      "hash": "5d37ac78fcda1dee",
+      "hash": "6e6eed5770877679",
       "changed": "2026-09-09"
     },
     "/free-tier-risk": {
-      "hash": "8a1d6b0608e5a069",
+      "hash": "4060c820afdd7bd7",
       "changed": "2026-09-09"
     },
     "/free-tier-tracker": {
-      "hash": "7499143296015e78",
+      "hash": "15fdfa289a728d2f",
       "changed": "2026-09-09"
     },
     "/freshping-alternatives": {
-      "hash": "7d6ea31571e91754",
+      "hash": "900ca0b211340c7c",
       "changed": "2026-09-09"
     },
     "/gcp-free-tier-2026": {
-      "hash": "ef94feee43d2ea60",
+      "hash": "a92a7c5e1f3f1e84",
       "changed": "2026-09-09"
     },
     "/gemini-api-pricing-2026": {
-      "hash": "500347332690227e",
+      "hash": "fa6c2c0419af4fdd",
       "changed": "2026-09-09"
     },
     "/gemini-api-pricing-changes": {
-      "hash": "06ba453617c6249b",
+      "hash": "19970fe42ff05e67",
       "changed": "2026-09-09"
     },
     "/github-actions-alternatives": {
-      "hash": "c4f1649eadfabbf8",
+      "hash": "8019ec61c4057acb",
       "changed": "2026-09-09"
     },
     "/github-actions-vs-gitlab-ci": {
@@ -1703,7 +1703,7 @@
       "changed": "2026-09-09"
     },
     "/google-developer-program-2026": {
-      "hash": "6516b5877e1326a8",
+      "hash": "89d7f522522164d1",
       "changed": "2026-09-09"
     },
     "/groq-vs-hugging-face": {
@@ -1715,79 +1715,79 @@
       "changed": "2026-09-09"
     },
     "/guides": {
-      "hash": "69fd16ea642887d8",
+      "hash": "037135137eb6c6b5",
       "changed": "2026-09-09"
     },
     "/guides/crewai": {
-      "hash": "6df960603d7eba8a",
+      "hash": "67730f541a479d6e",
       "changed": "2026-09-09"
     },
     "/guides/langchain": {
-      "hash": "f4b19b1117b98708",
+      "hash": "bb93d8d03faa460d",
       "changed": "2026-09-09"
     },
     "/guides/n8n": {
-      "hash": "bf109d88c2050997",
+      "hash": "adc05b532df23a69",
       "changed": "2026-09-09"
     },
     "/guides/vercel-ai-sdk": {
-      "hash": "7079f23fa1c3a8f8",
+      "hash": "3e2f6d45805fab1e",
       "changed": "2026-09-09"
     },
     "/hcp-terraform-migration": {
-      "hash": "bc8d0efaad61eadb",
+      "hash": "dba3cd5b3828fce8",
       "changed": "2026-09-09"
     },
     "/heroku-alternatives": {
-      "hash": "7b4bccb60f9d3bec",
+      "hash": "2f27db530451e558",
       "changed": "2026-09-09"
     },
     "/hetzner-alternatives": {
-      "hash": "93da4fb5df066cdd",
+      "hash": "7ae97ae8f13e5d9a",
       "changed": "2026-09-09"
     },
     "/hetzner-pricing-2026": {
-      "hash": "32257760116f6603",
+      "hash": "575d1eb3f7c6534c",
       "changed": "2026-09-09"
     },
     "/hosting-alternatives": {
-      "hash": "7a26996fecd95bba",
+      "hash": "4762bfc78c32e0c6",
       "changed": "2026-09-09"
     },
     "/hosting-free-tier-comparison-2026": {
-      "hash": "fd6590fdbaca0e99",
+      "hash": "b37c014887b896f0",
       "changed": "2026-09-09"
     },
     "/hosting-pricing": {
-      "hash": "415a5a6dae5185ed",
+      "hash": "49488f4f17e5f91a",
       "changed": "2026-09-09"
     },
     "/ide-code-editors-alternatives": {
-      "hash": "962ec3592c5c4c64",
+      "hash": "1d6d6f707802c876",
       "changed": "2026-09-09"
     },
     "/llm-api-pricing": {
-      "hash": "337cef80ea50d7f3",
+      "hash": "efd8834707200ca0",
       "changed": "2026-09-09"
     },
     "/localstack-alternatives": {
-      "hash": "ff63fe723933ffe0",
+      "hash": "1671614f78bf78a5",
       "changed": "2026-09-09"
     },
     "/mongodb-alternatives": {
-      "hash": "6fe08b7e7eb84b9d",
+      "hash": "cac83879c73b2863",
       "changed": "2026-09-09"
     },
     "/monitoring-alternatives": {
-      "hash": "51957bbf3698d43b",
+      "hash": "acc3ad0867d983fb",
       "changed": "2026-09-09"
     },
     "/monitoring-comparison-2026": {
-      "hash": "17b3170b45c489d0",
+      "hash": "54c282df7f2b7218",
       "changed": "2026-09-09"
     },
     "/neon-vs-supabase": {
-      "hash": "b3613363512ba204",
+      "hash": "ed837c25bad2bcf4",
       "changed": "2026-09-09"
     },
     "/neon-vs-turso": {
@@ -1799,7 +1799,7 @@
       "changed": "2026-09-09"
     },
     "/openai-assistants-alternatives": {
-      "hash": "550fb7eb11ed3122",
+      "hash": "369c12253bcc1d14",
       "changed": "2026-09-09"
     },
     "/openai-assistants-migration": {
@@ -1807,15 +1807,15 @@
       "changed": "2026-09-09"
     },
     "/openai-assistants-migration-2026": {
-      "hash": "74741db7ccfc39c4",
+      "hash": "acb53cbe0c626400",
       "changed": "2026-09-09"
     },
     "/openai-realtime-migration": {
-      "hash": "bcbe4ed95f2c9b44",
+      "hash": "47b6c73385968753",
       "changed": "2026-09-09"
     },
     "/postman-alternatives": {
-      "hash": "f70c1c59c637783f",
+      "hash": "812cf3087f3d2674",
       "changed": "2026-09-09"
     },
     "/postmark-vs-resend": {
@@ -1831,35 +1831,35 @@
       "changed": "2026-09-09"
     },
     "/project-management-alternatives": {
-      "hash": "ba12d4e3a3fafb39",
+      "hash": "364df3bb054c8b8f",
       "changed": "2026-09-09"
     },
     "/q1-2026-developer-pricing-report": {
-      "hash": "eb2643a2139af3e1",
+      "hash": "7062d903b703361f",
       "changed": "2026-09-09"
     },
     "/q2-pricing-preview-2026": {
-      "hash": "e020e5dab4634166",
+      "hash": "be96d0fc11ebc2e5",
       "changed": "2026-09-09"
     },
     "/railway-vs-render": {
-      "hash": "08bd035af3529a2d",
+      "hash": "56784160be665767",
       "changed": "2026-09-09"
     },
     "/redis-alternatives": {
-      "hash": "f5f1af7aa3e9f179",
+      "hash": "d448c07ee52f634d",
       "changed": "2026-09-09"
     },
     "/security-alternatives": {
-      "hash": "4372bec33aaef120",
+      "hash": "ad818b8a6e18218f",
       "changed": "2026-09-09"
     },
     "/security-free-tier-comparison-2026": {
-      "hash": "8a85025a5869a32e",
+      "hash": "9bc1c57257f60896",
       "changed": "2026-09-09"
     },
     "/serverless-free-tier-comparison-2026": {
-      "hash": "602b990ed7ad81b7",
+      "hash": "a4117f72a55cc68b",
       "changed": "2026-09-09"
     },
     "/setup": {
@@ -1867,15 +1867,15 @@
       "changed": "2026-09-09"
     },
     "/shutdowns": {
-      "hash": "b81994538e6fe0e6",
+      "hash": "ab0b86846eba558d",
       "changed": "2026-09-09"
     },
     "/stability": {
-      "hash": "bc193c1a7647b6bb",
+      "hash": "95cc30942919cf99",
       "changed": "2026-09-09"
     },
     "/stack-check": {
-      "hash": "89cef114805b1e74",
+      "hash": "4f19392b12bf2fd5",
       "changed": "2026-09-09"
     },
     "/stacks": {
@@ -1903,63 +1903,63 @@
       "changed": "2026-09-09"
     },
     "/startup-credits": {
-      "hash": "42855ac2d3241f9e",
+      "hash": "98b387f79093317a",
       "changed": "2026-09-09"
     },
     "/state-of-free-tiers": {
-      "hash": "c86aee8b89801deb",
+      "hash": "b973015a426ee9e5",
       "changed": "2026-09-09"
     },
     "/storage-alternatives": {
-      "hash": "4eff995e6a5f7c8a",
+      "hash": "dd3791b59ad9e805",
       "changed": "2026-09-09"
     },
     "/storage-comparison-2026": {
-      "hash": "a98ef7f4c13ea7ce",
+      "hash": "cb77602bdfbed074",
       "changed": "2026-09-09"
     },
     "/supabase-vs-firebase": {
-      "hash": "f7a15dcca0bc8eea",
+      "hash": "094133ee5a98657f",
       "changed": "2026-09-09"
     },
     "/team-collaboration-alternatives": {
-      "hash": "b6ce63562cc4c656",
+      "hash": "3cd9f3ef1833906a",
       "changed": "2026-09-09"
     },
     "/tenor-alternatives": {
-      "hash": "de07107c5f8bf923",
+      "hash": "f25aeaaed95d2381",
       "changed": "2026-09-09"
     },
     "/terraform-alternatives": {
-      "hash": "b69861a38c20bb8b",
+      "hash": "3101a257cac4f4b4",
       "changed": "2026-09-09"
     },
     "/terraform-cloud-free-tier-removed": {
-      "hash": "67c73b3b5c1b2a1c",
+      "hash": "6dfd3442c1036a27",
       "changed": "2026-09-09"
     },
     "/testing-alternatives": {
-      "hash": "5bb08c42a7bf5e3b",
+      "hash": "765202bd3c909b43",
       "changed": "2026-09-09"
     },
     "/testing-free-tier-comparison-2026": {
-      "hash": "53a2d63e1b856e8e",
+      "hash": "7885633e11b7b220",
       "changed": "2026-09-09"
     },
     "/vector-database-pricing": {
-      "hash": "e9186fa760d3bcbf",
+      "hash": "db9757e080c5e1a9",
       "changed": "2026-09-09"
     },
     "/vercel-alternatives": {
-      "hash": "477d9fc578836ba7",
+      "hash": "964da55cfe333a7f",
       "changed": "2026-09-09"
     },
     "/vercel-vs-netlify": {
-      "hash": "8863a87eff71432a",
+      "hash": "214501ee20432de3",
       "changed": "2026-09-09"
     },
     "/x402-services": {
-      "hash": "95e6b8e7903d154f",
+      "hash": "b376524e9d591ae6",
       "changed": "2026-09-09"
     }
   }

--- a/scripts/census-1500-host-restated.mjs
+++ b/scripts/census-1500-host-restated.mjs
@@ -1,0 +1,159 @@
+#!/usr/bin/env node
+
+import { readFileSync, writeFileSync, existsSync, mkdirSync } from "node:fs";
+import { createHash } from "node:crypto";
+import { resolve, dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { fetchPageText } from "./verify-freshness.js";
+import { priceSignals } from "./change-gate.js";
+import {
+  hostRestatement,
+  productHalf,
+  sourceCheckRecord,
+  pageNamesVendor,
+  pageNamesOnlyTheHost,
+  SOURCE_CHECK_OUTCOMES,
+  SOURCE_CHECK_NOT_THE_PRODUCT,
+} from "./vendor-naming.js";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const INDEX_PATH =
+  process.env.AGENTDEALS_INDEX_PATH || resolve(__dirname, "..", "data", "index.json");
+const CONCURRENCY = 12;
+
+const WITHHOLDING = new Set(["does_not_name_vendor", SOURCE_CHECK_NOT_THE_PRODUCT, "states_no_terms", "unreadable"]);
+
+function arg(name, fallback = null) {
+  const at = process.argv.indexOf(name);
+  return at !== -1 ? process.argv[at + 1] : fallback;
+}
+
+export function restatedRecords(offers) {
+  return offers
+    .map((offer, index) => ({ offer, index, restated: hostRestatement(offer.vendor, offer.url) }))
+    .filter(({ restated }) => restated.tokens.length > 0);
+}
+
+export function outcomeCounts(offers) {
+  const counts = Object.fromEntries(SOURCE_CHECK_OUTCOMES.map((outcome) => [outcome, 0]));
+  counts.none = 0;
+  for (const offer of offers) {
+    const outcome = offer.source_check?.outcome ?? "none";
+    counts[outcome] = (counts[outcome] ?? 0) + 1;
+  }
+  return counts;
+}
+
+async function mapWithConcurrency(items, limit, fn) {
+  const out = new Array(items.length);
+  let next = 0;
+  await Promise.all(
+    Array.from({ length: Math.min(limit, items.length) }, async () => {
+      while (true) {
+        const i = next++;
+        if (i >= items.length) return;
+        out[i] = await fn(items[i], i);
+      }
+    })
+  );
+  return out;
+}
+
+async function main() {
+  const write = process.argv.includes("--write");
+  const out = arg("--out", "/tmp/census-1500.json");
+  const checked = arg("--checked", new Date().toISOString().slice(0, 10));
+  const cacheDir = arg("--cache");
+  const limit = arg("--limit") ? parseInt(arg("--limit"), 10) : null;
+
+  const data = JSON.parse(readFileSync(INDEX_PATH, "utf-8"));
+  const offers = data.offers ?? [];
+  const before = outcomeCounts(offers);
+
+  let population = restatedRecords(offers);
+  if (limit) population = population.slice(0, limit);
+  const urls = [...new Set(population.map(({ offer }) => offer.url).filter(Boolean))];
+  console.error(`${population.length} of ${offers.length} records name a token their cited host restates`);
+  console.error(`${urls.length} distinct URLs to read`);
+
+  if (cacheDir && !existsSync(cacheDir)) mkdirSync(cacheDir, { recursive: true });
+  const cachePath = (url) => join(cacheDir, `${createHash("sha1").update(url).digest("hex")}.json`);
+
+  let done = 0;
+  const pages = new Map();
+  await mapWithConcurrency(urls, CONCURRENCY, async (url) => {
+    let page;
+    if (cacheDir && existsSync(cachePath(url))) {
+      page = JSON.parse(readFileSync(cachePath(url), "utf-8"));
+    } else {
+      const fetched = await fetchPageText(url);
+      page = fetched.ok
+        ? { ok: true, text: fetched.text, structured: fetched.structured ?? null }
+        : { ok: false, error: fetched.error };
+      if (cacheDir) writeFileSync(cachePath(url), JSON.stringify(page));
+    }
+    done++;
+    if (done % 50 === 0) console.error(`  ${done}/${urls.length}`);
+    pages.set(url, page);
+  });
+
+  const rows = [];
+  for (const { offer, index, restated } of population) {
+    const page = pages.get(offer.url) ?? { ok: false, error: "not fetched" };
+    const signals = page.ok ? priceSignals(page.text) : [];
+    const check = sourceCheckRecord(offer, page, signals, checked);
+    const was = offer.source_check?.outcome ?? "none";
+    const namedNow = page.ok ? pageNamesVendor(page.text, offer.vendor, { url: offer.url }).named : null;
+    const row = {
+      vendor: offer.vendor,
+      url: offer.url,
+      restates: restated.tokens,
+      product: productHalf(offer.vendor, restated),
+      was,
+      now: check.outcome,
+      detail: check.detail,
+      page_ok: page.ok,
+      named_now: namedNow,
+      names_only_the_host: page.ok ? pageNamesOnlyTheHost(page.text, offer.vendor, offer.url) : null,
+    };
+    rows.push(row);
+    if (write && check.outcome !== was && WITHHOLDING.has(check.outcome)) {
+      data.offers[index].source_check = check;
+      row.written = true;
+    }
+  }
+
+  const after = outcomeCounts(data.offers);
+  const moved = rows.filter((row) => row.was !== row.now);
+  const intoProduct = rows.filter((row) => row.now === SOURCE_CHECK_NOT_THE_PRODUCT);
+  const leftWithholding = rows.filter((row) => WITHHOLDING.has(row.was) && !WITHHOLDING.has(row.now));
+
+  const report = {
+    checked,
+    population: population.length,
+    catalogue: offers.length,
+    before,
+    after,
+    reread_outcomes: rows.reduce((a, row) => ({ ...a, [row.now]: (a[row.now] ?? 0) + 1 }), {}),
+    moved: moved.length,
+    into_does_not_name_product: intoProduct.length,
+    left_withholding_on_reread: leftWithholding.map((row) => `${row.vendor} — ${row.was} → ${row.now}`),
+    rows,
+  };
+  writeFileSync(out, JSON.stringify(report, null, 2) + "\n");
+  console.error(JSON.stringify({ ...report, rows: undefined, left_withholding_on_reread: report.left_withholding_on_reread.length }, null, 2));
+  console.error(`wrote ${out}`);
+
+  if (write) {
+    writeFileSync(INDEX_PATH, JSON.stringify(data, null, 2) + "\n");
+    console.error(`stamped ${rows.filter((row) => row.written).length} records in ${INDEX_PATH}`);
+  }
+}
+
+const invoked = process.argv[1] && resolve(process.argv[1]) === resolve(fileURLToPath(import.meta.url));
+if (invoked) {
+  main().catch((err) => {
+    console.error(`Fatal: ${err.message}`);
+    process.exit(1);
+  });
+}

--- a/scripts/mutate-1500.mjs
+++ b/scripts/mutate-1500.mjs
@@ -1,0 +1,106 @@
+import { readFileSync, writeFileSync } from "node:fs";
+import { execFileSync } from "node:child_process";
+
+const SUITE = [
+  "test/product-named-on-its-page.test.ts",
+  "test/vendor-naming.test.ts",
+  "test/source-check.test.ts",
+  "test/price-evidence-grade.test.ts",
+];
+
+const NAMING = "scripts/vendor-naming.js";
+const CHECK = "src/source-check.ts";
+
+const MUTANTS = [
+  ["no-name-ever-restates-its-host", NAMING,
+    `  const words = nameWords(vendor);
+  if (words.length < 2) return NOTHING_RESTATED;`,
+    `  const words = nameWords(vendor);
+  if (words.length >= 0) return NOTHING_RESTATED;`],
+  ["a-label-of-any-length-restates-a-token", NAMING,
+    `  if (label.length < MIN_FORM_LENGTH) return false;
+  if (label === token) return true;`,
+    `  if (label === token) return true;`],
+  ["a-remainder-of-qualifiers-is-still-a-product", NAMING,
+    `  if (!remainder.some(distinguishesTheProduct)) return NOTHING_RESTATED;`,
+    `  if (remainder.length === 0) return NOTHING_RESTATED;`],
+  ["the-tld-is-never-the-brand-in-the-host", NAMING,
+    `  for (const label of hostLabels(url)) {`,
+    `  for (const label of hostLabels(url).slice(0, -1)) {`],
+  ["a-restated-token-is-evidence-again", NAMING,
+    `  const forms = vendorNameForms(vendor, [...aliases, productHalf(vendor, restated)])
+    .filter((form) => !restating.has(form));`,
+    `  const forms = vendorNameForms(vendor, [...aliases, productHalf(vendor, restated)]);`],
+  ["the-host-fallback-forgets-which-labels-the-name-restates", NAMING,
+    `    if (restated.labels.includes(label)) continue;`,
+    `    if (restated.labels.includes(label) && false) continue;`],
+  ["the-product-half-is-never-a-form-of-its-own", NAMING,
+    `  const forms = vendorNameForms(vendor, [...aliases, productHalf(vendor, restated)])`,
+    `  const forms = vendorNameForms(vendor, [...aliases])`],
+  ["the-product-half-is-the-whole-name", NAMING,
+    `  const kept = nameWords(vendor).filter((word) => !nameTokens(word).some((token) => restating.has(token)));`,
+    `  const kept = nameWords(vendor);`],
+  ["a-parenthetical-aside-is-part-of-the-name", NAMING,
+    `    .replace(/\\([^)]*\\)/g, " ")`,
+    `    .replace(/\\([^)]*\\)/g, "$&")`],
+  ["an-unnamed-product-reads-as-an-unnamed-vendor", NAMING,
+    `    if (pageNamesOnlyTheHost(page.text, offer.vendor, offer.url)) {`,
+    `    if (false && pageNamesOnlyTheHost(page.text, offer.vendor, offer.url)) {`],
+  ["every-unnamed-page-reads-as-an-unnamed-product", NAMING,
+    `    if (pageNamesOnlyTheHost(page.text, offer.vendor, offer.url)) {`,
+    `    if (true) {`],
+  ["the-platform-test-answers-for-every-record", NAMING,
+    `  if (restated.tokens.length === 0) return false;`,
+    `  if (restated.tokens.length === 0) return true;`],
+  ["the-new-outcome-leaves-the-shared-vocabulary", NAMING,
+    `  SOURCE_CHECK_NOT_THE_PRODUCT,
+  SOURCE_CHECK_NO_TERMS,
+  SOURCE_CHECK_UNREADABLE,
+];`,
+    `  SOURCE_CHECK_NO_TERMS,
+  SOURCE_CHECK_UNREADABLE,
+];`],
+  ["an-unnamed-product-stops-holding-the-verified-date", NAMING,
+    `const OUTCOMES_THAT_HOLD_THE_VERIFIED_DATE = new Set([
+  SOURCE_CHECK_NOT_NAMED,
+  SOURCE_CHECK_NOT_THE_PRODUCT,`,
+    `const OUTCOMES_THAT_HOLD_THE_VERIFIED_DATE = new Set([
+  SOURCE_CHECK_NOT_NAMED,`],
+  ["an-unnamed-product-keeps-its-rating", CHECK,
+    `export const LEVEL_WITHHOLDING_OUTCOMES: SourceCheckOutcome[] = [
+  "does_not_name_vendor",
+  "does_not_name_product",`,
+    `export const LEVEL_WITHHOLDING_OUTCOMES: SourceCheckOutcome[] = [
+  "does_not_name_vendor",`],
+  ["the-reader-is-told-the-page-named-nobody", CHECK,
+    `  does_not_name_product: (subject) => \`The page we cite for \${subject} names the platform it runs on and not \${subject} itself.\`,`,
+    `  does_not_name_product: (subject) => \`The page we cite for \${subject} does not name it.\`,`],
+];
+
+function run(cmd, args) {
+  try {
+    execFileSync(cmd, args, { stdio: "pipe", encoding: "utf-8" });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+const survivors = [];
+for (const [name, file, from, to] of MUTANTS) {
+  const original = readFileSync(file, "utf-8");
+  if (!original.includes(from)) {
+    console.log(`SKIP  ${name} — the line it mutates is not in ${file}`);
+    survivors.push(`${name} (not applied)`);
+    continue;
+  }
+  writeFileSync(file, original.replace(from, to));
+  const built = run("npm", ["run", "build"]);
+  const green = built && run("node", ["--test", "--test-concurrency", "1", ...SUITE]);
+  writeFileSync(file, original);
+  console.log(`${green ? "SURVIVED" : built ? "killed  " : "killed (did not compile)"}  ${name}`);
+  if (green) survivors.push(name);
+}
+run("npm", ["run", "build"]);
+console.log(`\n${MUTANTS.length - survivors.length}/${MUTANTS.length} killed`);
+if (survivors.length > 0) console.log("survivors:", survivors.join(", "));

--- a/scripts/vendor-naming.js
+++ b/scripts/vendor-naming.js
@@ -16,6 +16,7 @@ const MIN_DISTINCTIVE_WORD = 7;
 export const SOURCE_CHECK_OK = "ok";
 export const SOURCE_CHECK_NO_AMOUNT = "states_no_amount";
 export const SOURCE_CHECK_NOT_NAMED = "does_not_name_vendor";
+export const SOURCE_CHECK_NOT_THE_PRODUCT = "does_not_name_product";
 export const SOURCE_CHECK_NO_TERMS = "states_no_terms";
 export const SOURCE_CHECK_UNREADABLE = "unreadable";
 
@@ -23,12 +24,14 @@ export const SOURCE_CHECK_OUTCOMES = [
   SOURCE_CHECK_OK,
   SOURCE_CHECK_NO_AMOUNT,
   SOURCE_CHECK_NOT_NAMED,
+  SOURCE_CHECK_NOT_THE_PRODUCT,
   SOURCE_CHECK_NO_TERMS,
   SOURCE_CHECK_UNREADABLE,
 ];
 
 const OUTCOMES_THAT_HOLD_THE_VERIFIED_DATE = new Set([
   SOURCE_CHECK_NOT_NAMED,
+  SOURCE_CHECK_NOT_THE_PRODUCT,
   SOURCE_CHECK_NO_TERMS,
   SOURCE_CHECK_UNREADABLE,
 ]);
@@ -131,9 +134,63 @@ export function servedFromTheVendorsDomain(offer, aliases = []) {
     .some((label) => hostLabelMatchesVendor(label, offer?.vendor ?? "", aliases));
 }
 
+const NAME_TLD_SET = new Set(NAME_TLDS);
+
+function nameTokens(vendor) {
+  return normalizeForMatch(vendor).trim().split(" ").filter(Boolean);
+}
+
+function labelRestatesToken(label, token) {
+  if (label.length < MIN_FORM_LENGTH) return false;
+  if (label === token) return true;
+  return label.length >= MIN_HOST_PREFIX && token.startsWith(label);
+}
+
+function distinguishesTheProduct(token) {
+  if (token.length < MIN_FORM_LENGTH) return false;
+  return !NAME_QUALIFIERS.has(token) && !NAME_TLD_SET.has(token) && !/^\d+$/.test(token);
+}
+
+export function nameWords(vendor) {
+  return String(vendor ?? "")
+    .replace(/\([^)]*\)/g, " ")
+    .trim()
+    .split(/\s+/)
+    .filter(Boolean);
+}
+
+const NOTHING_RESTATED = { tokens: [], labels: [], remainder: [] };
+
+export function hostRestatement(vendor, url) {
+  const words = nameWords(vendor);
+  if (words.length < 2) return NOTHING_RESTATED;
+  const tokens = nameTokens(words.join(" "));
+  const restated = new Set();
+  const labels = [];
+  for (const label of hostLabels(url)) {
+    const hits = tokens.filter((token) => labelRestatesToken(label, token));
+    if (hits.length === 0) continue;
+    labels.push(label);
+    for (const hit of hits) restated.add(hit);
+  }
+  const remainder = tokens.filter((token) => !restated.has(token));
+  if (!remainder.some(distinguishesTheProduct)) return NOTHING_RESTATED;
+  return { tokens: [...restated], labels, remainder };
+}
+
+export function productHalf(vendor, restated) {
+  const restating = new Set(restated.tokens);
+  const kept = nameWords(vendor).filter((word) => !nameTokens(word).some((token) => restating.has(token)));
+  return kept.length > 0 ? kept.join(" ") : restated.remainder.join(" ");
+}
+
 export function pageNamesVendor(pageText, vendor, options = {}) {
   const aliases = options.aliases ?? [];
-  const forms = vendorNameForms(vendor, aliases);
+  const url = options.url ?? "";
+  const restated = hostRestatement(vendor, url);
+  const restating = new Set(restated.tokens);
+  const forms = vendorNameForms(vendor, [...aliases, productHalf(vendor, restated)])
+    .filter((form) => !restating.has(form));
   const result = (named, via, form) => ({ named, via, form, forms });
   if (forms.length === 0) return result(false, null, null);
 
@@ -143,7 +200,8 @@ export function pageNamesVendor(pageText, vendor, options = {}) {
   }
 
   const written = haystack.replace(/ /g, "");
-  for (const label of hostLabels(options.url ?? "").slice(0, -1).reverse()) {
+  for (const label of hostLabels(url).slice(0, -1).reverse()) {
+    if (restated.labels.includes(label)) continue;
     if (label.length < MIN_FORM_LENGTH || !written.includes(label)) continue;
     if (hostLabelMatchesVendor(label, vendor, aliases)) {
       return result(true, NAMED_BY_A_HOST_THE_PAGE_WRITES, label);
@@ -151,6 +209,12 @@ export function pageNamesVendor(pageText, vendor, options = {}) {
   }
 
   return result(false, null, null);
+}
+
+export function pageNamesOnlyTheHost(pageText, vendor, url) {
+  const restated = hostRestatement(vendor, url);
+  if (restated.tokens.length === 0) return false;
+  return restated.tokens.some((token) => pageNamesVendor(pageText, token, { url }).named);
 }
 
 export const READ_FROM_MARKUP = "markup";
@@ -172,6 +236,13 @@ export function classifySource(offer, page, signals) {
   }
   const naming = pageNamesVendor(page.text, offer.vendor, { url: offer.url });
   if (!naming.named) {
+    if (pageNamesOnlyTheHost(page.text, offer.vendor, offer.url)) {
+      const restated = hostRestatement(offer.vendor, offer.url);
+      return {
+        outcome: SOURCE_CHECK_NOT_THE_PRODUCT,
+        detail: `the page names the platform in the domain we cite ${offer.vendor} from and never names ${productHalf(offer.vendor, restated)}`,
+      };
+    }
     return {
       outcome: SOURCE_CHECK_NOT_NAMED,
       detail: servedFromTheVendorsDomain(offer)

--- a/src/openapi.ts
+++ b/src/openapi.ts
@@ -1501,7 +1501,7 @@ export const openapiSpec = {
           verifiedDate: { type: "string", format: "date", description: "Date the offer was last verified (YYYY-MM-DD)" },
           eligibility: { $ref: "#/components/schemas/Eligibility" },
           gate: { $ref: "#/components/schemas/Gate" },
-          risk_level: { type: "string", enum: ["stable", "caution", "risky"], nullable: true, description: "Our published pricing-risk verdict, or null where a rule withholds it: gate is non-null (#1241, #1260), rating_withheld is non-null (#1352), or the page we cite could not confirm the record — link_unreachable, or a source_check outcome of does_not_name_vendor, states_no_terms or unreadable (#1046). One function applies all three rules and every surface that publishes a level calls it, so /api/audit-stack, /api/stack, /stack-check and MCP plan_stack answer the same as this field for the same record on the same day (#1486)." },
+          risk_level: { type: "string", enum: ["stable", "caution", "risky"], nullable: true, description: "Our published pricing-risk verdict, or null where a rule withholds it: gate is non-null (#1241, #1260), rating_withheld is non-null (#1352), or the page we cite could not confirm the record — link_unreachable, or a source_check outcome of does_not_name_vendor, does_not_name_product, states_no_terms or unreadable (#1046, #1500). One function applies all three rules and every surface that publishes a level calls it, so /api/audit-stack, /api/stack, /stack-check and MCP plan_stack answer the same as this field for the same record on the same day (#1486)." },
           source_check: { $ref: "#/components/schemas/SourceCheck" }
         },
         required: ["vendor", "category", "description", "tier", "url", "tags", "verifiedDate"]
@@ -1524,14 +1524,15 @@ export const openapiSpec = {
           checked: { type: "string", format: "date", description: "The day we last read the page." },
           outcome: {
             type: "string",
-            enum: ["ok", "states_no_amount", "does_not_name_vendor", "states_no_terms", "unreadable"],
+            enum: ["ok", "states_no_amount", "does_not_name_vendor", "does_not_name_product", "states_no_terms", "unreadable"],
             description: [
               "ok — the page names the vendor and states at least one amount, rate or price, either in figures the page renders or as a typed price in its schema.org markup (#1279).",
               "states_no_amount — the page names the vendor and names a plan or tier, but every price signal on it is a phrase such as \"Enterprise plan\" or \"Free forever\" and none is a figure (#1268). The quantities in description come from our own entry, not from that page. risk_level is still published and the summary says so, rather than being withheld.",
               "does_not_name_vendor — the page we read never writes the vendor's name. The URL we asked for is not evidence for this check, so a domain that keeps the vendor's name and loses its product reaches this outcome too (#1355).",
+              "does_not_name_product — the page we read writes the platform token the vendor name shares with the host we cite it from, and never writes the rest of the name. For a vendor called <Platform> <Product> this is a live page on the platform's own domain that says nothing about the product, so the record rests on the platform existing rather than on the offer existing (#1500).",
               "states_no_terms — the page names the vendor but carries no price signal of any kind.",
               "unreadable — the fetch produced no body we could read.",
-              "The last three withhold a favourable risk_level; the first two do not."
+              "The last four withhold a favourable risk_level; the first two do not."
             ].join(" ")
           },
           detail: { type: "string", description: "Our own sentence recording what the check found — never a quotation from the page, and not corroborable against it (#1467). For ok, the form of the vendor's name the check matched and the price signal it found, or what the markup states when the rendered page states no amount; for states_no_amount, the phrase that was the page's entire price evidence; otherwise why the page cannot confirm the record. Where the page was read for schema.org markup, the detail says whether that markup was absent, present and priceless, or priced. The fields carrying text taken from a page are product_role.source_quote and product_subtypes.labels[].source_quote." },

--- a/src/serve.ts
+++ b/src/serve.ts
@@ -885,6 +885,7 @@ const WITHHELD_BADGE_LABELS: Record<LevelWithheldReason | "no_source", string> =
   unreadable: "unrated \u2014 page unreadable",
   states_no_terms: "unrated \u2014 page states no terms",
   does_not_name_vendor: "unrated \u2014 page omits vendor",
+  does_not_name_product: "unrated \u2014 page omits product",
 };
 
 const GATED_BADGE_LABELS: Record<GateCode, string> = {
@@ -8759,7 +8760,6 @@ const EVENTS: EventDef[] = [
       { title: "Gemini 3.1 Pro (Preview)", detail: "1M token context, 2x reasoning improvement. $2/$12 per MTok (\u2264200K context, doubles above)." },
       { title: "Gemini 3.1 Flash-Lite (Preview)", detail: "Cost-efficient, low-latency model tier for high-throughput workloads." },
       { title: "Gemini 3.1 Flash Image", detail: "Dedicated image generation model with improved pricing and lower latency." },
-      { title: "GLM 5 (Experimental)", detail: "New model for complex systems engineering and agentic tasks." },
       { title: "Gemini Embedding 2", detail: "First natively multimodal embedding model \u2014 text, images, video, audio, and docs in a single embedding space." },
       { title: "Vector Search 2.0", detail: "Now GA on Vertex AI. Enhanced vector similarity search for AI/RAG applications." },
       { title: "Vertex AI Agent Engine", detail: "Sessions and memory now GA in Vertex AI Agent Builder." },

--- a/src/source-check.ts
+++ b/src/source-check.ts
@@ -4,6 +4,7 @@ export const SOURCE_CHECK_OUTCOMES: SourceCheckOutcome[] = [
   "ok",
   "states_no_amount",
   "does_not_name_vendor",
+  "does_not_name_product",
   "states_no_terms",
   "unreadable",
 ];
@@ -11,11 +12,13 @@ export const SOURCE_CHECK_OUTCOMES: SourceCheckOutcome[] = [
 export type LevelWithheldReason =
   | "link_unreachable"
   | "does_not_name_vendor"
+  | "does_not_name_product"
   | "states_no_terms"
   | "unreadable";
 
 export const LEVEL_WITHHOLDING_OUTCOMES: SourceCheckOutcome[] = [
   "does_not_name_vendor",
+  "does_not_name_product",
   "states_no_terms",
   "unreadable",
 ];
@@ -23,6 +26,7 @@ export const LEVEL_WITHHOLDING_OUTCOMES: SourceCheckOutcome[] = [
 const WITHHELD_LEVEL_CLAUSES: Record<LevelWithheldReason, (since: string) => string> = {
   link_unreachable: (since) => `its pricing page has not resolved for us${since}`,
   does_not_name_vendor: () => `the page we cite for this offer does not name it`,
+  does_not_name_product: () => `the page we cite for this offer names the platform it runs on and not the offer itself`,
   states_no_terms: () => `the page we cite for this offer states no terms we can read`,
   unreadable: () => `we could not read the page we cite for this offer`,
 };
@@ -30,6 +34,7 @@ const WITHHELD_LEVEL_CLAUSES: Record<LevelWithheldReason, (since: string) => str
 const WITHHELD_LEVEL_SENTENCES: Record<LevelWithheldReason, (subject: string, since: string) => string> = {
   link_unreachable: (subject, since) => `${subject}'s pricing page has not resolved for us${since}.`,
   does_not_name_vendor: (subject) => `The page we cite for ${subject} does not name it.`,
+  does_not_name_product: (subject) => `The page we cite for ${subject} names the platform it runs on and not ${subject} itself.`,
   states_no_terms: (subject) => `The page we cite for ${subject} states no terms we can read.`,
   unreadable: (subject) => `We could not read the page we cite for ${subject}.`,
 };
@@ -50,6 +55,7 @@ export type TermsUnconfirmedReason = Exclude<SourceCheckOutcome, "ok">;
 
 const UNCONFIRMED_TERMS_CLAUSES: Record<TermsUnconfirmedReason, string> = {
   does_not_name_vendor: WITHHELD_LEVEL_CLAUSES.does_not_name_vendor(""),
+  does_not_name_product: WITHHELD_LEVEL_CLAUSES.does_not_name_product(""),
   states_no_terms: WITHHELD_LEVEL_CLAUSES.states_no_terms(""),
   unreadable: WITHHELD_LEVEL_CLAUSES.unreadable(""),
   states_no_amount: `the page we cite for this offer names a plan but states no amount`,

--- a/src/types.ts
+++ b/src/types.ts
@@ -83,6 +83,7 @@ export type SourceCheckOutcome =
   | "ok"
   | "states_no_amount"
   | "does_not_name_vendor"
+  | "does_not_name_product"
   | "states_no_terms"
   | "unreadable";
 

--- a/test/api-gate-field.test.ts
+++ b/test/api-gate-field.test.ts
@@ -7,7 +7,7 @@ import { fileURLToPath } from "node:url";
 
 const { gateFor, utcDate, GATE_TABLE } = await import("../dist/ranking.js");
 const { gateClauseList, gateDisclosureSentence, matchingSubject } = await import("../dist/gate-disclosure.js");
-const { LEVEL_WITHHOLDING_OUTCOMES } = await import("../dist/source-check.js");
+const { LEVEL_WITHHOLDING_OUTCOMES, withheldLevelSentence } = await import("../dist/source-check.js");
 
 type Offer = import("../src/types.ts").Offer;
 type Gate = { code: string; reason: string } | null;
@@ -25,19 +25,22 @@ const NOT_RATED_CLAUSE = "We do not rate an offer we do not list.";
 const ENDED_VERDICT = "This offer has ended — we keep the page for the record and no longer rate it.";
 const STABLE_HISTORY = "has a stable pricing history.";
 
-const UNREAD_CITATION_FORMS = [
-  /^.+'s pricing page has not resolved for us( since \d{4}-\d{2}-\d{2})?\.$/,
-  /^The page we cite for .+ does not name it\.$/,
-  /^The page we cite for .+ states no terms we can read\.$/,
-  /^We could not read the page we cite for .+\.$/,
-];
+const REASONS_A_CITATION_CAN_GO_UNREAD = ["link_unreachable", ...LEVEL_WITHHOLDING_OUTCOMES];
 
-function gateSummaryShape(summary: string, gate: { code: string; reason: string }): string | null {
+function isAnUnreadCitation(rest: string, vendor: string): boolean {
+  const dated = rest.match(/ since (\d{4}-\d{2}-\d{2})\.$/);
+  return REASONS_A_CITATION_CAN_GO_UNREAD.some(reason =>
+    rest === withheldLevelSentence(reason as never, vendor, "")
+    || (dated !== null && rest === withheldLevelSentence(reason as never, vendor, ` since ${dated[1]}`))
+  );
+}
+
+function gateSummaryShape(summary: string, gate: { code: string; reason: string }, vendor: string): string | null {
   const opening = gate.code === "offer_retired" ? ENDED_VERDICT : `${gate.reason} ${NOT_RATED_CLAUSE}`;
   if (summary === opening) return null;
   if (!summary.startsWith(`${opening} `)) return `does not open with the gate's own verdict: ${summary}`;
   const rest = summary.slice(opening.length + 1);
-  if (UNREAD_CITATION_FORMS.some(form => form.test(rest))) return null;
+  if (isAnUnreadCitation(rest, vendor)) return null;
   return `carries prose that is neither the gate's verdict nor a citation we could not read: ${rest}`;
 }
 
@@ -387,7 +390,7 @@ describe("/api/vendor-risk does not rate an offer we do not list (issue #1241 Pa
       reported++;
       if (body.risk_level !== null) rated.push(offer.vendor);
       if (body.summary.includes(STABLE_HISTORY)) reassured.push(offer.vendor);
-      const problem = gateSummaryShape(body.summary, body.gate);
+      const problem = gateSummaryShape(body.summary, body.gate, offer.vendor);
       if (problem) offShape.push(`${offer.vendor} ${problem}`);
     }
     assert.deepStrictEqual(offShape, [], "gated summaries that are not the gate's verdict, alone or followed by an unread citation");

--- a/test/badge-withholding.test.ts
+++ b/test/badge-withholding.test.ts
@@ -38,6 +38,7 @@ const WITHHELD_LABELS: Record<string, string> = {
   unreadable: "unrated — page unreadable",
   states_no_terms: "unrated — page states no terms",
   does_not_name_vendor: "unrated — page omits vendor",
+  does_not_name_product: "unrated — page omits product",
   eligibility_restricted: "unrated — restricted offer",
   not_a_free_offer: "unrated — not a free offer",
   offer_expired: "unrated — offer expired",

--- a/test/feed-weekly-digest.test.ts
+++ b/test/feed-weekly-digest.test.ts
@@ -58,7 +58,11 @@ describe("/feed.xml weekly digest feed", () => {
     const xml = await res.text();
     const entries = xml.match(/<entry>/g);
     assert.ok(entries && entries.length > 0, "Should have at least one entry");
-    assert.ok(entries!.length <= 4, "Should have at most 4 weeks");
+    const weeks = xml.match(/<id>urn:agentdeals:weekly-digest:[^<]*<\/id>/g) ?? [];
+    assert.ok(weeks.length > 0, "Should have at least one week");
+    assert.ok(weeks.length <= 4, `Should have at most 4 weeks, found ${weeks.length}`);
+    const corrections = xml.match(/<id>urn:agentdeals:correction:[^<]*<\/id>/g) ?? [];
+    assert.strictEqual(entries!.length, weeks.length + corrections.length, "every entry is a week or a correction to one");
   });
 
   it("entries have correct structure", async () => {

--- a/test/product-named-on-its-page.test.ts
+++ b/test/product-named-on-its-page.test.ts
@@ -1,0 +1,215 @@
+import { describe, it } from "node:test";
+import assert from "node:assert";
+import {
+  hostRestatement,
+  productHalf,
+  pageNamesVendor,
+  pageNamesOnlyTheHost,
+  classifySource,
+  SOURCE_CHECK_OK,
+  SOURCE_CHECK_NOT_NAMED,
+  SOURCE_CHECK_NOT_THE_PRODUCT,
+  SOURCE_CHECK_OUTCOMES,
+} from "../scripts/vendor-naming.js";
+import { priceSignals } from "../scripts/change-gate.js";
+import {
+  LEVEL_WITHHOLDING_OUTCOMES,
+  cannotVouchForLevel,
+  levelWithheldReason,
+  withheldLevelClause,
+  withheldLevelSentence,
+  unconfirmedTermsClause,
+} from "../dist/source-check.js";
+import { loadOffers } from "../dist/data.js";
+import { openapiSpec } from "../dist/openapi.js";
+import { assertPopulationFloor } from "./population-floor.ts";
+
+const VERTEX_MODEL_REFERENCE = "https://cloud.google.com/vertex-ai/docs/generative-ai/model-reference/overview";
+const A_GOOGLE_PAGE_ABOUT_GEMINI =
+  "Use the Model API for Gemini in Gemini Enterprise Agent Platform to create custom applications. " +
+  "Google Cloud samples video at 10 frames per second. Gemini 3 Pro costs $2 per 1M input tokens.";
+
+describe("a page that names the platform and not the product", () => {
+  it("does not confirm a record whose name is the platform plus a product", () => {
+    const result = pageNamesVendor(A_GOOGLE_PAGE_ABOUT_GEMINI, "Google GLM 5", { url: VERTEX_MODEL_REFERENCE });
+    assert.strictEqual(result.named, false);
+  });
+
+  it("confirms the same record once the page writes the product", () => {
+    const page = `${A_GOOGLE_PAGE_ABOUT_GEMINI} GLM 5 is available in preview.`;
+    assert.strictEqual(pageNamesVendor(page, "Google GLM 5", { url: VERTEX_MODEL_REFERENCE }).named, true);
+  });
+
+  it("reads the product off a page that writes it without the platform", () => {
+    const page = "ECR Public repositories include 50 GB per month of always-free storage.";
+    assert.strictEqual(pageNamesVendor(page, "Amazon ECR Public", { url: "https://aws.amazon.com/ecr/pricing/" }).named, true);
+  });
+
+  it("separates it from a page belonging to another company", () => {
+    const check = classifySource(
+      { vendor: "Google GLM 5", url: VERTEX_MODEL_REFERENCE },
+      { ok: true, text: A_GOOGLE_PAGE_ABOUT_GEMINI },
+      priceSignals(A_GOOGLE_PAGE_ABOUT_GEMINI),
+    );
+    assert.strictEqual(check.outcome, SOURCE_CHECK_NOT_THE_PRODUCT);
+    assert.notStrictEqual(check.outcome, SOURCE_CHECK_NOT_NAMED);
+    assert.match(check.detail, /never names GLM 5/);
+  });
+
+  it("stays does_not_name_vendor where the page writes neither the platform nor the product", () => {
+    const text = "Langit77 Pusat Situs Resmi Online Slot. Bonus $107.50 setiap hari.";
+    const check = classifySource(
+      { vendor: "Amazon ECR Public", url: "https://aws.amazon.com/ecr/pricing/" },
+      { ok: true, text },
+      priceSignals(text),
+    );
+    assert.strictEqual(check.outcome, SOURCE_CHECK_NOT_NAMED);
+  });
+
+  it("passes a page that states terms and writes the whole name", () => {
+    const text = "Amazon ECR Public gives 50 GB per month of always-free storage.";
+    const check = classifySource(
+      { vendor: "Amazon ECR Public", url: "https://aws.amazon.com/ecr/pricing/" },
+      { ok: true, text },
+      priceSignals(text),
+    );
+    assert.strictEqual(check.outcome, SOURCE_CHECK_OK);
+  });
+});
+
+describe("which names the rule reaches", () => {
+  const cases: [string, string, boolean][] = [
+    ["Google GLM 5", VERTEX_MODEL_REFERENCE, true],
+    ["Amazon ECR Public", "https://aws.amazon.com/ecr/pricing/", true],
+    ["Zoho Docs", "https://www.zoho.com/workdrive/pricing.html", true],
+    ["Vercel", "https://vercel.com/pricing", false],
+    ["zoom.us", "https://zoom.us/", false],
+    ["Bolt.new", "https://bolt.new/pricing", false],
+    ["Cloudflare KV", "https://developers.cloudflare.com/kv/platform/pricing/", false],
+    ["Google Cloud Run", "https://cloud.google.com/run/pricing", false],
+    ["Sevalla (formerly Kinsta)", "https://sevalla.com/static-site-hosting/", false],
+    ["Cloudflare WARP", "https://one.one.one.one/", false],
+    ["Google Gemini Code Assist", "https://codeassist.google", true],
+    ["Google Antigravity", "https://antigravity.google", false],
+    ["Val Town", "https://www.val.town/pricing", false],
+  ];
+
+  for (const [vendor, url, restated] of cases) {
+    it(`${restated ? "reads" : "leaves alone"} ${vendor} cited from ${new URL(url).hostname}`, () => {
+      assert.strictEqual(hostRestatement(vendor, url).tokens.length > 0, restated);
+    });
+  }
+
+  it("reads a brand that is the suffix of the host as well as one that is not", () => {
+    assert.deepStrictEqual(hostRestatement("Google Gemini Code Assist", "https://codeassist.google").tokens, ["google"]);
+    assert.deepStrictEqual(hostRestatement("Google GLM 5", VERTEX_MODEL_REFERENCE).tokens, ["google"]);
+  });
+
+  it("asks for nothing more where the host says the whole name already", () => {
+    for (const [vendor, url] of [
+      ["Google Antigravity", "https://antigravity.google"],
+      ["Val Town", "https://www.val.town/pricing"],
+      ["Icon Horse", "https://icon.horse"],
+    ] as [string, string][]) {
+      assert.deepStrictEqual(hostRestatement(vendor, url), { tokens: [], labels: [], remainder: [] }, vendor);
+    }
+  });
+
+  it("names the half of the record the page has to carry", () => {
+    assert.strictEqual(productHalf("Google GLM 5", hostRestatement("Google GLM 5", VERTEX_MODEL_REFERENCE)), "GLM 5");
+    assert.strictEqual(
+      productHalf("Amazon ECR Public", hostRestatement("Amazon ECR Public", "https://aws.amazon.com/ecr/pricing/")),
+      "ECR Public",
+    );
+  });
+});
+
+describe("deleting the host brand from a name does not change the verdict", () => {
+  const offers = loadOffers();
+  const exposed = offers
+    .map((offer) => ({ offer, restated: hostRestatement(offer.vendor, offer.url) }))
+    .filter(({ restated }) => restated.tokens.length > 0);
+
+  it("reads a real population of records, not an empty one", () => {
+    assertPopulationFloor(exposed.length, 100, "catalogue records whose name restates the host we cite them from");
+  });
+
+  it("accepts no form that a page could match without writing past the host brand", () => {
+    let checked = 0;
+    for (const { offer, restated } of exposed) {
+      for (const form of pageNamesVendor("", offer.vendor, { url: offer.url }).forms) {
+        const beyondTheHost = restated.tokens.reduce((written, token) => written.split(token).join(""), form.replace(/ /g, ""));
+        checked++;
+        assert.ok(
+          beyondTheHost.length > 0,
+          `${offer.vendor} can be confirmed by a page writing "${form}", which says no more than ${restated.tokens.join(" ")} (${offer.url})`,
+        );
+      }
+    }
+    assertPopulationFloor(checked, 200, "name forms checked for a token the cited host does not already say");
+  });
+
+  it("still confirms the whole name wherever the shortened name is confirmed", () => {
+    for (const { offer, restated } of exposed) {
+      const product = productHalf(offer.vendor, restated);
+      for (const form of pageNamesVendor("", product, { url: offer.url }).forms) {
+        const page = `Pricing and plans. ${form} from $0 per month.`;
+        assert.strictEqual(
+          pageNamesVendor(page, offer.vendor, { url: offer.url }).named,
+          true,
+          `${offer.vendor} is refused by a page writing "${form}", which confirms ${product} (${offer.url})`,
+        );
+      }
+    }
+  });
+
+  it("refuses every record on a page that writes only the host brand", () => {
+    for (const { offer, restated } of exposed) {
+      const page = `Pricing and plans. ${restated.tokens.join(" ")} from $0 per month.`;
+      assert.strictEqual(
+        pageNamesVendor(page, offer.vendor, { url: offer.url }).named,
+        false,
+        `${offer.vendor} is confirmed by a page writing only ${restated.tokens.join(" ")} (${offer.url})`,
+      );
+      assert.strictEqual(pageNamesOnlyTheHost(page, offer.vendor, offer.url), true);
+    }
+  });
+});
+
+describe("what the catalogue publishes for a record whose product is unnamed", () => {
+  const offers = loadOffers();
+  const withheld = offers.filter((offer) => offer.source_check?.outcome === SOURCE_CHECK_NOT_THE_PRODUCT);
+
+  it("carries records, so the rules below read something", () => {
+    assert.ok(withheld.length > 0, "no record in the catalogue records the new outcome");
+  });
+
+  it("publishes no rating for any of them", () => {
+    for (const offer of withheld) {
+      assert.strictEqual(cannotVouchForLevel(offer, null), true, offer.vendor);
+      assert.strictEqual(levelWithheldReason(offer, null), SOURCE_CHECK_NOT_THE_PRODUCT, offer.vendor);
+    }
+  });
+
+  it("says why in a sentence a reader gets, not only in an API field", () => {
+    const sentence = withheldLevelSentence(SOURCE_CHECK_NOT_THE_PRODUCT, "Zoho Docs");
+    assert.match(sentence, /Zoho Docs/);
+    assert.match(sentence, /platform/);
+    assert.match(withheldLevelClause(SOURCE_CHECK_NOT_THE_PRODUCT), /platform/);
+    assert.match(unconfirmedTermsClause(SOURCE_CHECK_NOT_THE_PRODUCT), /platform/);
+  });
+
+  it("keeps the records that name nobody at all on the older outcome", () => {
+    const nobody = offers.filter((offer) => offer.source_check?.outcome === SOURCE_CHECK_NOT_NAMED);
+    assertPopulationFloor(nobody.length, 75, "records whose cited page names no part of the vendor");
+  });
+
+  it("belongs to the vocabulary every side of the pipeline shares", () => {
+    assert.ok(SOURCE_CHECK_OUTCOMES.includes(SOURCE_CHECK_NOT_THE_PRODUCT));
+    assert.ok(LEVEL_WITHHOLDING_OUTCOMES.includes(SOURCE_CHECK_NOT_THE_PRODUCT));
+    const documented = (openapiSpec as unknown as {
+      components: { schemas: Record<string, { properties: Record<string, { enum?: string[] }> }> };
+    }).components.schemas.SourceCheck.properties.outcome.enum!;
+    assert.ok(documented.includes(SOURCE_CHECK_NOT_THE_PRODUCT));
+  });
+});

--- a/test/source-check-pages.test.ts
+++ b/test/source-check-pages.test.ts
@@ -79,6 +79,17 @@ const QUOTED_FROM_THE_PAGE_IT_CITES = {
   source_check: { checked: "2026-09-02", outcome: "ok", detail: "text" },
 };
 
+const SOURCED_FROM_A_PAGE_NAMING_ONLY_THE_PLATFORM = {
+  ...SOURCED_FROM_A_MARKETPLACE,
+  vendor: "Platformcorp",
+  url: "https://platformcorp.example/products/pricing",
+  source_check: {
+    checked: "2026-09-09",
+    outcome: "does_not_name_product",
+    detail: "the page names the platform in the domain we cite Platformcorp Ledger from and never names Ledger",
+  },
+};
+
 const SOURCED_FROM_A_PAGE_NAMING_ONLY_A_PLAN = {
   ...SOURCED_FROM_A_MARKETPLACE,
   vendor: "Plancorp",
@@ -149,6 +160,7 @@ const FIXTURES = [
   SOURCED_FROM_ITS_OWN_PAGE,
   SOURCED_FROM_A_PAGE_WE_COULD_NOT_READ,
   SOURCED_FROM_A_PAGE_STATING_NO_FIGURES,
+  SOURCED_FROM_A_PAGE_NAMING_ONLY_THE_PLATFORM,
   SOURCED_FROM_A_PAGE_NAMING_ONLY_A_PLAN,
   QUOTED_FROM_THE_PAGE_IT_CITES,
 ];


### PR DESCRIPTION
Refs #1500

The vendor-name half of `source_check` was satisfied by any token the cited host already writes. For a vendor called `<Platform> <Product>`, any page on the platform's own domain passed it, so the product half was never checked against anything. `does_not_name_vendor` fired on 0.15% of the exposed records and 10.87% of every other one.

## The rule

A vendor-name token that restates a label of the host we cite the record from is no longer evidence on its own — not in the page text, and not through the host fallback. The product half of the name joins the forms the check will accept, so a page that writes `ECR Public` without `Amazon` still confirms `Amazon ECR Public`.

Two guards keep it off names that are not `<Platform> <Product>`:

- A name of one word is one name. `zoom.us`, `Bolt.new` and `Revolt.chat` are untouched.
- If every token past the host brand is a qualifier, a TLD, a number or under three characters, there is nothing distinguishing to demand and the record is left alone. `Google Cloud Run`, `Cloudflare KV` and `Grafana k6 Cloud` are untouched.
- Where every token of the name is in the host, the host already says the whole name. `Google Antigravity` on `antigravity.google`, `Val Town` on `val.town` and `Icon Horse` on `icon.horse` are untouched.

137 of 1,579 records are in scope.

## The new outcome

`does_not_name_product` — a live, readable page that writes the platform token and never writes the rest of the name. It is distinct from `does_not_name_vendor` (the page names no part of the record) and from `states_no_terms` (the page names the record and no terms). It withholds a favourable level, holds the verified date, carries a badge label, and states its reason on the vendor page, in the FAQ answers, in the comparison row and in `/api/openapi.json`.

## Outcome distribution

| outcome | before | after |
| --- | --- | --- |
| ok | 769 | 766 |
| states_no_terms | 451 | 448 |
| unreadable | 172 | 172 |
| states_no_amount | 86 | 85 |
| does_not_name_vendor | 102 | 102 |
| does_not_name_product | — | 7 |
| records | 1,580 | 1,579 |

The seven, each re-read against its own cited page:

| record | was | product half | the page |
| --- | --- | --- | --- |
| Amazon ECR Public | `ok`, rated `stable` | ECR Public | writes `ecr` 51 times and never the phrase |
| Zoho Docs | `ok`, rated `caution` | Docs | writes `docs` 0 times |
| Mockplus iDoc | `states_no_amount`, rated `stable` | iDoc | writes `idoc` 0 times |
| Chargebee Launch Programme | `ok` | Launch Programme | writes `programme` 0 times |
| Freshworks for Startups | `states_no_terms` | for Startups | writes `startups` 0 times |
| Startup with IBM | `states_no_terms` | Startup with | writes `startup` 0 times |
| OntarioNet.ca CN Test | `states_no_terms` | CN Test | 832 characters, neither token |

Three published ratings go: `Amazon ECR Public` and `Mockplus iDoc` lose `stable`, and `Google GLM 5` is withdrawn. `Zoho Docs` keeps `caution` — that level rests on a recorded change with its own source, not on the offer page, and only a favourable level is withheld. No record moves from a withheld state into a rated one.

## Google GLM 5

Withdrawn. Google publishes no model called GLM 5; GLM is Zhipu AI's family, and the catalogue already holds a Zhipu AI record listing the GLM-4 series. The Vertex AI model reference the record cited redirects to a live Google page of 73,312 readable characters in which `GLM` appears zero times, and the terms we published from it — "10 frames per second" — are a video sampling rate from the Gemini API docs. A `record_corrected` change carries the resolution and its source URL. `/free-llm-api-index` is regenerated without it, 83 rows. The Google Cloud Next 2026 page listed the same model as a confirmed announcement; that line is gone too.

## Found, not fixed

Two records would leave a withheld state on a fresh read: `Google Gemini Code Assist` (`does_not_name_vendor` → `ok`) and `Google Vector Search 2.0` (`states_no_terms` → `ok`). Neither is written here, because AC-5 asks that nothing move into a rated state as a result of this change. The rolling re-verification will re-read both on its own schedule.

Removing one record from a category rotates that category's comparison pairs, because `generateCategoryPairs` seeds its shuffle on the vendor list itself. Withdrawing `Google GLM 5` dropped five published `/compare/` URLs and added five others. That is not this rule — any curation does it — and it belongs with #1465.

## Verification

Suite 4,788 of 4,788. 16 mutants, 16 killed — the survivor on the first pass was real: excluding the TLD from the host labels made the rule demand that `antigravity.google` write "Google" and that `val.town` write "Town". The census script is `scripts/census-1500-host-restated.mjs`; the mutants are `scripts/mutate-1500.mjs`.

Checked against a running server: `/vendor/zoho-docs` states the reason in its verdict and its FAQ, `/api/offers` carries the outcome, `/api/openapi.json` enumerates it, and `/vendor/google-glm-5` is 404.
