### PR TITLE
Publish the AI and LLM index as a standalone repository's root README (#1497)

### DIFF
--- a/.github/workflows/llm-api-readme.yml
+++ b/.github/workflows/llm-api-readme.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - main
+  schedule:
+    - cron: "0 8 * * *"
   workflow_dispatch:
 
 permissions:
@@ -52,6 +54,14 @@ jobs:
             data-quarantine/llm-api-readme \
             "data(auto): AI and LLM free-tier index — ${ROWS} records, ${WITHHELD} unrated, ${PRIOR} showing prior terms" \
             artifacts/free-llm-api-index/README.md
+
+      - name: Publish the index main now holds as the root README of the standalone repository
+        id: publish
+        env:
+          AGENTDEALS_LLM_INDEX_REPO: ${{ vars.LLM_INDEX_REPO }}
+          AGENTDEALS_LLM_INDEX_BRANCH: ${{ vars.LLM_INDEX_BRANCH }}
+          AGENTDEALS_LLM_INDEX_TOKEN: ${{ secrets.LLM_INDEX_PUBLISH_TOKEN }}
+        run: node scripts/publish-llm-api-index.js
 
       - name: Say where it can be seen what the gate did with this run's index
         if: always() && (steps.gate.outputs.quarantined == 'true' || steps.gate.outputs.pushed_over_failures == 'true')

--- a/artifacts/free-llm-api-index/README.md
+++ b/artifacts/free-llm-api-index/README.md
@@ -2,7 +2,7 @@
 
 31 records for vendors that serve models behind an API, each one carrying the date we last read the vendor's own page and the URL we read it on. There is no single freshness stamp for this file, because a single stamp for a list nobody re-read is worth nothing.
 
-Generated from the free-tier catalogue at https://agentdeals.dev, which is where each row's record lives. It is regenerated whenever those records move, so editing it by hand is pointless — the next run overwrites it.
+Generated from the free-tier catalogue at https://agentdeals.dev, which is where each row's record lives. It is regenerated whenever those records move, so editing it by hand is pointless — the next run overwrites it. The code that writes it is https://github.com/robhunter/agentdeals/blob/main/src/llm-api-readme.ts, so every rule this file states can be read against the rule it applies.
 
 What this file has that a hand-kept list does not: **the terms a vendor replaced, next to the terms it replaced them with, with the date.** 7 rows carry that today.
 

--- a/scripts/generate-llm-api-readme.js
+++ b/scripts/generate-llm-api-readme.js
@@ -1,52 +1,35 @@
-import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { mkdirSync, writeFileSync } from "node:fs";
 import path from "node:path";
-import { fileURLToPath } from "node:url";
 
-const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
-const { excludedByReason, readmeCensus, readmeSelection, renderReadme } = await import(`${root}/dist/llm-api-readme.js`);
-const { reverificationIntervalDays } = await import(`${root}/dist/badge-staleness.js`);
+import { ROOT, heldIndex, indexPath, renderIndex, servedOnFrom } from "./llm-api-index-render.js";
 
 const args = process.argv.slice(2);
 const asJson = args.includes("--json");
 const check = args.includes("--check");
-const onArg = args.find(a => a.startsWith("--on="));
 
-const OUTPUT = process.env.AGENTDEALS_LLM_INDEX_PATH || path.join(root, "artifacts", "free-llm-api-index", "README.md");
+const OUTPUT = indexPath();
 
