### PR TITLE
Read the sweep floor off the catalogue rather than a literal (#1465)

### DIFF
--- a/test/change-row-citation.test.ts
+++ b/test/change-row-citation.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, before, after } from "node:test";
 import assert from "node:assert";
-import { assertPopulationFloor } from "./population-floor.ts";
+import { assertPopulationFloor, vendorsInTheCatalogue } from "./population-floor.ts";
 import { spawn, type ChildProcess } from "node:child_process";
 import { readFileSync, readdirSync } from "node:fs";
 import path from "node:path";
@@ -211,7 +211,7 @@ describe("every published change row carries the page it was read from", () => {
   after(() => proc?.kill());
 
   it("reads a population on both sides of the question", () => {
-    assertPopulationFloor(sweptPaths.length, 1900, "paths served for the sweep");
+    assertPopulationFloor(sweptPaths.length, vendorsInTheCatalogue(), "paths served for the sweep");
     assertPopulationFloor(pagesWithARow, 800, "served pages render at least one change row");
     assertPopulationFloor(rowsChecked, 7000, "change rows rendered across the site");
     assertPopulationFloor(rows.length, 390, "distinct summaries the store can put on a page");

--- a/test/faq-names-no-winner.test.ts
+++ b/test/faq-names-no-winner.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, before, after } from "node:test";
 import assert from "node:assert";
-import { assertPopulationFloor } from "./population-floor.ts";
+import { assertPopulationFloor, vendorsInTheCatalogue } from "./population-floor.ts";
 import { spawn, type ChildProcess } from "node:child_process";
 import { readFileSync } from "node:fs";
 import path from "node:path";
@@ -153,7 +153,7 @@ describe("no served FAQ answer crowns a vendor we hold no ranking for", () => {
   after(() => proc?.kill());
 
   it("reads every FAQ answer the site serves", () => {
-    assertPopulationFloor(sweptPaths.length, 1900, "paths served for the sweep");
+    assertPopulationFloor(sweptPaths.length, vendorsInTheCatalogue(), "paths served for the sweep");
     assertPopulationFloor(blocksByPath.size, 1500, "served pages publishing an FAQPage block");
     assertPopulationFloor(answers.length, 9000, "FAQ answers parsed out of FAQPage markup");
     assertPopulationFloor(vendorNames.length, 900, "catalogue vendor names the sweep matches against");

--- a/test/marketplace-promise-removed.test.ts
+++ b/test/marketplace-promise-removed.test.ts
@@ -3,7 +3,7 @@ import assert from "node:assert";
 import { spawn, type ChildProcess } from "node:child_process";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import { assertPopulationFloor } from "./population-floor.ts";
+import { assertPopulationFloor, vendorsInTheCatalogue } from "./population-floor.ts";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -70,7 +70,7 @@ describe("no published page offers revenue for a submitted referral code", () =>
 
   it("every route in the sitemap is clean", async () => {
     const paths = await allSitemapPaths();
-    assertPopulationFloor(paths.length, 1900, "routes in the sitemap the sweep read");
+    assertPopulationFloor(paths.length, vendorsInTheCatalogue(), "routes in the sitemap the sweep read");
 
     const offenders: string[] = [];
     for (const p of paths) {

--- a/test/population-floor.ts
+++ b/test/population-floor.ts
@@ -1,5 +1,7 @@
 import assert from "node:assert";
-import { appendFileSync } from "node:fs";
+import { appendFileSync, readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
 
 export const HEADROOM = 0.25;
 
@@ -67,6 +69,14 @@ const callSite = (): string => {
   if (!at) return "unknown";
   return `${at[1].replace("file://", "").replace(`${process.cwd()}/`, "")}:${at[2]}`;
 };
+
+export function vendorsInTheCatalogue(): number {
+  const REPO = path.join(path.dirname(fileURLToPath(import.meta.url)), "..");
+  const offers: Array<{ vendor: string }> = JSON.parse(
+    readFileSync(path.join(REPO, "data", "index.json"), "utf-8"),
+  ).offers;
+  return new Set(offers.map((offer) => offer.vendor.trim().toLowerCase())).size;
+}
 
 export function assertPopulationFloor(observed: number, floor: number, subject: string): void {
   const log = process.env.POPULATION_FLOOR_LOG;

--- a/test/vultr-referral-code.test.ts
+++ b/test/vultr-referral-code.test.ts
@@ -4,7 +4,7 @@ import fs from "node:fs";
 import path from "node:path";
 import { spawn, type ChildProcess } from "node:child_process";
 import { fileURLToPath } from "node:url";
-import { assertPopulationFloor } from "./population-floor.ts";
+import { assertPopulationFloor, vendorsInTheCatalogue } from "./population-floor.ts";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const PLATFORM_CODES_PATH = path.join(__dirname, "..", "data", "platform_codes.json");
@@ -271,7 +271,7 @@ describe("every surface that offers the code also states its conditions", () => 
 
   it("publishes no Vultr credit figure that contradicts the record", async () => {
     const paths = await sitemapPaths();
-    assertPopulationFloor(paths.length, 1900, "routes in the sitemap the sweep read");
+    assertPopulationFloor(paths.length, vendorsInTheCatalogue(), "routes in the sitemap the sweep read");
 
     const offenders: string[] = [];
     let readerCreditMentions = 0;


### PR DESCRIPTION
Four sweeps opened with `assertPopulationFloor(paths.length, 1900, ...)`. 1900 against the 2528 paths the live site serves is 24.8% headroom — five routes under the rule's own line. Curating 26 records out of the catalogue was enough to trip it, which made a deliberate data decision read as a regression.

The floor is now the number of vendors the catalogue lists. Every one of them has a `/vendor/` route in the sitemap, so the sweep cannot have read the site properly and come back with fewer paths than that. A sweep that silently reads nothing still fails. A catalogue that legitimately shrinks does not, because both sides move together.

## Verified on both catalogues

| catalogue | vendors | paths swept | floor clears headroom |
|---|---|---|---|
| as it stands | 1,571 | 2,528 | yes |
| 26 records curated out | 1,546 | 2,502 | yes |

All four files pass against each: `change-row-citation`, `faq-names-no-winner`, `marketplace-promise-removed`, `vultr-referral-code`.

## A fifth floor of the same shape, which this does not fix

`test/faq-names-no-winner.test.ts:227` holds `assertPopulationFloor(checked, 55, "answers publishing a catalogue denominator")`. On the smaller catalogue it measures 72 and fails the same headroom rule. It was masked by the floor twelve lines above it, so it did not appear in the report of what was red.

It does not take the same remedy. The population it reads is categories, not vendors — 65 now, 60 after the curation — and 60 against 72 measured is 20% headroom, so **the derived floor fails the headroom rule even though deriving it is exactly what the rule's own message asks for.**

That is a limitation in `assertPopulationFloor` rather than in this call site. The headroom rule exists because a hardcoded floor drifts away from the data it guards. A floor read from the same data cannot drift, so it should not be held to a slack requirement designed for one that can. The shape that fits is a sibling assertion — the observed count covers a population, checked without headroom — and applying it would also be the more honest reading of the four this PR changes.

I have not built it here. It touches the mechanism every floor in the suite is written against, and this PR is what unblocks the four that are red today.

Refs #1465