### PR TITLE
Sort the re-read queue on the day we looked, not on the day a read failed

### DIFF
--- a/scripts/mutate-1513.mjs
+++ b/scripts/mutate-1513.mjs
@@ -1,0 +1,76 @@
+import { readFileSync, writeFileSync } from "node:fs";
+import { execFileSync } from "node:child_process";
+
+const SUITE = [
+  "test/reverify-rolling.test.ts",
+  "test/change-refusals.test.ts",
+  "test/verification-state.test.ts",
+  "test/verification-quarantine-surface.test.ts",
+];
+
+const ROLLING = "scripts/reverify-rolling.js";
+const STATE = "scripts/verification-state.js";
+
+const MUTANTS = [
+  ["the-check-counts-only-when-it-failed", ROLLING,
+    `  const dates = [
+    offer?.verifiedDate,
+    offer?.source_check?.checked,`,
+    `  const dates = [
+    offer?.verifiedDate,
+    holdsVerifiedDate(offer?.source_check?.outcome) ? offer?.source_check?.checked : null,`],
+  ["the-check-never-counts", ROLLING,
+    `    offer?.source_check?.checked,
+    refusedOn,`,
+    `    refusedOn,`],
+  ["same-age-order-ignores-whether-the-read-answered", ROLLING,
+    `  const byAge = (a, b) => a.ts - b.ts || Number(b.readFailed) - Number(a.readFailed);`,
+    `  const byAge = (a, b) => a.ts - b.ts;`],
+  ["an-answered-read-goes-first-among-equals", ROLLING,
+    `  const byAge = (a, b) => a.ts - b.ts || Number(b.readFailed) - Number(a.readFailed);`,
+    `  const byAge = (a, b) => a.ts - b.ts || Number(a.readFailed) - Number(b.readFailed);`],
+  ["the-read-outcome-outranks-the-date", ROLLING,
+    `  const byAge = (a, b) => a.ts - b.ts || Number(b.readFailed) - Number(a.readFailed);`,
+    `  const byAge = (a, b) => Number(b.readFailed) - Number(a.readFailed) || a.ts - b.ts;`],
+  ["the-batch-count-ignores-the-read-outcome", ROLLING,
+    `    pickedAfterAFailedRead: drawn.filter((entry) => entry.readFailed).length,`,
+    `    pickedAfterAFailedRead: drawn.length,`],
+  ["every-record-reads-as-a-failed-read", STATE,
+    `  return Boolean(record) && !ANSWERED_OUTCOMES.has(record.last_outcome);`,
+    `  return Boolean(record);`],
+  ["a-record-nobody-has-read-reads-as-a-failed-read", STATE,
+    `  return Boolean(record) && !ANSWERED_OUTCOMES.has(record.last_outcome);`,
+    `  return !ANSWERED_OUTCOMES.has(record?.last_outcome);`],
+  ["a-page-we-could-not-use-counts-as-answered", STATE,
+    `export const ANSWERED_OUTCOMES = new Set([
+  ATTEMPT_CONFIRMED,`,
+    `export const ANSWERED_OUTCOMES = new Set([
+  ATTEMPT_SOURCE_UNUSABLE,
+  ATTEMPT_CONFIRMED,`],
+];
+
+function run(cmd, args) {
+  try {
+    execFileSync(cmd, args, { stdio: "pipe", encoding: "utf-8" });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+const survivors = [];
+for (const [name, file, from, to] of MUTANTS) {
+  const original = readFileSync(file, "utf-8");
+  if (!original.includes(from)) {
+    console.log(`SKIP  ${name} — the line it mutates is not in ${file}`);
+    survivors.push(`${name} (not applied)`);
+    continue;
+  }
+  writeFileSync(file, original.replace(from, to));
+  const green = run("node", ["--test", "--test-concurrency", "1", ...SUITE]);
+  writeFileSync(file, original);
+  console.log(`${green ? "SURVIVED" : "killed  "}  ${name}`);
+  if (green) survivors.push(name);
+}
+console.log(`\n${MUTANTS.length - survivors.length}/${MUTANTS.length} killed`);
+if (survivors.length > 0) console.log("survivors:", survivors.join(", "));

--- a/scripts/reverify-rolling.js
+++ b/scripts/reverify-rolling.js
@@ -46,6 +46,7 @@ import {
   classifyFetchError,
   failureCategoryCounts,
   isQuarantined,
+  lastReadFailed,
   pruneToOffers,
   quarantineRetryDue,
   quarantinedRecords,
@@ -65,9 +66,12 @@ const STAGGER_WINDOW_DAYS = 3;
 const QUARANTINE_RETRY_SHARE = 0.2;
 
 export function lastAttemptedDate(offer, refusedOn = null, verificationRecord = null) {
-  const check = offer?.source_check;
-  const held = check && holdsVerifiedDate(check.outcome) ? check.checked : null;
-  const dates = [offer?.verifiedDate, held, refusedOn, verificationRecord?.last_attempt_at].filter(Boolean);
+  const dates = [
+    offer?.verifiedDate,
+    offer?.source_check?.checked,
+    refusedOn,
+    verificationRecord?.last_attempt_at,
+  ].filter(Boolean);
   return dates.length > 0 ? dates.sort().pop() : null;
 }
 
@@ -84,9 +88,9 @@ export function pickOldestEntries(offers, limit, now = new Date(), options = {})
     const record = state.get(key) ?? null;
     const attempted = lastAttemptedDate(offer, holds.get(key), record);
     const ts = attempted ? new Date(attempted).getTime() : 0;
-    return { index, offer, record, ts };
+    return { index, offer, record, ts, readFailed: lastReadFailed(record) };
   });
-  const byAge = (a, b) => a.ts - b.ts;
+  const byAge = (a, b) => a.ts - b.ts || Number(b.readFailed) - Number(a.readFailed);
   const active = entries.filter((entry) => !isQuarantined(entry.record)).sort(byAge);
   const dueRetries = entries
     .filter((entry) => isQuarantined(entry.record) && quarantineRetryDue(entry.record, today))
@@ -97,15 +101,15 @@ export function pickOldestEntries(offers, limit, now = new Date(), options = {})
   const spare = limit - retries.length - fromActive.length;
   const extraRetries = spare > 0 ? dueRetries.slice(retries.length, retries.length + spare) : [];
 
-  const picked = [...retries, ...extraRetries, ...fromActive]
-    .sort(byAge)
-    .map(({ index, offer }) => ({ index, offer }));
+  const drawn = [...retries, ...extraRetries, ...fromActive].sort(byAge);
+  const picked = drawn.map(({ index, offer }) => ({ index, offer }));
   const remaining = active.slice(fromActive.length);
   const oldestRemaining = remaining.length > 0
     ? (remaining[0].offer.verifiedDate || null)
     : null;
   return {
     picked,
+    pickedAfterAFailedRead: drawn.filter((entry) => entry.readFailed).length,
     oldestRemaining,
     retriedFromQuarantine: retries.length + extraRetries.length,
     quarantineDue: dueRetries.length,
@@ -368,8 +372,12 @@ export function quarantineLines(quarantine) {
   return lines;
 }
 
-export function summaryLines(result, { useAi, checked, oldestRemaining, total, quarantine, repicked }) {
-  const lines = ["", "── Summary ──", `Checked: ${checked}`, `Verified (date bumped): ${result.verified}`];
+export function summaryLines(result, { useAi, checked, oldestRemaining, total, quarantine, repicked, pickedAfterAFailedRead }) {
+  const lines = ["", "── Summary ──", `Checked: ${checked}`];
+  if (pickedAfterAFailedRead !== undefined) {
+    lines.push(`Drawn after a read that failed: ${pickedAfterAFailedRead} of ${checked}`);
+  }
+  lines.push(`Verified (date bumped): ${result.verified}`);
   if (useAi) {
     lines.push(`Changed (PM review needed): ${result.changed}`);
     const refusals = rejectionCounts(result.rejected ?? []);
@@ -455,7 +463,7 @@ async function main() {
   }
 
   const selection = { refusalHolds: holds, verificationState: state };
-  const { picked, oldestRemaining, retriedFromQuarantine } = pickOldestEntries(offers, limit, now, selection);
+  const { picked, oldestRemaining, retriedFromQuarantine, pickedAfterAFailedRead } = pickOldestEntries(offers, limit, now, selection);
 
   console.log(
     `Rolling re-verification — ${picked.length} oldest entries` +
@@ -510,6 +518,7 @@ async function main() {
     total: offers.length,
     quarantine,
     repicked,
+    pickedAfterAFailedRead,
   })) {
     console.log(line);
   }

--- a/scripts/verification-state.js
+++ b/scripts/verification-state.js
@@ -122,6 +122,10 @@ export function applyAttempt(previous, attempt) {
   };
 }
 
+export function lastReadFailed(record) {
+  return Boolean(record) && !ANSWERED_OUTCOMES.has(record.last_outcome);
+}
+
 export function isQuarantined(record) {
   return Boolean(record?.quarantined_since);
 }

--- a/test/reverify-rolling.test.ts
+++ b/test/reverify-rolling.test.ts
@@ -23,6 +23,12 @@ const {
   QUARANTINE_RETRY_DAYS,
   recordAttempts,
 } = await import("../scripts/verification-state.js");
+const {
+  SOURCE_CHECK_OK,
+  SOURCE_CHECK_NO_TERMS,
+  SOURCE_CHECK_UNREADABLE,
+  SOURCE_CHECK_OUTCOMES,
+} = await import("../scripts/vendor-naming.js");
 
 describe("rolling re-verification", () => {
   describe("pickOldestEntries", () => {
@@ -367,5 +373,105 @@ describe("the run summary says whether the queue moved", () => {
   it("says nothing about quarantine when the run reported none", () => {
     const lines = summaryLines(result, base);
     assert.ok(!lines.some((l: string) => l.includes("quarantine")), lines.join("\n"));
+  });
+});
+
+describe("a read that failed buys the record no reprieve", () => {
+  const NOW = new Date("2026-09-02T10:00:00Z");
+  const CONFIRMED_ON = "2026-07-05";
+  const READ_ON = "2026-09-02";
+
+  function offer(vendor: string, outcome: string | null, verifiedDate = CONFIRMED_ON) {
+    const url = `https://${vendor.toLowerCase()}.example/pricing`;
+    const base: any = { vendor, url, verifiedDate, description: `${vendor} free tier` };
+    if (outcome) base.source_check = { outcome, checked: READ_ON, detail: `${vendor} read` };
+    return base;
+  }
+
+  function stateOf(rows: Array<{ vendor: string; outcome: string }>, at = NOW) {
+    const state = new Map();
+    for (const row of rows) {
+      recordAttempts(state, [{ vendor: row.vendor, url: `https://${row.vendor.toLowerCase()}.example/pricing`, outcome: row.outcome }], at);
+    }
+    return state;
+  }
+
+  it("counts the day we read the page whatever the read found", () => {
+    for (const outcome of SOURCE_CHECK_OUTCOMES) {
+      assert.strictEqual(
+        lastAttemptedDate(offer("Read", outcome)),
+        READ_ON,
+        `a check that returned ${outcome} is a day we looked at the page`,
+      );
+    }
+  });
+
+  it("gives the same queue date to a page we could not read as to one we could", () => {
+    const unreadable = lastAttemptedDate(offer("Unreadable", SOURCE_CHECK_UNREADABLE));
+    const read = lastAttemptedDate(offer("Read", SOURCE_CHECK_OK));
+    assert.strictEqual(unreadable, read);
+  });
+
+  it("lets the check's outcome decide nothing about which of two same-day reads goes first", () => {
+    const unreadable = offer("Unreadable", SOURCE_CHECK_UNREADABLE);
+    const read = offer("Read", SOURCE_CHECK_OK);
+    for (const pair of [[unreadable, read], [read, unreadable]]) {
+      const { picked } = pickOldestEntries(pair, 1, NOW);
+      assert.strictEqual(picked[0].offer.vendor, pair[0].vendor);
+    }
+  });
+
+  it("places no record whose last read failed behind one of the same age whose read answered", () => {
+    const rows = [];
+    for (let i = 0; i < 24; i++) {
+      rows.push({ vendor: `Vendor${i}`, answered: i % 2 === 0 });
+    }
+    const offers = rows.map((row) => offer(row.vendor, SOURCE_CHECK_OK));
+    const state = stateOf(rows.map((row) => ({
+      vendor: row.vendor,
+      outcome: row.answered ? ATTEMPT_CONFIRMED : ATTEMPT_SOURCE_UNUSABLE,
+    })));
+    const { picked } = pickOldestEntries(offers, offers.length, NOW, { verificationState: state });
+    const answeredBy = new Map(rows.map((row) => [row.vendor, row.answered]));
+    const order = picked.map((entry: any) => entry.offer.vendor);
+    const failedPlaces = order.map((v: string, i: number) => (answeredBy.get(v) ? -1 : i)).filter((i: number) => i >= 0);
+    const answeredPlaces = order.map((v: string, i: number) => (answeredBy.get(v) ? i : -1)).filter((i: number) => i >= 0);
+    assert.strictEqual(failedPlaces.length + answeredPlaces.length, rows.length);
+    assert.ok(
+      Math.max(...failedPlaces) < Math.min(...answeredPlaces),
+      `a record read on ${READ_ON} without an answer sits behind one that answered: ${order.join(", ")}`,
+    );
+  });
+
+  it("still puts an older record ahead of a newer one whose read failed", () => {
+    const older = offer("Older", SOURCE_CHECK_OK, "2026-06-01");
+    delete older.source_check;
+    const newer = offer("Newer", SOURCE_CHECK_NO_TERMS);
+    const state = stateOf([{ vendor: "Newer", outcome: ATTEMPT_SOURCE_UNUSABLE }]);
+    const { picked } = pickOldestEntries([newer, older], 1, NOW, { verificationState: state });
+    assert.strictEqual(picked[0].offer.vendor, "Older");
+  });
+
+  it("does not read a record nobody has attempted yet as one whose read failed", () => {
+    const answered = offer("Answered", SOURCE_CHECK_OK);
+    const unattempted = offer("Unattempted", SOURCE_CHECK_OK);
+    const state = stateOf([{ vendor: "Answered", outcome: ATTEMPT_CONFIRMED }]);
+    for (const pair of [[answered, unattempted], [unattempted, answered]]) {
+      const { picked, pickedAfterAFailedRead } = pickOldestEntries(pair, 2, NOW, { verificationState: state });
+      assert.strictEqual(pickedAfterAFailedRead, 0);
+      assert.strictEqual(picked[0].offer.vendor, pair[0].vendor);
+    }
+  });
+
+  it("counts how much of the batch it drew after a read that failed", () => {
+    const rows = [
+      { vendor: "Answered", outcome: ATTEMPT_CONFIRMED },
+      { vendor: "Unusable", outcome: ATTEMPT_SOURCE_UNUSABLE },
+      { vendor: "Unfetched", outcome: ATTEMPT_FETCH_FAILED },
+    ];
+    const offers = rows.map((row) => offer(row.vendor, SOURCE_CHECK_OK));
+    const { picked, pickedAfterAFailedRead } = pickOldestEntries(offers, 3, NOW, { verificationState: stateOf(rows) });
+    assert.strictEqual(picked.length, 3);
+    assert.strictEqual(pickedAfterAFailedRead, 2);
   });
 });


### PR DESCRIPTION
The queue key read the source check's date **only when the check had failed**. `holdsVerifiedDate` — a predicate for deciding whether to publish a verified date — was answering a different question: when did we last look at this. A check that returned `ok` contributed nothing to the key; a check that failed contributed today.

597 records in the catalogue have their queue position set by a check that told us nothing, and 578 of them gained exactly five days from it on 2026-09-02.

## What changed

`lastAttemptedDate` now counts `source_check.checked` whatever the check found, and consults no outcome predicate at all.

Among records last looked at on the same day, one whose last read failed is ordered ahead of one whose last read answered. Without that, a same-age tie was broken by catalogue array order, and 752 records were placed behind a same-age record that had answered. That count is now 0.

The tie-break reads the verification state's own record of what a read returned (`ANSWERED_OUTCOMES`), not the publishing predicate — the two questions stay separate.

The run prints `Drawn after a read that failed: N of M`, so the share can be watched rather than measured by hand.

## What this does to the daily run

Simulated forward from the live catalogue at 75 a day, assuming a record whose stored check failed fails again — which a 60-record live sample supports, 0 of 60 re-judged usable:

| run | drawn after a read that failed |
| --- | --- |
| 1 | 65 of 75 |
| 2-5 | 0 to 16 of 75 |
| 6-14 | 75 of 75 |
| 15 | 43 of 75 |
| 16 | 13 of 75 |

That is the 597 being read in queue order instead of skipped, and it is concentration rather than extra work: over a full pass of the catalogue the same records are read either way. The concentration comes from 754 records sharing one date — the tie this tie-break orders. Before it, that order was the order they happen to sit in `index.json`.

**Quarantine does not absorb them, and I expected it to.** Three *consecutive* failures means three successive draws, and a record goes to the back of the queue after each one, so the fuse is three passes of the catalogue — about 60 days at 75 a day, not three runs. Quarantine holds flat at 63 across all 16 simulated runs. Named on the issue.

Suite 4,913 of 4,913. 9 mutants, 9 killed (`scripts/mutate-1513.mjs`). Ran end to end against the live catalogue in dry-run URL mode: 8 of 8 drawn after a failed read, 0 checked again on the next run, nothing written.

Refs #1513