### PR TITLE
State a filtered subset as a share of what it filtered, not a count (#1465)

### DIFF
--- a/test/function-naming.test.ts
+++ b/test/function-naming.test.ts
@@ -23,6 +23,7 @@ import {
 } from "../dist/product-function.js";
 import { rankOffers } from "../dist/ranking.js";
 import { verificationLedger } from "../dist/verification-state.js";
+import { assertSharesPopulation, categoriesInTheCatalogue } from "./population-floor.ts";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const REPO = path.join(__dirname, "..");
@@ -303,7 +304,7 @@ describe("a page's title names a class of product", () => {
 
   it("leaves every category-named page titled after its category", async () => {
     const named = published.filter(fn => fn.categories.length > 0);
-    assert.strictEqual(named.length, 58);
+    assertSharesPopulation(named.length, categoriesInTheCatalogue(), 0.6, "categories publishing a page titled after them");
     for (const fn of named) {
       assert.strictEqual(fn.title, fn.categories[0]);
       assert.strictEqual(fn.listNoun, `${fn.categories[0]} Tools`);

--- a/test/population-floor.test.ts
+++ b/test/population-floor.test.ts
@@ -4,12 +4,16 @@ import { readdirSync, readFileSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import {
+  asShare,
   assertCoversPopulation,
   assertPopulationFloor,
+  assertSharesPopulation,
   bareFloorsIn,
   categoriesInTheCatalogue,
   floorClearsHeadroom,
   passedPopulationsIn,
+  recordsInTheCatalogue,
+  shareClearsHeadroom,
   REGISTERED_FROM,
   vendorsInTheCatalogue,
 } from "./population-floor.ts";
@@ -20,6 +24,8 @@ const asWritten = (expression: string, comparison: string, literal: number) =>
   `assert.ok(${expression} ${comparison} ${literal}, "the message it carries");`;
 
 const COVERAGE = "assertCoversPopulation";
+
+const SHARE = "assertSharesPopulation";
 
 describe("a floor over a live population states headroom it has measured", () => {
   it("passes a floor the population clears by more than a quarter", () => {
@@ -86,6 +92,8 @@ describe("a sweep read against the population it covers states coverage, not hea
 
   it("refuses a population handed over as a number rather than read from the data", () => {
     const asCalled = (population: string) => `${COVERAGE}(checked, ${population}, "a subject");`;
+    assert.deepStrictEqual(passedPopulationsIn(`${SHARE}(checked, 1573, 0.05, "a subject");`).map(p => p.argument), ["1573"]);
+    assert.deepStrictEqual(passedPopulationsIn(`${SHARE}(checked, recordsInTheCatalogue(), 0.05, "a subject");`), []);
     assert.deepStrictEqual(passedPopulationsIn(asCalled("60")).map(p => p.argument), ["60"]);
     assert.deepStrictEqual(
       passedPopulationsIn(asCalled('{ size: 60, read: "made up" }')).map(p => p.argument),
@@ -108,6 +116,64 @@ describe("a sweep read against the population it covers states coverage, not hea
       [],
       "a population has to be read by a no-argument reader in population-floor.ts, because a caller that computes the number has put the literal back one indirection later",
     );
+  });
+});
+
+describe("a filtered subset states a share of the population it filtered, not a count", () => {
+  const asRead = (size: number) => () => ({ size, read: "records the catalogue holds" });
+  const wholeCatalogue = asRead(1573);
+  const curatedCatalogue = asRead(1547);
+  const halfTheCatalogue = asRead(900);
+  const aSliverOfIt = asRead(160);
+  const noCatalogueAtAll = asRead(0);
+
+  it("passes where the subset is a comfortable share of what it was filtered from", () => {
+    assertSharesPopulation(137, wholeCatalogue(), 0.05, "records restating their host");
+  });
+
+  it("holds where the population shrinks and the subset shrinks with it", () => {
+    const measured: [number, () => { size: number; read: string }][] = [
+      [137, wholeCatalogue],
+      [132, curatedCatalogue],
+      [80, halfTheCatalogue],
+      [14, aSliverOfIt],
+    ];
+    for (const [subset, population] of measured) {
+      assertSharesPopulation(subset, population(), 0.05, "records restating their host");
+    }
+  });
+
+  it("fails where the filter collapses while the population stands still", () => {
+    assert.throws(
+      () => assertSharesPopulation(40, wholeCatalogue(), 0.05, "records restating their host"),
+      /40 records restating their host, which is 2.5% of the 1573 records the catalogue holds it was filtered from, under a floor of 5.0%/,
+    );
+  });
+
+  it("refuses a share set close enough to what it measured to be a tripwire on the filter", () => {
+    assert.strictEqual(shareClearsHeadroom(0.05, 137, 1573), true);
+    assert.strictEqual(shareClearsHeadroom(0.08, 137, 1573), false);
+    assert.throws(
+      () => assertSharesPopulation(137, wholeCatalogue(), 0.08, "records restating their host"),
+      /a share of 8.0% leaves under 25% headroom over the 8.7% it measured/,
+    );
+  });
+
+  it("says nothing rather than passing vacuously when the population it filtered is empty", () => {
+    assert.throws(
+      () => assertSharesPopulation(0, noCatalogueAtAll(), 0.05, "records restating their host"),
+      /there are no records the catalogue holds, so no share of them says anything/,
+    );
+  });
+
+  it("reads a share the way a reader would", () => {
+    assert.strictEqual(asShare(0.05), "5.0%");
+    assert.strictEqual(asShare(137 / 1573), "8.7%");
+  });
+
+  it("reads its own populations off the catalogue, both of them non-empty", () => {
+    assert.ok(recordsInTheCatalogue().size > categoriesInTheCatalogue().size);
+    assert.notStrictEqual(recordsInTheCatalogue().read, categoriesInTheCatalogue().read);
   });
 });
 

--- a/test/population-floor.ts
+++ b/test/population-floor.ts
@@ -89,7 +89,8 @@ export interface Population {
 
 function catalogueOffers(): Array<{ vendor: string; category: string }> {
   const REPO = path.join(path.dirname(fileURLToPath(import.meta.url)), "..");
-  return JSON.parse(readFileSync(path.join(REPO, "data", "index.json"), "utf-8")).offers;
+  const at = process.env.AGENTDEALS_INDEX_PATH || path.join(REPO, "data", "index.json");
+  return JSON.parse(readFileSync(at, "utf-8")).offers;
 }
 
 export function vendorsInTheCatalogue(): Population {
@@ -102,19 +103,26 @@ export function categoriesInTheCatalogue(): Population {
   return { size: categories.size, read: "categories the catalogue holds an offer under" };
 }
 
+export function recordsInTheCatalogue(): Population {
+  return { size: catalogueOffers().length, read: "records the catalogue holds" };
+}
+
 const POPULATION_READER = /^[A-Za-z_$][\w$]*\(\s*\)$/;
+
+export const POPULATION_ASSERTIONS = ["assertCoversPopulation", "assertSharesPopulation"] as const;
 
 export type PassedPopulation = { line: number; argument: string };
 
 export function passedPopulationsIn(source: string): PassedPopulation[] {
   const found: PassedPopulation[] = [];
-  for (const call of source.matchAll(/(?<!function )assertCoversPopulation\(/g)) {
-    const open = call.index + "assertCoversPopulation".length;
-    const argument = (argumentsAt(source, open)[1] ?? "").trim();
-    if (POPULATION_READER.test(argument)) continue;
-    found.push({ line: source.slice(0, call.index).split("\n").length, argument });
+  for (const name of POPULATION_ASSERTIONS) {
+    for (const call of source.matchAll(new RegExp(`(?<!function )${name}\\(`, "g"))) {
+      const argument = (argumentsAt(source, call.index + name.length)[1] ?? "").trim();
+      if (POPULATION_READER.test(argument)) continue;
+      found.push({ line: source.slice(0, call.index).split("\n").length, argument });
+    }
   }
-  return found;
+  return found.sort((a, b) => a.line - b.line);
 }
 
 export function assertPopulationFloor(observed: number, floor: number, subject: string): void {
@@ -138,5 +146,40 @@ export function assertCoversPopulation(observed: number, population: Population,
   assert.ok(
     observed >= population.size,
     `${observed} ${subject}, against ${population.size} ${population.read} — the sweep does not cover the population it is read against`,
+  );
+}
+
+export function asShare(fraction: number): string {
+  return `${(fraction * 100).toFixed(1)}%`;
+}
+
+export function shareClearsHeadroom(share: number, observed: number, population: number): boolean {
+  return share * 4 <= (observed / population) * 3;
+}
+
+export function assertSharesPopulation(
+  observed: number,
+  population: Population,
+  share: number,
+  subject: string,
+): void {
+  const log = process.env.POPULATION_FLOOR_LOG;
+  if (log) {
+    appendFileSync(
+      log,
+      `${JSON.stringify({ site: callSite(), subject, filteredFrom: population.read, population: population.size, share, observed })}\n`,
+    );
+  }
+  assert.ok(
+    population.size > 0,
+    `there are no ${population.read}, so no share of them says anything about ${subject}`,
+  );
+  assert.ok(
+    observed >= population.size * share,
+    `${observed} ${subject}, which is ${asShare(observed / population.size)} of the ${population.size} ${population.read} it was filtered from, under a floor of ${asShare(share)}`,
+  );
+  assert.ok(
+    shareClearsHeadroom(share, observed, population.size),
+    `a share of ${asShare(share)} leaves under ${Math.round(HEADROOM * 100)}% headroom over the ${asShare(observed / population.size)} it measured — ${subject}. A share does not drift as the data grows or shrinks, so one set this close to what it measures is a tripwire on the filter rather than a guard against it returning nothing.`,
   );
 }

--- a/test/product-named-on-its-page.test.ts
+++ b/test/product-named-on-its-page.test.ts
@@ -22,7 +22,7 @@ import {
 } from "../dist/source-check.js";
 import { loadOffers } from "../dist/data.js";
 import { openapiSpec } from "../dist/openapi.js";
-import { assertPopulationFloor } from "./population-floor.ts";
+import { assertPopulationFloor, assertSharesPopulation, recordsInTheCatalogue } from "./population-floor.ts";
 
 const VERTEX_MODEL_REFERENCE = "https://cloud.google.com/vertex-ai/docs/generative-ai/model-reference/overview";
 const A_GOOGLE_PAGE_ABOUT_GEMINI =
@@ -131,7 +131,12 @@ describe("deleting the host brand from a name does not change the verdict", () =
     .filter(({ restated }) => restated.tokens.length > 0);
 
   it("reads a real population of records, not an empty one", () => {
-    assertPopulationFloor(exposed.length, 100, "catalogue records whose name restates the host we cite them from");
+    assertSharesPopulation(
+      exposed.length,
+      recordsInTheCatalogue(),
+      0.05,
+      "catalogue records whose name restates the host we cite them from",
+    );
   });
 
   it("accepts no form that a page could match without writing past the host brand", () => {
@@ -201,7 +206,7 @@ describe("what the catalogue publishes for a record whose product is unnamed", (
 
   it("keeps the records that name nobody at all on the older outcome", () => {
     const nobody = offers.filter((offer) => offer.source_check?.outcome === SOURCE_CHECK_NOT_NAMED);
-    assertPopulationFloor(nobody.length, 75, "records whose cited page names no part of the vendor");
+    assertPopulationFloor(nobody.length, 1, "records whose cited page names no part of the vendor");
   });
 
   it("belongs to the vocabulary every side of the pipeline shares", () => {


### PR DESCRIPTION
Refs #1465 — shapes 3 and 4 from your comment, and a third of the same shape found by measuring. These are the two tests still red on https://github.com/robhunter/agentdeals/pull/1410; both go green here, on both catalogues.

## What was wrong

| site | wrote | on `main` | on `pm/drop-consumer-media-records` |
| --- | --- | --- | --- |
| `product-named-on-its-page.test.ts:134` | `assertPopulationFloor(exposed.length, 100, …)` | 137 records — headroom allows at most 102 | 132 — fails, exactly the error you diagnosed |
| `function-naming.test.ts:306` | `assert.strictEqual(named.length, 58)` | 58 | 56 — fails |

Reproduced both before changing them, against that branch's `data/index.json`:

```
AssertionError: Expected values to be strictly equal:  actual: 56, expected: 58
AssertionError: a floor of 100 leaves under 25% headroom over the 132 it measured
```

## What they say now

`assertSharesPopulation(observed, population, share, subject)` — the third member of the family, for the case neither of the first two fits. A filtered subset has no total to cover and no count that stays true, but it does have a share of the population it filtered:

- the population is read by a no-argument reader, and `passedPopulationsIn` now scans this call too, so a caller cannot hand over a number;
- the share is held to the same 25% headroom rule, on the rate rather than the count — a share does not drift as the data grows or shrinks, so one set close to what it measures is a tripwire on the filter rather than a guard against it returning nothing;
- an empty population fails rather than passing vacuously, which a `size * share` floor of zero would do silently.

Measured on both trees before choosing either share:

| subject | `main` | #1410 | share set | highest the headroom rule allows |
| --- | --- | --- | --- | --- |
| records whose name restates their host | 137 / 1,573 = 8.71% | 132 / 1,547 = 8.53% | 5% | 6.53% / 6.40% |
| categories publishing a page titled after them | 58 / 65 = 89.2% | 56 / 60 = 93.3% | 60% | 66.9% / 70.0% |

I took the share for shape 3 rather than the set equality you offered, because the two sides you wanted moving together are the same expression — `published.filter(fn => fn.categories.length > 0)` **is** the set of categories holding a page, so the equality would be true by construction. What the line is actually doing is keeping the loop under it non-vacuous, which is shape 4's job exactly. One assertion covers both.

## The third one, found by measuring

`product-named-on-its-page.test.ts:209` floored `not_named` records at 75 against 102 — inside the headroom rule by **1.5 records**, and invisible to the scan because 75 is under the 100 it registers from.

A share is wrong here, and that is the more interesting part. The subject is records whose cited page names no part of the vendor: a class the catalogue is working to empty, and one #1500 deliberately moved records out of last week. Any floor over it — count or share — goes red on the day the reading improves, which is #1090's and #1190's trap rather than this issue's. It now says the class is not empty, which is what its own sibling one describe below already does for the newer outcome (`assert.ok(withheld.length > 0)`). Kept on `assertPopulationFloor` with a floor of 1, so the site stays in the ledger; the headroom rule allows a floor of one by design.

The remaining floor in that file, `checked >= 200` against 611 and 594, is fine and untouched.

## Not closed

The scan reads `assert.ok(… >= N)` for N at or above 100. Shape 3 was `assert.strictEqual(x.length, 58)` — an equality, at 58, so it was invisible on both counts. Every floor of this shape that the scan does catch is now converted, but the scan does not yet catch the equality form, and lowering its threshold to reach 58 would flag fixture assertions. Reported rather than guessed at; if you want that class closed it wants its own measurement of how many equality-on-a-length sites the suite holds and what each is for.

## Verification

Both files green on `main` and on `pm/drop-consumer-media-records`, run with `AGENTDEALS_INDEX_PATH` pointed at that branch's data — which `catalogueOffers()` now honours, so the population reader and `loadOffers()` cannot read different catalogues in the same run. `population-floor.test.ts` gains 7 tests: the share holding as a population shrinks with its subset, failing when the filter collapses while the population stands still, refusing a share too close to what it measured, and failing rather than passing on an empty population. Its fixtures pass their populations through no-argument readers, because the scan reads this file too.