### PR TITLE
Make the merge tests read a state rather than a moment (#1220)

### DIFF
--- a/scripts/mutate-1220-tests.mjs
+++ b/scripts/mutate-1220-tests.mjs
@@ -1,0 +1,118 @@
+import { copyFileSync, readFileSync, writeFileSync } from "node:fs";
+import { execFileSync } from "node:child_process";
+
+const SUITE = [
+  "test/vendor-merge-redirect.test.ts",
+  "test/shared-pricing-pages.test.ts",
+  "test/substitute-evidence.test.ts",
+];
+
+const INDEX = "data/index.json";
+const REGISTRY = "data/vendor_merges.json";
+const BEFORE = "/tmp/mutate-1220-before.json";
+const AFTER = "/tmp/mutate-1220-after.json";
+
+const MERGES = "src/vendor-merges.ts";
+const LINT = "scripts/lint-shared-pages.js";
+const ROLE = "src/product-role.ts";
+
+const MUTANTS = [
+  ["a-listed-record-redirects-anyway", MERGES,
+    `    if (liveSlugs.has(from)) continue;
+    if (!liveSlugs.has(to)) continue;`,
+    `    if (!liveSlugs.has(to)) continue;`],
+  ["a-redirect-points-at-a-page-the-catalogue-does-not-answer", MERGES,
+    `    if (liveSlugs.has(from)) continue;
+    if (!liveSlugs.has(to)) continue;`,
+    `    if (liveSlugs.has(from)) continue;`],
+  ["history-moves-before-the-record-does", MERGES,
+    `    if (liveVendors.has(key)) return null;
+    if (!liveVendors.has(merge.survivor.trim().toLowerCase())) return null;`,
+    `    if (!liveVendors.has(merge.survivor.trim().toLowerCase())) return null;`],
+  ["history-moves-to-a-name-the-catalogue-does-not-carry", MERGES,
+    `    if (liveVendors.has(key)) return null;
+    if (!liveVendors.has(merge.survivor.trim().toLowerCase())) return null;`,
+    `    if (liveVendors.has(key)) return null;`],
+  ["a-registered-merge-stops-silencing-its-own-pair", LINT,
+    `    const live = members.filter((o) => !retiredKeys.has(vendorKey(o.vendor)));`,
+    `    const live = members.slice();`],
+  ["every-shared-page-reads-as-reviewed", LINT,
+    `    if (allowSets.some((allowed) => sameVendorSet(vendors, allowed))) continue;`,
+    `    if (true) continue;`],
+  ["an-add-on-is-offered-as-a-substitute", ROLE,
+    `  if (role.is_addon) gates.add("addon");`,
+    `  if (false) gates.add("addon");`],
+  ["a-local-emulator-is-offered-as-a-substitute", ROLE,
+    `  if (role.deployment_model === "local_dev_only") gates.add("local_dev_only");`,
+    `  if (false) gates.add("local_dev_only");`],
+  ["a-record-is-turned-away-under-the-last-reason-it-carries", ROLE,
+    `  for (const gate of MEMBERSHIP_GATE_ORDER) {
+    if (candidateGates.has(gate) && !subjectGates.has(gate)) return gate;
+  }
+  return null;
+}
+
+export function alternativeMembershipGate`,
+    `  for (const gate of [...MEMBERSHIP_GATE_ORDER].reverse()) {
+    if (candidateGates.has(gate) && !subjectGates.has(gate)) return gate;
+  }
+  return null;
+}
+
+export function alternativeMembershipGate`],
+];
+
+function run(cmd, args) {
+  try {
+    execFileSync(cmd, args, { stdio: "pipe", encoding: "utf-8" });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+copyFileSync(INDEX, BEFORE);
+
+const index = JSON.parse(readFileSync(BEFORE, "utf-8"));
+const retired = new Set(
+  JSON.parse(readFileSync(REGISTRY, "utf-8")).merges.map((m) => m.retired.trim().toLowerCase()),
+);
+writeFileSync(
+  AFTER,
+  JSON.stringify({ ...index, offers: index.offers.filter((o) => !retired.has(o.vendor.trim().toLowerCase())) }),
+);
+
+const CATALOGUES = [["before the merge", BEFORE], ["after the merge", AFTER]];
+
+const survivors = [];
+for (const [name, file, from, to] of MUTANTS) {
+  const original = readFileSync(file, "utf-8");
+  if (!original.includes(from)) {
+    console.log(`SKIP  ${name} — the line it mutates is not in ${file}`);
+    survivors.push(`${name} (not applied)`);
+    continue;
+  }
+  writeFileSync(file, original.replace(from, to));
+  const built = run("npm", ["run", "build"]);
+  const survived = [];
+  if (built) {
+    for (const [label, catalogue] of CATALOGUES) {
+      copyFileSync(catalogue, INDEX);
+      if (run("node", ["--test", "--test-concurrency", "1", ...SUITE])) survived.push(label);
+    }
+  }
+  writeFileSync(file, original);
+  copyFileSync(BEFORE, INDEX);
+  const verdict = !built
+    ? "killed (did not compile)"
+    : survived.length === 0
+      ? "killed          "
+      : survived.length === CATALOGUES.length
+        ? "SURVIVED        "
+        : `killed only ${survived.length === 1 && survived[0] === "before the merge" ? "before" : "after"} `;
+  console.log(`${verdict}  ${name}`);
+  if (survived.length > 0) survivors.push(`${name} [survives ${survived.join(" and ")}]`);
+}
+run("npm", ["run", "build"]);
+console.log(`\n${MUTANTS.length - survivors.length}/${MUTANTS.length} killed against both catalogues`);
+if (survivors.length > 0) console.log("survivors:", survivors.join("; "));

--- a/test/shared-pricing-pages.test.ts
+++ b/test/shared-pricing-pages.test.ts
@@ -39,6 +39,12 @@ function withoutMerge(retired: string) {
   };
 }
 
+function catalogueHolding(vendors: string[]): Offer[] {
+  return vendors.map(
+    (vendor) => ({ vendor, category: "Databases", tier: "Free", url: "https://one-product.example/pricing" }) as Offer,
+  );
+}
+
 describe("normalizePricingUrl", () => {
   it("reads one page through the spellings a record can use for it", () => {
     const forms = [
@@ -146,17 +152,6 @@ describe("the catalogue as it stands", () => {
     }
   });
 
-  it("reports the group behind every registered merge when that merge is unregistered", () => {
-    for (const merge of registry.merges) {
-      const groups = advisoryGroups(offers, withoutMerge(merge.retired));
-      assert.deepStrictEqual(
-        groups.map((g: { vendors: string[] }) => named(g.vendors)),
-        [named([merge.retired, merge.survivor])],
-        `unregistering the ${merge.retired} merge does not report it`,
-      );
-    }
-  });
-
   it("holds one registered shared page that the blocking rule needs, and it is the two Google One products", () => {
     const loadBearing = registry.sharedPricingPages.filter(
       (entry: { vendors: string[] }) => blockingGroups(offers, withoutAllowlistEntry(entry.vendors)).length > 0,
@@ -164,6 +159,32 @@ describe("the catalogue as it stands", () => {
     assert.deepStrictEqual(
       loadBearing.map((entry: { vendors: string[] }) => named(entry.vendors)),
       ["Google Drive, Google Photos"],
+    );
+  });
+});
+
+describe("a catalogue holding both records of a registered merge", () => {
+  it("is silent while the merge is registered and reports the pair when it is not", () => {
+    for (const merge of registry.merges) {
+      const catalogue = catalogueHolding([merge.retired, merge.survivor]);
+      assert.deepStrictEqual(
+        advisoryGroups(catalogue, registry).map((g: { vendors: string[] }) => named(g.vendors)),
+        [],
+        `the registered ${merge.retired} merge does not silence its own pair`,
+      );
+      assert.deepStrictEqual(
+        advisoryGroups(catalogue, withoutMerge(merge.retired)).map((g: { vendors: string[] }) => named(g.vendors)),
+        [named([merge.retired, merge.survivor])],
+        `unregistering the ${merge.retired} merge does not report it`,
+      );
+    }
+  });
+
+  it("reports a pair no merge and no shared page names", () => {
+    const catalogue = catalogueHolding(["Kept One", "Kept Two"]);
+    assert.deepStrictEqual(
+      advisoryGroups(catalogue, registry).map((g: { vendors: string[] }) => named(g.vendors)),
+      ["Kept One, Kept Two"],
     );
   });
 });

--- a/test/substitute-evidence.test.ts
+++ b/test/substitute-evidence.test.ts
@@ -4,7 +4,7 @@ import { spawn, type ChildProcess } from "node:child_process";
 import { readFileSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import { partitionSubstitutes, subtypeGateBinds, substitutesFor, MEMBERSHIP_GATE_ORDER, MEMBERSHIP_GATE_RULES } from "../dist/product-role.js";
+import { partitionSubstitutes, roleMembershipGate, subtypeGateBinds, substitutesFor, MEMBERSHIP_GATE_ORDER, MEMBERSHIP_GATE_RULES } from "../dist/product-role.js";
 import { toSlug, vendorSlugMap } from "../dist/vendor-slug.js";
 import { curatedAlternativeNames } from "../dist/curated-alternatives.js";
 import type { DealChange, Offer } from "../src/types.ts";
@@ -305,10 +305,28 @@ describe("what a classified page leaves out, and why it says it left it out", ()
   it("still turns a product-role finding away under its own reason", () => {
     const neon = offers.filter(o => o.vendor === "Neon");
     assert.ok(neon.length > 0, "Neon must be in the index");
-    const gates = new Map(pagePartition("Neon").removed.map(r => [r.offer.vendor, r.gate]));
-    assert.strictEqual(gates.get("Hasura Cloud"), "addon");
-    assert.strictEqual(gates.get("Prisma Accelerate"), "addon");
-    assert.strictEqual(gates.get("DynamoDB Local"), "local_dev_only");
+    const partition = pagePartition("Neon");
+
+    assert.deepStrictEqual(
+      partition.kept.filter(o => roleMembershipGate(o)).map(o => o.vendor),
+      [],
+      "offered as a substitute for Neon over the product role we read off its own site"
+    );
+
+    const byRole = partition.removed.filter(r => roleMembershipGate(r.offer));
+    for (const { offer, gate } of byRole) {
+      assert.strictEqual(
+        gate,
+        roleMembershipGate(offer),
+        `${offer.vendor} is turned away as ${gate} rather than for the role we read`
+      );
+    }
+    for (const gate of ["addon", "local_dev_only"] as const) {
+      assert.ok(
+        byRole.some(r => r.gate === gate),
+        `no record in Neon's pool is turned away as ${gate}, so that reason is not under test here`
+      );
+    }
   });
 
   it("does not blame a record that does say what kind of product it is", async () => {

--- a/test/vendor-merge-redirect.test.ts
+++ b/test/vendor-merge-redirect.test.ts
@@ -28,6 +28,14 @@ const merges = vendorMerges();
 const retiringNames = new Set(merges.map((m) => m.retired.trim().toLowerCase()));
 const liveNames = new Set(offers.map((o) => o.vendor.trim().toLowerCase()));
 const stillListed = merges.filter((m) => liveNames.has(m.retired.trim().toLowerCase()));
+const alreadyMade = merges.filter(
+  (m) => !liveNames.has(m.retired.trim().toLowerCase()) && liveNames.has(m.survivor.trim().toLowerCase()),
+);
+
+const key = (name: string) => name.trim().toLowerCase();
+const listing = (...names: string[]) => new Set([...liveNames, ...names.map(key)]);
+const unlisting = (absent: string, ...present: string[]) =>
+  new Set([...listing(...present)].filter((n) => n !== key(absent)));
 
 function startServer(env: NodeJS.ProcessEnv = {}): Promise<{ child: ChildProcess; port: number }> {
   return new Promise((resolve, reject) => {
@@ -56,8 +64,9 @@ describe("the registry a merge is declared in", () => {
   });
 
   it("redirects no slug while the record it names is still listed", () => {
-    const targets = retiredSlugTargets(new Set(offers.map((o) => toSlug(o.vendor))), merges);
-    for (const merge of stillListed) {
+    const live = new Set(offers.map((o) => toSlug(o.vendor)));
+    for (const merge of merges) {
+      const targets = retiredSlugTargets(new Set([...live, toSlug(merge.retired), toSlug(merge.survivor)]), merges);
       assert.ok(!targets.has(toSlug(merge.retired)), `/vendor/${toSlug(merge.retired)} redirects while its record is still listed`);
     }
   });
@@ -77,9 +86,8 @@ describe("the registry a merge is declared in", () => {
 
   it("moves a change record to the survivor only once the name it holds is unlisted", () => {
     for (const merge of merges) {
-      assert.strictEqual(survivingVendorName(merge.retired, liveNames, merges), null);
-      const without = new Set([...liveNames].filter((n) => n !== merge.retired.trim().toLowerCase()));
-      assert.strictEqual(survivingVendorName(merge.retired, without, merges), merge.survivor);
+      assert.strictEqual(survivingVendorName(merge.retired, listing(merge.retired, merge.survivor), merges), null);
+      assert.strictEqual(survivingVendorName(merge.retired, unlisting(merge.retired, merge.survivor), merges), merge.survivor);
     }
   });
 
@@ -151,14 +159,26 @@ describe("the catalogue as it stands", () => {
   before(async () => { ({ child: server, port } = await startServer()); });
   after(() => { server?.kill(); });
 
-  it("has records under merge, so the redirects here are under test", () => {
-    assert.ok(stillListed.length > 0, "every registered merge has already been made, so nothing here is under test");
+  it("holds every registered merge in one of the two states the redirect reads", () => {
+    const neither = merges.filter((m) => !stillListed.includes(m) && !alreadyMade.includes(m));
+    assert.deepStrictEqual(
+      neither.map((m) => `${m.retired} -> ${m.survivor}`),
+      [],
+      "a merge whose record has gone and whose survivor is unlisted sends a reader to a page the catalogue does not answer",
+    );
   });
 
-  it("keeps answering a page for a record it still lists", async () => {
-    for (const merge of stillListed) {
+  it("answers a retired path with its own page until the record goes, and with the survivor after", async () => {
+    for (const merge of merges) {
       const res = await fetch(`http://localhost:${port}/vendor/${toSlug(merge.retired)}`, { redirect: "manual" });
-      assert.strictEqual(res.status, 200, `/vendor/${toSlug(merge.retired)} answers ${res.status} while its record is still listed`);
+      if (stillListed.includes(merge)) {
+        assert.strictEqual(res.status, 200, `/vendor/${toSlug(merge.retired)} answers ${res.status} while its record is still listed`);
+        continue;
+      }
+      assert.strictEqual(res.status, 301, `/vendor/${toSlug(merge.retired)} answers ${res.status} once its record is gone`);
+      assert.strictEqual(res.headers.get("location"), `/vendor/${toSlug(merge.survivor)}`);
+      const followed = await fetch(`http://localhost:${port}${res.headers.get("location")}`, { redirect: "manual" });
+      assert.strictEqual(followed.status, 200, `${merge.retired} redirects to a path that answers ${followed.status}`);
     }
   });
 
@@ -173,16 +193,17 @@ describe("the catalogue as it stands", () => {
     }
   });
 
-  it("leaves the history of a record it still lists on that record's own page", async () => {
-    for (const merge of stillListed) {
+  it("leaves the history of a retiring name on its own page until the record goes, and on the survivor after", async () => {
+    for (const merge of merges) {
       const carried = changes.filter((c) => c.vendor.trim().toLowerCase() === merge.retired.trim().toLowerCase());
       if (carried.length === 0) continue;
-      const res = await fetch(`http://localhost:${port}/api/changes?vendor=${encodeURIComponent(merge.retired)}&since=2000-01-01&limit=1000`);
+      const holder = stillListed.includes(merge) ? merge.retired : merge.survivor;
+      const res = await fetch(`http://localhost:${port}/api/changes?vendor=${encodeURIComponent(holder)}&since=2000-01-01&limit=1000`);
       const published: DealChange[] = (await res.json()).changes;
       for (const change of carried) {
         assert.ok(
-          published.some((p) => p.vendor === merge.retired && p.date === change.date),
-          `the ${change.change_type} recorded for ${merge.retired} on ${change.date} moved before its record did`,
+          published.some((p) => p.date === change.date && p.change_type === change.change_type),
+          `the ${change.change_type} recorded for ${merge.retired} on ${change.date} is published on no page`,
         );
       }
     }


### PR DESCRIPTION
Four tests hold the data PR that merges six duplicate vendor records. None of the four is about the data — each asserts something that is only true while the merges are pending, so the change they were written to make safe is the change that turns them red.

`data/vendor_merges.json` is a declaration that six records will be deleted. A test that reads the catalogue still holding them is reading a moment. Each of the four now reads the property the rule actually has, and holds in both states.

## What changed

| Test | Was | Now |
|---|---|---|
| `moves a change record to the survivor only once the name it holds is unlisted` | read `data/index.json` for the "still listed" half | builds both halves synthetically, the way the "unlisted" half already did |
| `redirects no slug while the record it names is still listed` | iterated the pending merges, so it empties as they land | iterates every merge against a catalogue synthesised to list it |
| `has records under merge` + `keeps answering a page for a record it still lists` | asserted at least one merge is pending, then tested only those | asserts every merge is in one of the two states the redirect reads, then asserts 200 while listed and 301 to the survivor once gone — over all six |
| `leaves the history of a record it still lists on that record's own page` | pending merges only | the retiring name's history publishes on its own page until the record goes, and on the survivor after |
| `reports the group behind every registered merge when that merge is unregistered` | needed both records in `data/index.json` | runs against a fixture catalogue holding the pair; also asserts registration silences it, which the original did not |
| `still turns a product-role finding away under its own reason` | three vendor names, one of which the merge retires | selects controls by the product role we read, and adds the converse: no record carrying a role gate is offered as a substitute |

## Verification

- Suite green on the catalogue as it stands: **4,837 of 4,837**.
- Suite green on the merged catalogue: **4,839 of 4,839**, run against the data PR's `data/index.json`.
- The four failures reproduce on this branch's parent and do not reproduce here.
- Redirects read off a running server on the merged catalogue: `/vendor/slack-api` → `/vendor/slack`, `/vendor/arize-ai` → `/vendor/arize-ax`, `/vendor/hasura-cloud` → `/vendor/hasura`, `/compare/arize-ai-vs-arize-ax` → `/vendor/arize-ax`, `/compare/graphcomment-vs-slack-api` → `/compare/graphcomment-vs-slack`. `/vendor/slack` publishes the `limits_increased` recorded 2026-09-03 and no longer answers that it has no recorded pricing changes.
- `scripts/mutate-1220-tests.mjs` runs 9 mutants against the catalogue before the merge and the catalogue after it. **9 of 9 die in both.** It synthesises the merged catalogue from the registry, so it needs no branch to run.

## One mutant left out of the script, with the measurement

Widening `sameVendorSet` from `a.size !== b.size` to `a.size < b.size` survives, and the input class that would reach it is empty: `sharedPageGroups` returns before the comparison unless the group holds two or more distinct vendors, and every registered shared page holds exactly two. The subset case it would change — a page registered as holding three distinct products, later holding two of them — has no member and no settled answer, so pinning one with a test would pin a guess.

Refs #1220