-const offers = JSON.parse(readFileSync(path.join(root, "data", "index.json"), "utf8")).offers;
-const changes = JSON.parse(readFileSync(path.join(root, "data", "deal_changes.json"), "utf8")).changes;
-
-const servedOn = onArg ? onArg.slice("--on=".length) : new Date().toISOString().slice(0, 10);
-const nowMs = Date.parse(`${servedOn}T00:00:00Z`);
-if (!Number.isFinite(nowMs)) {
-  console.error(`Not a date: ${servedOn}`);
+let index;
+try {
+  index = await renderIndex(servedOnFrom(args));
+} catch (error) {
+  console.error(error.message);
   process.exit(2);
 }
 
-const staleAfterDays = reverificationIntervalDays(offers.map(o => o.verifiedDate), nowMs);
-const context = { servedOn, nowMs, staleAfterDays };
-const { rows, excluded } = readmeSelection(offers, changes, context);
-const census = readmeCensus(rows);
-const leftOut = excludedByReason(excluded);
+const { census, excludedByReason: leftOut, excluded, rendered, staleAfterDays, servedOn } = index;
 
-if (rows.length === 0) {
+if (census.rows === 0) {
   console.error("Refusing to publish: no catalogue record carries a subtype label this file selects on.");
   process.exit(1);
 }
 
-const rendered = renderReadme(rows, { staleAfterDays, excluded });
-const held = (() => {
-  try {
-    return readFileSync(OUTPUT, "utf8");
-  } catch {
-    return null;
-  }
-})();
+const held = heldIndex(OUTPUT);
 
 const changed = held !== rendered;
 if (check) {
   if (changed) {
-    console.error(`${path.relative(root, OUTPUT)} is not what this data generates. Run: npm run generate:llm-readme`);
+    console.error(`${path.relative(ROOT, OUTPUT)} is not what this data generates. Run: npm run generate:llm-readme`);
     process.exit(1);
   }
 } else if (changed) {
@@ -58,7 +41,7 @@ const outcome = { ...census, excluded: excluded.length, excludedByReason: leftOu
 if (asJson) {
   console.log(JSON.stringify(outcome));
 } else {
-  console.log(`${path.relative(root, OUTPUT)} — ${changed ? "regenerated" : "unchanged"}`);
+  console.log(`${path.relative(ROOT, OUTPUT)} — ${changed ? "regenerated" : "unchanged"}`);
   console.log(
     [
       `rows ${census.rows}`,

--- a/scripts/llm-api-index-render.js
+++ b/scripts/llm-api-index-render.js
@@ -1,0 +1,46 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+export const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+
+export function indexPath() {
+  return process.env.AGENTDEALS_LLM_INDEX_PATH || path.join(ROOT, "artifacts", "free-llm-api-index", "README.md");
+}
+
+export function servedOnFrom(args) {
+  const onArg = args.find(a => a.startsWith("--on="));
+  return onArg ? onArg.slice("--on=".length) : new Date().toISOString().slice(0, 10);
+}
+
+export async function renderIndex(servedOn) {
+  const { excludedByReason, readmeCensus, readmeSelection, renderReadme } = await import(`${ROOT}/dist/llm-api-readme.js`);
+  const { reverificationIntervalDays } = await import(`${ROOT}/dist/badge-staleness.js`);
+
+  const nowMs = Date.parse(`${servedOn}T00:00:00Z`);
+  if (!Number.isFinite(nowMs)) throw new Error(`Not a date: ${servedOn}`);
+
+  const offers = JSON.parse(readFileSync(path.join(ROOT, "data", "index.json"), "utf8")).offers;
+  const changes = JSON.parse(readFileSync(path.join(ROOT, "data", "deal_changes.json"), "utf8")).changes;
+
+  const staleAfterDays = reverificationIntervalDays(offers.map(o => o.verifiedDate), nowMs);
+  const { rows, excluded } = readmeSelection(offers, changes, { servedOn, nowMs, staleAfterDays });
+
+  return {
+    rows,
+    excluded,
+    census: readmeCensus(rows),
+    excludedByReason: excludedByReason(excluded),
+    rendered: renderReadme(rows, { staleAfterDays, excluded }),
+    staleAfterDays,
+    servedOn,
+  };
+}
+
+export function heldIndex(at = indexPath()) {
+  try {
+    return readFileSync(at, "utf8");
+  } catch {
+    return null;
+  }
+}

--- a/scripts/publish-llm-api-index.js
+++ b/scripts/publish-llm-api-index.js
@@ -1,0 +1,153 @@
+import { appendFileSync } from "node:fs";
+import path from "node:path";
+
+import { ROOT, heldIndex, indexPath, renderIndex, servedOnFrom } from "./llm-api-index-render.js";
+
+const {
+  publicationBranch,
+  publicationCommitMessage,
+  publicationDecision,
+  publicationTarget,
+} = await import(`${ROOT}/dist/llm-api-index-publication.js`);
+
+const args = process.argv.slice(2);
+const dryRun = args.includes("--dry-run");
+const API = process.env.AGENTDEALS_GITHUB_API || "https://api.github.com";
+
+function say(line) {
+  console.log(line);
+}
+
+function report(fields) {
+  const to = process.env.GITHUB_OUTPUT;
+  if (!to) return;
+  appendFileSync(to, `${Object.entries(fields).map(([k, v]) => `${k}=${v}`).join("\n")}\n`);
+}
+
+function done(published, detail) {
+  report({ published, ...detail });
+  process.exit(0);
+}
+
+function stop(published, because) {
+  console.error(because);
+  report({ published, reason: because.replace(/\n/g, " ") });
+  process.exit(1);
+}
+
+const reading = publicationTarget(process.env);
+if (reading.state === "unnamed") {
+  say(reading.because);
+  say(`Nothing was published to any other repository. Set ${"AGENTDEALS_LLM_INDEX_REPO"} to turn publication on.`);
+  done("unnamed", {});
+}
+if (reading.state === "unusable") stop("misconfigured", reading.because);
+
+const target = reading.target;
+
+async function call(route, init = {}) {
+  const response = await fetch(`${API}${route}`, {
+    ...init,
+    headers: {
+      accept: "application/vnd.github+json",
+      authorization: `Bearer ${target.token}`,
+      "x-github-api-version": "2022-11-28",
+      "user-agent": "agentdeals-llm-api-index",
+      ...(init.body ? { "content-type": "application/json" } : {}),
+      ...(init.headers ?? {}),
+    },
+  });
+  const text = await response.text();
+  let body = null;
+  try {
+    body = text === "" ? null : JSON.parse(text);
+  } catch {
+    body = null;
+  }
+  return { status: response.status, body, text };
+}
+
+function apiFailure(what, response) {
+  const message = response.body?.message ?? response.text.slice(0, 300);
+  return `${what} answered HTTP ${response.status}: ${message}`;
+}
+
+let index;
+try {
+  index = await renderIndex(servedOnFrom(args));
+} catch (error) {
+  stop("failed", error.message);
+}
+
+const held = heldIndex();
+
+const repo = await call(`/repos/${target.repo}`);
+if (repo.status !== 200 && repo.status !== 404) stop("failed", apiFailure(`GET /repos/${target.repo}`, repo));
+
+const remote = {
+  repoExists: repo.status === 200,
+  defaultBranch: repo.body?.default_branch ?? null,
+  branchCount: 0,
+  branchExists: false,
+  file: null,
+};
+
+if (remote.repoExists) {
+  const branches = await call(`/repos/${target.repo}/branches?per_page=100`);
+  if (branches.status !== 200) stop("failed", apiFailure(`GET /repos/${target.repo}/branches`, branches));
+  const names = (branches.body ?? []).map(b => b.name);
+  remote.branchCount = names.length;
+  const wanted = publicationBranch(target, remote);
+  remote.branchExists = wanted !== null && names.includes(wanted);
+
+  if (remote.branchExists) {
+    const file = await call(`/repos/${target.repo}/contents/${target.path}?ref=${encodeURIComponent(wanted)}`);
+    if (file.status === 200) {
+      if (file.body?.encoding !== "base64" || typeof file.body?.content !== "string") {
+        stop("failed", `${target.repo} returned ${target.path} in an encoding this run cannot read: ${file.body?.encoding}`);
+      }
+      remote.file = { content: Buffer.from(file.body.content, "base64").toString("utf8"), sha: file.body.sha ?? "" };
+    } else if (file.status !== 404) {
+      stop("failed", apiFailure(`GET /repos/${target.repo}/contents/${target.path}`, file));
+    }
+  }
+}
+
+const decision = publicationDecision({
+  rows: index.census.rows,
+  generated: index.rendered,
+  held,
+  target,
+  remote,
+});
+
+const named = target.branch ?? remote.defaultBranch ?? "(the repository's first branch)";
+say(`${path.relative(ROOT, indexPath())} → ${target.repo}:${named}/${target.path}`);
+
+if (decision.action === "refuse") stop("refused", decision.because);
+say(decision.because);
+if (decision.action === "unchanged") done("unchanged", { rows: index.census.rows });
+
+const message = publicationCommitMessage(index.census);
+if (dryRun) {
+  say(`--dry-run: would ${decision.action} with the message "${message}".`);
+  done(`would-${decision.action}`, { rows: index.census.rows });
+}
+
+const write = await call(`/repos/${target.repo}/contents/${target.path}`, {
+  method: "PUT",
+  body: JSON.stringify({
+    message,
+    content: Buffer.from(index.rendered, "utf8").toString("base64"),
+    ...(decision.sha ? { sha: decision.sha } : {}),
+    ...(decision.branch ? { branch: decision.branch } : {}),
+  }),
+});
+if (write.status !== 200 && write.status !== 201) {
+  stop("failed", apiFailure(`PUT /repos/${target.repo}/contents/${target.path}`, write));
+}
+
+const commit = write.body?.commit?.sha ?? "";
+say(`${decision.action === "create" ? "Created" : "Updated"} ${target.path} on ${target.repo} as ${commit.slice(0, 7)} — ${message}`);
+say(write.body?.content?.html_url ?? `https://github.com/${target.repo}/blob/${decision.branch ?? "HEAD"}/${target.path}`);
+done(decision.action === "create" ? "created" : "updated", { rows: index.census.rows, commit });

--- a/src/llm-api-index-publication.ts
+++ b/src/llm-api-index-publication.ts
@@ -1,0 +1,166 @@
+import type { ReadmeCensus } from "./llm-api-readme.js";
+
+export const CATALOGUE_REPO = "robhunter/agentdeals";
+
+export const PUBLISHED_README_PATH = "README.md";
+
+export const REPO_ENV = "AGENTDEALS_LLM_INDEX_REPO";
+export const BRANCH_ENV = "AGENTDEALS_LLM_INDEX_BRANCH";
+export const PATH_ENV = "AGENTDEALS_LLM_INDEX_README_PATH";
+export const TOKEN_ENV = "AGENTDEALS_LLM_INDEX_TOKEN";
+
+const OWNER_AND_NAME = /^[A-Za-z0-9._-]+\/[A-Za-z0-9._-]+$/;
+
+export interface PublicationTarget {
+  repo: string;
+  branch: string | null;
+  path: string;
+  token: string;
+}
+
+export type TargetReading =
+  | { state: "unnamed"; because: string }
+  | { state: "unusable"; because: string }
+  | { state: "named"; target: PublicationTarget };
+
+function trimmed(value: string | undefined): string {
+  return (value ?? "").trim();
+}
+
+export function publicationTarget(env: Record<string, string | undefined>): TargetReading {
+  const repo = trimmed(env[REPO_ENV]);
+  if (repo === "") {
+    return {
+      state: "unnamed",
+      because: `${REPO_ENV} names no repository, so the index is published in this repository's own tree and nowhere else.`,
+    };
+  }
+  if (!OWNER_AND_NAME.test(repo)) {
+    return {
+      state: "unusable",
+      because: `${REPO_ENV} reads ${JSON.stringify(repo)}, which is not an owner/name pair.`,
+    };
+  }
+  const path = trimmed(env[PATH_ENV]) || PUBLISHED_README_PATH;
+  if (repo === CATALOGUE_REPO && path === PUBLISHED_README_PATH) {
+    return {
+      state: "unusable",
+      because: `${REPO_ENV} names ${CATALOGUE_REPO} and ${PATH_ENV} names ${PUBLISHED_README_PATH}, which is this repository's own README. The index is a separate artefact and replacing this repository's front page with it is never the intent.`,
+    };
+  }
+  const token = trimmed(env[TOKEN_ENV]);
+  if (token === "") {
+    return {
+      state: "unusable",
+      because: `${REPO_ENV} names ${repo} but ${TOKEN_ENV} is empty, so nothing can be written there. A named repository nobody can write to publishes a stale index rather than no index.`,
+    };
+  }
+  return { state: "named", target: { repo, branch: trimmed(env[BRANCH_ENV]) || null, path, token } };
+}
+
+export interface RemoteFile {
+  content: string;
+  sha: string;
+}
+
+export interface RemoteReading {
+  repoExists: boolean;
+  defaultBranch: string | null;
+  branchCount: number;
+  branchExists: boolean;
+  file: RemoteFile | null;
+}
+
+export function publicationBranch(target: PublicationTarget, remote: RemoteReading): string | null {
+  return target.branch ?? remote.defaultBranch;
+}
+
+export type PublicationAction = "create" | "update" | "unchanged" | "refuse";
+
+export interface Publication {
+  action: PublicationAction;
+  branch: string | null;
+  sha: string | null;
+  because: string;
+}
+
+export interface PublicationInput {
+  rows: number;
+  generated: string;
+  held: string | null;
+  target: PublicationTarget;
+  remote: RemoteReading;
+}
+
+export function publicationDecision(input: PublicationInput): Publication {
+  const { rows, generated, held, target, remote } = input;
+  const refuse = (because: string): Publication => ({ action: "refuse", branch: null, sha: null, because });
+
+  if (rows === 0) {
+    return refuse(
+      "No catalogue record carries a subtype label this index selects on, so the file this run renders holds no rows. An index of nothing is not published over an index of something.",
+    );
+  }
+  if (held === null) {
+    return refuse(
+      `Nothing has been generated at the index path in this workspace, so there is no file to publish to ${target.repo}.`,
+    );
+  }
+  if (held !== generated) {
+    return refuse(
+      `The index held in this workspace is not what this catalogue generates, so publishing it would put a stale or hand-edited file on ${target.repo}. Regenerate it first.`,
+    );
+  }
+  if (!remote.repoExists) {
+    return refuse(
+      `${target.repo} does not exist, or the token cannot see it. The repository is created once, by hand; this run publishes into it and does not make it.`,
+    );
+  }
+
+  const branch = publicationBranch(target, remote);
+  if (remote.branchCount > 0 && branch === null) {
+    return refuse(
+      `${target.repo} has branches but names no default, and ${BRANCH_ENV} is empty, so this run cannot tell which branch the index belongs on.`,
+    );
+  }
+  if (remote.branchCount > 0 && !remote.branchExists) {
+    return refuse(`${target.repo} has no branch ${branch}, so the index has nowhere to land on it.`);
+  }
+  if (remote.file === null) {
+    return {
+      action: "create",
+      branch: remote.branchCount === 0 ? null : branch,
+      sha: null,
+      because: `${target.repo} publishes no ${target.path} yet, so this run writes the first one.`,
+    };
+  }
+  if (remote.file.sha === "") {
+    return refuse(
+      `${target.repo} holds a ${target.path} that reports no blob sha, and an update without one would overwrite whatever is there blind.`,
+    );
+  }
+  if (remote.file.content === generated) {
+    return {
+      action: "unchanged",
+      branch,
+      sha: remote.file.sha,
+      because: `${target.repo} already publishes exactly what this catalogue generates, so this run writes no commit.`,
+    };
+  }
+  return {
+    action: "update",
+    branch,
+    sha: remote.file.sha,
+    because: `${target.repo} publishes an index this catalogue no longer generates, so this run replaces it.`,
+  };
+}
+
+export function publicationCommitMessage(census: ReadmeCensus): string {
+  const records = `${census.rows} record${census.rows === 1 ? "" : "s"}`;
+  return [
+    `Regenerate from the free-tier catalogue — ${records}`,
+    `${census.rated} rated`,
+    `${census.withheld} publishing a reason instead of a rating`,
+    `${census.withPriorTerms} showing the terms they replaced`,
+  ].join(", ");
+}

--- a/src/llm-api-readme.ts
+++ b/src/llm-api-readme.ts
@@ -36,7 +36,11 @@ export const README_TAXONOMY = "AI / ML";
 
 export const README_SUBTYPES = ["llm_api", "model_gateway", "model_hosting", "embeddings_api"] as const;
 
-export const CATALOGUE_ISSUES_URL = "https://github.com/robhunter/agentdeals/issues";
+export const CATALOGUE_REPO_URL = "https://github.com/robhunter/agentdeals";
+
+export const CATALOGUE_ISSUES_URL = `${CATALOGUE_REPO_URL}/issues`;
+
+export const README_GENERATOR_URL = `${CATALOGUE_REPO_URL}/blob/main/src/llm-api-readme.ts`;
 
 export const README_TITLE = "Free tiers for AI and LLM APIs, with the date we read each one";
 
@@ -73,6 +77,10 @@ export const README_ORDER_RULE =
 
 export const README_EDIT_WARNING =
   "It is regenerated whenever those records move, so editing it by hand is pointless — the next run overwrites it.";
+
+export const README_GENERATOR_SENTENCE =
+  `The code that writes it is ${README_GENERATOR_URL}, so every rule this file states can be read against the rule `
+  + "it applies.";
 
 export interface PublishedTerms {
   text: string;
@@ -570,7 +578,7 @@ export function renderReadme(rows: ReadmeRow[], meta: ReadmeMeta): string {
     + "single stamp for a list nobody re-read is worth nothing.",
     "",
     `Generated from the free-tier catalogue at ${BASE_URL}, which is where each row's record lives. `
-    + README_EDIT_WARNING,
+    + `${README_EDIT_WARNING} ${README_GENERATOR_SENTENCE}`,
     "",
     "What this file has that a hand-kept list does not: **the terms a vendor replaced, next to the terms it replaced "
     + `them with, with the date.** ${census.withPriorTerms} rows carry that today.`,

--- a/test/llm-api-index-publication.test.ts
+++ b/test/llm-api-index-publication.test.ts
@@ -1,0 +1,401 @@
+import { describe, it, before, after } from "node:test";
+import assert from "node:assert";
+import { spawn, spawnSync } from "node:child_process";
+import { createServer, type Server } from "node:http";
+import { mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO = path.join(__dirname, "..");
+const WORKFLOW = path.join(REPO, ".github", "workflows", "llm-api-readme.yml");
+const PUBLISHER = path.join(REPO, "scripts", "publish-llm-api-index.js");
+const GENERATOR = path.join(REPO, "scripts", "generate-llm-api-readme.js");
+
+const {
+  BRANCH_ENV,
+  CATALOGUE_REPO,
+  PATH_ENV,
+  PUBLISHED_README_PATH,
+  REPO_ENV,
+  TOKEN_ENV,
+  publicationBranch,
+  publicationCommitMessage,
+  publicationDecision,
+  publicationTarget,
+} = await import("../dist/llm-api-index-publication.js");
+
+const SERVED_ON = "2026-09-01";
+
+const TARGET = { repo: "robhunter/llm-api-free-tiers", branch: "main", path: "README.md", token: "t" };
+
+function remote(over: Record<string, unknown> = {}) {
+  return {
+    repoExists: true,
+    defaultBranch: "main",
+    branchCount: 1,
+    branchExists: true,
+    file: null,
+    ...over,
+  };
+}
+
+function decide(over: Record<string, unknown> = {}) {
+  return publicationDecision({
+    rows: 31,
+    generated: "INDEX",
+    held: "INDEX",
+    target: TARGET,
+    remote: remote(),
+    ...over,
+  });
+}
+
+describe("#1497 the index names one repository to publish into, or none", () => {
+  it("publishes nowhere when no repository is named", () => {
+    for (const value of [undefined, "", "   "]) {
+      const reading = publicationTarget(value === undefined ? {} : { [REPO_ENV]: value });
+      assert.equal(reading.state, "unnamed", `${JSON.stringify(value)} should leave publication off`);
+      assert.match(reading.because, new RegExp(REPO_ENV));
+    }
+  });
+
+  it("refuses a repository that is not an owner/name pair", () => {
+    for (const value of ["llm-api-free-tiers", "owner/name/extra", "owner /name", "https://github.com/o/n"]) {
+      const reading = publicationTarget({ [REPO_ENV]: value, [TOKEN_ENV]: "t" });
+      assert.equal(reading.state, "unusable", `${value} should not be accepted as a target`);
+    }
+  });
+
+  it("refuses a named repository with no token, because that publishes a stale index rather than none", () => {
+    const reading = publicationTarget({ [REPO_ENV]: "robhunter/llm-api-free-tiers" });
+    assert.equal(reading.state, "unusable");
+    assert.match(reading.because, new RegExp(TOKEN_ENV));
+    assert.match(reading.because, /stale/);
+  });
+
+  it("refuses to write this repository's own front page", () => {
+    const reading = publicationTarget({ [REPO_ENV]: CATALOGUE_REPO, [TOKEN_ENV]: "t" });
+    assert.equal(reading.state, "unusable");
+    assert.match(reading.because, new RegExp(PUBLISHED_README_PATH));
+  });
+
+  it("allows the catalogue repository at some other path, so the mechanism can be exercised against a real remote", () => {
+    const reading = publicationTarget({
+      [REPO_ENV]: CATALOGUE_REPO,
+      [PATH_ENV]: "artifacts/publish-check/README.md",
+      [TOKEN_ENV]: "t",
+    });
+    assert.equal(reading.state, "named");
+    assert.equal(reading.target.path, "artifacts/publish-check/README.md");
+  });
+
+  it("defaults the path to the repository root README and leaves the branch for the remote to name", () => {
+    const reading = publicationTarget({ [REPO_ENV]: "robhunter/llm-api-free-tiers", [TOKEN_ENV]: "t" });
+    assert.equal(reading.state, "named");
+    assert.equal(reading.target.path, PUBLISHED_README_PATH);
+    assert.equal(reading.target.branch, null);
+    assert.equal(publicationBranch(reading.target, remote({ defaultBranch: "trunk" })), "trunk");
+  });
+
+  it("takes a named branch over the remote's default", () => {
+    const reading = publicationTarget({
+      [REPO_ENV]: "robhunter/llm-api-free-tiers",
+      [BRANCH_ENV]: "publish",
+      [TOKEN_ENV]: "t",
+    });
+    assert.equal(reading.state, "named");
+    assert.equal(publicationBranch(reading.target, remote({ defaultBranch: "main" })), "publish");
+  });
+});
+
+describe("#1497 what reaches the published repository is what the catalogue generates", () => {
+  it("refuses when the file held in the workspace is not what the catalogue generates", () => {
+    const decision = decide({ held: "INDEX with a hand edit" });
+    assert.equal(decision.action, "refuse");
+    assert.match(decision.because, /stale or hand-edited/);
+  });
+
+  it("refuses when nothing has been generated in the workspace at all", () => {
+    const decision = decide({ held: null });
+    assert.equal(decision.action, "refuse");
+  });
+
+  it("refuses to publish an index holding no rows over one holding rows", () => {
+    const decision = decide({ rows: 0, generated: "EMPTY", held: "EMPTY" });
+    assert.equal(decision.action, "refuse");
+    assert.match(decision.because, /index of nothing/);
+  });
+
+  it("refuses when the repository does not exist, rather than trying to make it", () => {
+    const decision = decide({ remote: remote({ repoExists: false, defaultBranch: null, branchCount: 0, branchExists: false }) });
+    assert.equal(decision.action, "refuse");
+    assert.match(decision.because, /does not exist/);
+  });
+
+  it("refuses when the repository has branches but not the one named", () => {
+    const decision = decide({ remote: remote({ branchExists: false, branchCount: 2 }) });
+    assert.equal(decision.action, "refuse");
+    assert.match(decision.because, /no branch main/);
+  });
+
+  it("writes the first README into a repository that holds none", () => {
+    const decision = decide();
+    assert.equal(decision.action, "create");
+    assert.equal(decision.branch, "main");
+    assert.equal(decision.sha, null);
+  });
+
+  it("lets a repository with no commits name its own first branch", () => {
+    const decision = decide({ remote: remote({ branchCount: 0, branchExists: false }) });
+    assert.equal(decision.action, "create");
+    assert.equal(decision.branch, null);
+  });
+
+  it("writes no commit when the published README already reads what the catalogue generates", () => {
+    const decision = decide({ remote: remote({ file: { content: "INDEX", sha: "abc" } }) });
+    assert.equal(decision.action, "unchanged");
+  });
+
+  it("replaces a published README the catalogue no longer generates, naming the blob it replaces", () => {
+    const decision = decide({ remote: remote({ file: { content: "an older index", sha: "abc" } }) });
+    assert.equal(decision.action, "update");
+    assert.equal(decision.sha, "abc");
+  });
+
+  it("refuses an update it cannot address, rather than overwriting blind", () => {
+    const decision = decide({ remote: remote({ file: { content: "an older index", sha: "" } }) });
+    assert.equal(decision.action, "refuse");
+    assert.match(decision.because, /blind/);
+  });
+});
+
+describe("#1497 the published commit says what moved", () => {
+  const census = {
+    rows: 31, rated: 19, ended: 2, withheld: 10, withheldByReason: {},
+    withPriorTerms: 7, linkUnreachable: 0, stale: 0, caveated: 0,
+  };
+
+  it("names every count a reader of the history would check", () => {
+    const message = publicationCommitMessage(census);
+    for (const figure of ["31 record", "19 rated", "10 publishing a reason", "7 showing the terms"]) {
+      assert.ok(message.includes(figure), `${JSON.stringify(message)} should carry ${figure}`);
+    }
+  });
+
+  it("counts one record in the singular", () => {
+    assert.match(publicationCommitMessage({ ...census, rows: 1 }), /1 record,/);
+  });
+});
+
+describe("#1497 the publisher run end to end against a repository API", () => {
+  let server: Server;
+  let origin = "";
+  let calls: { method: string; url: string; body: unknown }[] = [];
+  let state: { repo: unknown; branches: unknown; file: { content: string; sha: string } | null } = {
+    repo: null, branches: null, file: null,
+  };
+  let heldPath = "";
+  let generated = "";
+
+  before(async () => {
+    heldPath = path.join(mkdtempSync(path.join(tmpdir(), "llm-index-publish-")), "README.md");
+    const wrote = spawnSync("node", [GENERATOR, `--on=${SERVED_ON}`], {
+      cwd: REPO,
+      encoding: "utf8",
+      env: { ...process.env, AGENTDEALS_LLM_INDEX_PATH: heldPath, TZ: "UTC" },
+    });
+    assert.equal(wrote.status, 0, wrote.stderr);
+    generated = readFileSync(heldPath, "utf8");
+
+    server = createServer((req, res) => {
+      let raw = "";
+      req.on("data", chunk => { raw += chunk; });
+      req.on("end", () => {
+        calls.push({ method: req.method ?? "", url: req.url ?? "", body: raw === "" ? null : JSON.parse(raw) });
+        const answer = (status: number, body: unknown) => {
+          res.writeHead(status, { "content-type": "application/json" });
+          res.end(JSON.stringify(body));
+        };
+        const url = req.url ?? "";
+        if (req.method === "GET" && /^\/repos\/[^/]+\/[^/]+$/.test(url)) {
+          return state.repo === null ? answer(404, { message: "Not Found" }) : answer(200, state.repo);
+        }
+        if (req.method === "GET" && url.includes("/branches")) {
+          return answer(200, state.branches ?? []);
+        }
+        if (req.method === "GET" && url.includes("/contents/")) {
+          if (state.file === null) return answer(404, { message: "Not Found" });
+          return answer(200, {
+            encoding: "base64",
+            content: Buffer.from(state.file.content, "utf8").toString("base64"),
+            sha: state.file.sha,
+          });
+        }
+        if (req.method === "PUT" && url.includes("/contents/")) {
+          const body = calls[calls.length - 1]!.body as { content: string };
+          state.file = { content: Buffer.from(body.content, "base64").toString("utf8"), sha: "written" };
+          return answer(200, { commit: { sha: "0123456789" }, content: { html_url: "https://example.invalid/readme" } });
+        }
+        return answer(500, { message: `unrouted ${req.method} ${url}` });
+      });
+    });
+    await new Promise<void>(resolve => server.listen(0, "127.0.0.1", resolve));
+    const address = server.address();
+    origin = typeof address === "object" && address !== null ? `http://127.0.0.1:${address.port}` : "";
+  });
+
+  after(async () => {
+    await new Promise<void>(resolve => server.close(() => resolve()));
+  });
+
+  function publish(env: Record<string, string | undefined> = {}, args: string[] = []) {
+    calls = [];
+    const child = spawn("node", [PUBLISHER, `--on=${SERVED_ON}`, ...args], {
+      cwd: REPO,
+      env: {
+        ...process.env,
+        TZ: "UTC",
+        AGENTDEALS_GITHUB_API: origin,
+        AGENTDEALS_LLM_INDEX_PATH: heldPath,
+        [REPO_ENV]: "robhunter/llm-api-free-tiers",
+        [TOKEN_ENV]: "a-token",
+        ...env,
+      },
+    });
+    return new Promise<{ status: number | null; stdout: string; stderr: string }>((resolve, reject) => {
+      let stdout = "";
+      let stderr = "";
+      child.stdout.on("data", chunk => { stdout += chunk; });
+      child.stderr.on("data", chunk => { stderr += chunk; });
+      child.on("error", reject);
+      child.on("close", status => resolve({ status, stdout, stderr }));
+    });
+  }
+
+  function puts() {
+    return calls.filter(c => c.method === "PUT");
+  }
+
+  it("does nothing and says so when no repository is named", async () => {
+    state = { repo: null, branches: null, file: null };
+    const run = await publish({ [REPO_ENV]: "" });
+    assert.equal(run.status, 0, run.stderr);
+    assert.match(run.stdout, new RegExp(REPO_ENV));
+    assert.equal(calls.length, 0, "an unnamed target should not reach the API at all");
+  });
+
+  it("fails rather than publishing when a repository is named with no token", async () => {
+    const run = await publish({ [TOKEN_ENV]: "" });
+    assert.equal(run.status, 1);
+    assert.equal(puts().length, 0);
+  });
+
+  it("fails loudly when the named repository does not exist", async () => {
+    state = { repo: null, branches: null, file: null };
+    const run = await publish();
+    assert.equal(run.status, 1);
+    assert.match(run.stderr, /does not exist/);
+    assert.equal(puts().length, 0);
+  });
+
+  it("writes the generated index, byte for byte, as the first README", async () => {
+    state = { repo: { default_branch: "main" }, branches: [{ name: "main" }], file: null };
+    const run = await publish();
+    assert.equal(run.status, 0, run.stderr);
+    assert.equal(puts().length, 1);
+    const body = puts()[0]!.body as { content: string; branch?: string; sha?: string; message: string };
+    assert.equal(Buffer.from(body.content, "base64").toString("utf8"), generated);
+    assert.equal(body.branch, "main");
+    assert.equal(body.sha, undefined, "a create carries no blob to replace");
+    assert.match(body.message, /31 records/);
+  });
+
+  it("writes no commit on a second run over the same data", async () => {
+    const run = await publish();
+    assert.equal(run.status, 0, run.stderr);
+    assert.equal(puts().length, 0, "identical content should produce no commit");
+    assert.match(run.stdout, /already publishes/);
+  });
+
+  it("replaces a published README that has drifted, naming the blob it replaces", async () => {
+    state.file = { content: "an index somebody edited by hand", sha: "deadbeef" };
+    const run = await publish();
+    assert.equal(run.status, 0, run.stderr);
+    assert.equal(puts().length, 1);
+    assert.equal((puts()[0]!.body as { sha: string }).sha, "deadbeef");
+    assert.equal(state.file.content, generated);
+  });
+
+  it("refuses to publish a workspace file the catalogue does not generate", async () => {
+    writeFileSync(heldPath, `${generated}\nan extra line nobody generated\n`);
+    try {
+      const run = await publish();
+      assert.equal(run.status, 1);
+      assert.match(run.stderr, /stale or hand-edited/);
+      assert.equal(puts().length, 0);
+    } finally {
+      writeFileSync(heldPath, generated);
+    }
+  });
+
+  it("reads the remote and writes nothing under --dry-run", async () => {
+    state.file = { content: "something else", sha: "cafe" };
+    const run = await publish({}, ["--dry-run"]);
+    assert.equal(run.status, 0, run.stderr);
+    assert.equal(puts().length, 0);
+    assert.match(run.stdout, /--dry-run/);
+  });
+});
+
+describe("#1497 the workflow that owns the index is the workflow that publishes it", () => {
+  const workflow = readFileSync(WORKFLOW, "utf8");
+
+  function stepsOf(text: string) {
+    const out: { name: string; body: string }[] = [];
+    for (const line of text.split("\n")) {
+      const start = line.match(/^ {6}- (?:name|uses):\s*(.+)$/);
+      if (start) out.push({ name: start[1]!.trim(), body: `${line}\n` });
+      else if (out.length > 0) out[out.length - 1]!.body += `${line}\n`;
+    }
+    return out;
+  }
+
+  const steps = stepsOf(workflow);
+  const publisher = steps.find(s => /publish-llm-api-index\.js/.test(s.body));
+  const gate = steps.findIndex(s => /gate-data-push\.sh/.test(s.body));
+
+  it("invokes the publisher", () => {
+    assert.ok(publisher, "the index workflow should publish the index it regenerates");
+  });
+
+  it("publishes only what the gate has already put on main", () => {
+    assert.ok(gate >= 0, "the index workflow should still gate its own commit");
+    assert.ok(steps.indexOf(publisher!) > gate, "publication should follow the gate, not precede it");
+    assert.doesNotMatch(
+      publisher!.body,
+      /if:\s*(always\(\)|failure\(\)|!cancelled\(\))/,
+      "a quarantined index must not be published, so the publish step runs only on success",
+    );
+  });
+
+  it("takes its target from repository configuration rather than a literal in the workflow", () => {
+    assert.match(publisher!.body, new RegExp(`${REPO_ENV}:\\s*\\$\\{\\{\\s*vars\\.`));
+    assert.match(publisher!.body, new RegExp(`${TOKEN_ENV}:\\s*\\$\\{\\{\\s*secrets\\.`));
+  });
+
+  it("keeps publishing current even when a data run reaches main without firing a push event", () => {
+    assert.match(workflow, /^\s+schedule:/m, "a GITHUB_TOKEN push fires no push event, so the mirror needs its own clock");
+  });
+});
+
+describe("#1497 one path holds the index, and both scripts read it from one place", () => {
+  for (const script of [GENERATOR, PUBLISHER]) {
+    it(`${path.basename(script)} takes the index path from the shared renderer`, () => {
+      const source = readFileSync(script, "utf8");
+      assert.match(source, /from "\.\/llm-api-index-render\.js"/);
+      assert.doesNotMatch(source, /free-llm-api-index/, "the path is named once, in the renderer");
+    });
+  }
+});


### PR DESCRIPTION
Refs #1497 — the order's number one. The content is done; what was left was where the artefact lives.

The generator writes the index into this repository's tree at `artifacts/free-llm-api-index/README.md` and nothing reads it there. It can now also push those exact bytes to the root `README.md` of a named repository, so the public copy has one source and cannot drift from the catalogue.

## How it is turned on

Repository configuration, not a literal in the workflow:

| | |
| --- | --- |
| `vars.LLM_INDEX_REPO` | `owner/name`. Unset means publication is off and the run says so. |
| `vars.LLM_INDEX_BRANCH` | Optional. Unset takes the remote's own default branch. |
| `secrets.LLM_INDEX_PUBLISH_TOKEN` | A token that can write to that repository. |

So the repository being made and the variable being set is the whole launch step, and no code changes when it happens.

## What it refuses

Every one of these was run against the live GitHub API, not only the stub.

| condition | outcome |
| --- | --- |
| no repository named | exit 0, nothing written, says which variable turns it on |
| repository named, no token | exit 1 — a repository nobody can write to publishes a *stale* index, not no index |
| repository does not exist | exit 1, naming it; this run publishes into a repository and does not make one |
| branch does not exist | exit 1, naming the branch |
| the workspace file is not what the catalogue generates | exit 1 — a hand-edited or stale file is never published |
| the index holds no rows | exit 1 — an index of nothing is not published over an index of something |
| the target is this repository's own `README.md` | exit 1 at any branch |

## What it does

Verified end to end against `robhunter/agentdeals` on a throwaway branch at a throwaway path, since the destination repository does not exist yet. The branch is deleted; no workflow fired on it.

- **create** — wrote 27,405 bytes, byte-identical to the generated file (`cmp` clean), one commit;
- **unchanged** — a second run over the same data wrote no commit, still one commit on the path;
- **update** — after the remote copy was replaced by hand, the next run restored it to the generated bytes, addressing the blob it replaced by sha;
- **`--dry-run`** — reads the remote, decides, writes nothing.

The commit it writes names the counts a reader of the history would check: `Regenerate from the free-tier catalogue — 31 records, 19 rated, 10 publishing a reason instead of a rating, 7 showing the terms they replaced`.

## Where it runs

The publish step follows the gate in the workflow that already owns this artefact, so only an index `main` holds is mirrored — a quarantined one is skipped, because the step runs on success and a test in this PR refuses `if: always()` on it.

A push made with `GITHUB_TOKEN` fires no `on: push` workflow, so an index that reaches `main` from inside a data run would not otherwise be mirrored. The workflow takes a daily schedule as well, and since the publisher writes no commit when nothing moved, a quiet day costs one API read.

## Also here

`README_GENERATOR_SENTENCE` — the file now names the source file that writes it. Checkability is the claim this artefact makes against 479-entry mirrors that publish one refresh stamp, and a generated file that does not say where its generator lives is asking to be taken on trust. One line, in both copies, because they are the same bytes.

`scripts/llm-api-index-render.js` — the render and the index path are named once and read by both scripts. A test refuses either script naming the path itself.

## Not done

No repository is created; the order says that is yours. Nothing about a description or topics either — that is copy, and it is not mine to write.

33 tests, `test/llm-api-index-publication.test.ts`. The end-to-end block runs the real script against a stub contents API, asserting on the requests it makes: the base64 body decodes to the generated file byte for byte, a create carries no `sha`, an update carries the one it replaces, and identical content produces no `PUT` at all.