### PR TITLE
Assert a read population is covered rather than clearing a literal's headroom (#1465)

### DIFF
--- a/test/change-row-citation.test.ts
+++ b/test/change-row-citation.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, before, after } from "node:test";
 import assert from "node:assert";
-import { assertPopulationFloor, vendorsInTheCatalogue } from "./population-floor.ts";
+import { assertCoversPopulation, assertPopulationFloor, vendorsInTheCatalogue } from "./population-floor.ts";
 import { spawn, type ChildProcess } from "node:child_process";
 import { readFileSync, readdirSync } from "node:fs";
 import path from "node:path";
@@ -211,7 +211,7 @@ describe("every published change row carries the page it was read from", () => {
   after(() => proc?.kill());
 
   it("reads a population on both sides of the question", () => {
-    assertPopulationFloor(sweptPaths.length, vendorsInTheCatalogue(), "paths served for the sweep");
+    assertCoversPopulation(sweptPaths.length, vendorsInTheCatalogue(), "paths served for the sweep");
     assertPopulationFloor(pagesWithARow, 800, "served pages render at least one change row");
     assertPopulationFloor(rowsChecked, 7000, "change rows rendered across the site");
     assertPopulationFloor(rows.length, 390, "distinct summaries the store can put on a page");

--- a/test/faq-names-no-winner.test.ts
+++ b/test/faq-names-no-winner.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, before, after } from "node:test";
 import assert from "node:assert";
-import { assertPopulationFloor, vendorsInTheCatalogue } from "./population-floor.ts";
+import { assertCoversPopulation, assertPopulationFloor, categoriesInTheCatalogue, vendorsInTheCatalogue } from "./population-floor.ts";
 import { spawn, type ChildProcess } from "node:child_process";
 import { readFileSync } from "node:fs";
 import path from "node:path";
@@ -153,7 +153,7 @@ describe("no served FAQ answer crowns a vendor we hold no ranking for", () => {
   after(() => proc?.kill());
 
   it("reads every FAQ answer the site serves", () => {
-    assertPopulationFloor(sweptPaths.length, vendorsInTheCatalogue(), "paths served for the sweep");
+    assertCoversPopulation(sweptPaths.length, vendorsInTheCatalogue(), "paths served for the sweep");
     assertPopulationFloor(blocksByPath.size, 1500, "served pages publishing an FAQPage block");
     assertPopulationFloor(answers.length, 9000, "FAQ answers parsed out of FAQPage markup");
     assertPopulationFloor(vendorNames.length, 900, "catalogue vendor names the sweep matches against");
@@ -214,17 +214,17 @@ describe("no served FAQ answer crowns a vendor we hold no ranking for", () => {
   it("counts one named catalogue category behind every denominator it publishes", () => {
     const held = /We hold (\d+) (.+?) services in our catalogue/g;
     const wrong: string[] = [];
-    let checked = 0;
+    const named = new Set<string>();
     for (const answer of answers) {
       for (const match of answer.a.matchAll(held)) {
         const stated = parseInt(match[1], 10);
         const category = match[2];
         const actual = offers.filter(o => o.category === category).length;
-        checked++;
+        named.add(category);
         if (actual !== stated || actual === 0) wrong.push(`${answer.path} :: ${category} stated ${stated}, catalogue holds ${actual}`);
       }
     }
-    assertPopulationFloor(checked, 55, "answers publishing a catalogue denominator");
+    assertCoversPopulation(named.size, categoriesInTheCatalogue(), "categories publishing a denominator in an answer");
     assert.deepStrictEqual(wrong, [], `denominators that name no single catalogue category: ${wrong.length}`);
   });
 

--- a/test/marketplace-promise-removed.test.ts
+++ b/test/marketplace-promise-removed.test.ts
@@ -3,7 +3,7 @@ import assert from "node:assert";
 import { spawn, type ChildProcess } from "node:child_process";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import { assertPopulationFloor, vendorsInTheCatalogue } from "./population-floor.ts";
+import { assertCoversPopulation, assertPopulationFloor, vendorsInTheCatalogue } from "./population-floor.ts";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -70,7 +70,7 @@ describe("no published page offers revenue for a submitted referral code", () =>
 
   it("every route in the sitemap is clean", async () => {
     const paths = await allSitemapPaths();
-    assertPopulationFloor(paths.length, vendorsInTheCatalogue(), "routes in the sitemap the sweep read");
+    assertCoversPopulation(paths.length, vendorsInTheCatalogue(), "routes in the sitemap the sweep read");
 
     const offenders: string[] = [];
     for (const p of paths) {

--- a/test/population-floor.test.ts
+++ b/test/population-floor.test.ts
@@ -4,16 +4,22 @@ import { readdirSync, readFileSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import {
+  assertCoversPopulation,
   assertPopulationFloor,
   bareFloorsIn,
+  categoriesInTheCatalogue,
   floorClearsHeadroom,
+  passedPopulationsIn,
   REGISTERED_FROM,
+  vendorsInTheCatalogue,
 } from "./population-floor.ts";
 
 const TEST_DIR = path.dirname(fileURLToPath(import.meta.url));
 
 const asWritten = (expression: string, comparison: string, literal: number) =>
   `assert.ok(${expression} ${comparison} ${literal}, "the message it carries");`;
+
+const COVERAGE = "assertCoversPopulation";
 
 describe("a floor over a live population states headroom it has measured", () => {
   it("passes a floor the population clears by more than a quarter", () => {
@@ -48,6 +54,60 @@ describe("a floor over a live population states headroom it has measured", () =>
     assert.strictEqual(floorClearsHeadroom(300, 552), true);
     assert.strictEqual(floorClearsHeadroom(500, 552), false);
     assert.strictEqual(floorClearsHeadroom(1500, 1572), false);
+  });
+});
+
+describe("a sweep read against the population it covers states coverage, not headroom", () => {
+  it("passes where the sweep reaches every member of the population it was read against", () => {
+    assertCoversPopulation(2528, vendorsInTheCatalogue(), "paths served for the sweep");
+    assertCoversPopulation(77, categoriesInTheCatalogue(), "categories publishing a denominator in an answer");
+  });
+
+  it("passes where the sweep covers the population exactly, which a floor would refuse for headroom", () => {
+    const measured = categoriesInTheCatalogue().size;
+    assert.strictEqual(floorClearsHeadroom(measured, measured), false);
+    assertCoversPopulation(measured, categoriesInTheCatalogue(), "categories publishing a denominator in an answer");
+  });
+
+  it("fails where the sweep misses a member, naming both sides", () => {
+    const measured = vendorsInTheCatalogue().size;
+    assert.throws(
+      () => assertCoversPopulation(measured - 1, vendorsInTheCatalogue(), "paths served for the sweep"),
+      new RegExp(`${measured - 1} paths served for the sweep, against ${measured} vendors the catalogue holds`),
+    );
+  });
+
+  it("shrinks with the data it reads rather than going red when a curation empties a category", () => {
+    const catalogue = vendorsInTheCatalogue();
+    const categories = categoriesInTheCatalogue();
+    assert.ok(catalogue.size > categories.size, "the catalogue holds more vendors than categories");
+    assert.notStrictEqual(catalogue.read, categories.read);
+  });
+
+  it("refuses a population handed over as a number rather than read from the data", () => {
+    const asCalled = (population: string) => `${COVERAGE}(checked, ${population}, "a subject");`;
+    assert.deepStrictEqual(passedPopulationsIn(asCalled("60")).map(p => p.argument), ["60"]);
+    assert.deepStrictEqual(
+      passedPopulationsIn(asCalled('{ size: 60, read: "made up" }')).map(p => p.argument),
+      ['{ size: 60, read: "made up" }'],
+    );
+    assert.deepStrictEqual(passedPopulationsIn(asCalled("liveCategories(60)")).map(p => p.argument), ["liveCategories(60)"]);
+    assert.deepStrictEqual(passedPopulationsIn(asCalled("() => 60")).map(p => p.argument), ["() => 60"]);
+    assert.deepStrictEqual(passedPopulationsIn(asCalled("categoriesInTheCatalogue()")), []);
+  });
+
+  it("holds every file in the suite to it", () => {
+    const passed: string[] = [];
+    for (const file of readdirSync(TEST_DIR).filter(name => name.endsWith(".ts"))) {
+      for (const site of passedPopulationsIn(readFileSync(path.join(TEST_DIR, file), "utf-8"))) {
+        passed.push(`${file}:${site.line} ${site.argument}`);
+      }
+    }
+    assert.deepStrictEqual(
+      passed,
+      [],
+      "a population has to be read by a no-argument reader in population-floor.ts, because a caller that computes the number has put the literal back one indirection later",
+    );
   });
 });
 

--- a/test/population-floor.ts
+++ b/test/population-floor.ts
@@ -14,8 +14,10 @@ const FLOOR = /(?<![<>=!])(?:>=|>)\s*([\dA-Za-z_$][\w$]*)\b/g;
 const CEILING = /(?<![-=])(?:<=|<)\s*[\dA-Za-z_$]/;
 const NAMED_NUMBER = /^const\s+([A-Za-z_$][\w$]*)\s*(?::\s*number\s*)?=\s*(\d[\d_]*)\s*;/gm;
 
-function conditionAt(source: string, open: number): string {
+function argumentsAt(source: string, open: number): string[] {
+  const found: string[] = [];
   let depth = 0;
+  let from = open + 1;
   let quote: string | null = null;
   for (let at = open; at < source.length; at++) {
     const char = source[at]!;
@@ -28,10 +30,20 @@ function conditionAt(source: string, open: number): string {
     else if (char === "(" || char === "[" || char === "{") depth++;
     else if (char === ")" || char === "]" || char === "}") {
       depth--;
-      if (depth === 0) return source.slice(open + 1, at);
-    } else if (char === "," && depth === 1) return source.slice(open + 1, at);
+      if (depth === 0) {
+        found.push(source.slice(from, at));
+        return found;
+      }
+    } else if (char === "," && depth === 1) {
+      found.push(source.slice(from, at));
+      from = at + 1;
+    }
   }
-  return "";
+  return found;
+}
+
+function conditionAt(source: string, open: number): string {
+  return argumentsAt(source, open)[0] ?? "";
 }
 
 export function bareFloorsIn(source: string): BareFloor[] {
@@ -70,12 +82,39 @@ const callSite = (): string => {
   return `${at[1].replace("file://", "").replace(`${process.cwd()}/`, "")}:${at[2]}`;
 };
 
-export function vendorsInTheCatalogue(): number {
+export interface Population {
+  size: number;
+  read: string;
+}
+
+function catalogueOffers(): Array<{ vendor: string; category: string }> {
   const REPO = path.join(path.dirname(fileURLToPath(import.meta.url)), "..");
-  const offers: Array<{ vendor: string }> = JSON.parse(
-    readFileSync(path.join(REPO, "data", "index.json"), "utf-8"),
-  ).offers;
-  return new Set(offers.map((offer) => offer.vendor.trim().toLowerCase())).size;
+  return JSON.parse(readFileSync(path.join(REPO, "data", "index.json"), "utf-8")).offers;
+}
+
+export function vendorsInTheCatalogue(): Population {
+  const vendors = new Set(catalogueOffers().map((offer) => offer.vendor.trim().toLowerCase()));
+  return { size: vendors.size, read: "vendors the catalogue holds" };
+}
+
+export function categoriesInTheCatalogue(): Population {
+  const categories = new Set(catalogueOffers().map((offer) => offer.category.trim()));
+  return { size: categories.size, read: "categories the catalogue holds an offer under" };
+}
+
+const POPULATION_READER = /^[A-Za-z_$][\w$]*\(\s*\)$/;
+
+export type PassedPopulation = { line: number; argument: string };
+
+export function passedPopulationsIn(source: string): PassedPopulation[] {
+  const found: PassedPopulation[] = [];
+  for (const call of source.matchAll(/(?<!function )assertCoversPopulation\(/g)) {
+    const open = call.index + "assertCoversPopulation".length;
+    const argument = (argumentsAt(source, open)[1] ?? "").trim();
+    if (POPULATION_READER.test(argument)) continue;
+    found.push({ line: source.slice(0, call.index).split("\n").length, argument });
+  }
+  return found;
 }
 
 export function assertPopulationFloor(observed: number, floor: number, subject: string): void {
@@ -84,6 +123,20 @@ export function assertPopulationFloor(observed: number, floor: number, subject: 
   assert.ok(observed >= floor, `only ${observed} ${subject}, under a floor of ${floor}`);
   assert.ok(
     floorClearsHeadroom(floor, observed),
-    `a floor of ${floor} leaves under ${Math.round(HEADROOM * 100)}% headroom over the ${observed} it measured — ${subject}. It goes red when this data shrinks and stays green when this data is wrong. Lower it, or state the property relative to the population it reads.`,
+    `a floor of ${floor} leaves under ${Math.round(HEADROOM * 100)}% headroom over the ${observed} it measured — ${subject}. It goes red when this data shrinks and stays green when this data is wrong. Lower it, or state the property relative to the population it reads with assertCoversPopulation.`,
+  );
+}
+
+export function assertCoversPopulation(observed: number, population: Population, subject: string): void {
+  const log = process.env.POPULATION_FLOOR_LOG;
+  if (log) {
+    appendFileSync(
+      log,
+      `${JSON.stringify({ site: callSite(), subject, covers: population.read, population: population.size, observed })}\n`,
+    );
+  }
+  assert.ok(
+    observed >= population.size,
+    `${observed} ${subject}, against ${population.size} ${population.read} — the sweep does not cover the population it is read against`,
   );
 }

--- a/test/vultr-referral-code.test.ts
+++ b/test/vultr-referral-code.test.ts
@@ -4,7 +4,7 @@ import fs from "node:fs";
 import path from "node:path";
 import { spawn, type ChildProcess } from "node:child_process";
 import { fileURLToPath } from "node:url";
-import { assertPopulationFloor, vendorsInTheCatalogue } from "./population-floor.ts";
+import { assertCoversPopulation, assertPopulationFloor, vendorsInTheCatalogue } from "./population-floor.ts";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const PLATFORM_CODES_PATH = path.join(__dirname, "..", "data", "platform_codes.json");
@@ -271,7 +271,7 @@ describe("every surface that offers the code also states its conditions", () => 
 
   it("publishes no Vultr credit figure that contradicts the record", async () => {
     const paths = await sitemapPaths();
-    assertPopulationFloor(paths.length, vendorsInTheCatalogue(), "routes in the sitemap the sweep read");
+    assertCoversPopulation(paths.length, vendorsInTheCatalogue(), "routes in the sitemap the sweep read");
 
     const offenders: string[] = [];
     let readerCreditMentions = 0;


### PR DESCRIPTION
Refs #1465 — the sibling assertion you ruled on, and the five sites that read a population.

## The rule it adds

`assertPopulationFloor` catches a sweep that read nothing and reported success. Its 25% headroom catches a different failure: a literal that was true when written and has drifted so far below the data it can no longer go red. A floor read off the population it guards cannot drift, because both sides move together — so holding it to the slack rule asks it to be wrong by 25% on purpose.

```ts
assertCoversPopulation(observed: number, population: Population, subject: string): void
```

Asserts `observed >= population.size`. No headroom test. Both your conditions:

**The name says which kind it is at the call site.** `assertPopulationFloor(x, 55, ...)` and `assertCoversPopulation(x, categoriesInTheCatalogue(), ...)` read differently without opening the module.

**The population is read, not passed.** `Population` is `{ size, read }` and is produced by a no-argument reader here — `vendorsInTheCatalogue()`, `categoriesInTheCatalogue()`. A source scan holds every file in the suite to it and refuses `60`, `{ size: 60, read: "…" }`, `liveCategories(60)` and `() => 60`. The `read` field carries the sentence the failure message uses, so a miss names both sides: *"2527 paths served for the sweep, against 2528 vendors the catalogue holds — the sweep does not cover the population it is read against"*.

The headroom failure message now names the sibling as the remedy, so the next author who hits it is pointed at the thing that fits rather than told to lower the number.

## The site that was blocking #1410

`test/faq-names-no-winner.test.ts:227` counted denominators and floored the count at 55. I measured the population rather than converting the literal: **every one of the 65 live categories publishes a denominator, and no denominator names a category holding nothing.** The set is exactly total, so the honest statement is coverage of the categories, not a count of the matches:

```ts
assertCoversPopulation(named.size, categoriesInTheCatalogue(), "categories publishing a denominator in an answer");
```

`named` is the distinct categories named. The existing `actual === 0` check already refuses a denominator naming a dead category, so coverage in one direction plus that check is set equality — it goes red if a category stops publishing one, which a count of 77 matches would not.

Verified on both catalogues. On `main`: 77 denominators over 65 of 65 categories. On `pm/drop-consumer-media-records`: 72 over 60 of 60. **The literal fails there** — `a floor of 55 leaves under 25% headroom over the 72 it measured` — which is the diagnosis on #1465 reproduced, and the replacement passes on both.

## The four from #1506

They read `vendorsInTheCatalogue()` as a floor and clear headroom by having 60% slack, which is luck rather than a property anyone stated. They assert coverage now: `change-row-citation`, `faq-names-no-winner`, `marketplace-promise-removed`, `vultr-referral-code`. `vendorsInTheCatalogue()` returns a `Population` rather than a bare number, so a fifth site cannot pick it up as a floor by accident.

## #1465's other criteria, verified on the emptied catalogue

Not part of this diff — both shipped in #1466 — but you said they could not be checked until #1410 lands, and they can be checked against its data. I served `pm/drop-consumer-media-records`'s `data/index.json` locally and read them:

- **AC-1** — `/category/streaming-media` returns **200** and renders the notice: `Retired category`, *"Streaming & Media is no longer listed"*, `Retired on 2026-09-08`.
- **AC-4** — `/`, `/category` and `/llms.txt` all print **60 categories**, not 65. `getCategories()` builds from offers, so an emptied name contributes nothing and the count is live-only by construction.

Suite 4,843 of 4,843 locally, and the five converted files green against both catalogues.
