### PR TITLE
Score a page that states no price as a reading, not a read that failed (#1515)

### DIFF
--- a/scripts/mutate-1515.mjs
+++ b/scripts/mutate-1515.mjs
@@ -1,0 +1,101 @@
+import { readFileSync, writeFileSync } from "node:fs";
+import { execFileSync } from "node:child_process";
+
+const SUITE = [
+  "test/no-price-on-the-page-is-a-reading.test.ts",
+  "test/reverify-rolling.test.ts",
+  "test/verification-state.test.ts",
+  "test/verification-quarantine-surface.test.ts",
+  "test/vendor-naming.test.ts",
+];
+
+const ROLLING = "scripts/reverify-rolling.js";
+const STATE = "scripts/verification-state.js";
+const NAMING = "scripts/vendor-naming.js";
+
+const MUTANTS = [
+  ["a-silent-page-is-a-failed-read-again", STATE,
+    `export const ANSWERED_OUTCOMES = new Set([
+  ATTEMPT_CONFIRMED,
+  ATTEMPT_CHANGED,
+  ATTEMPT_LINK_OK,
+  ATTEMPT_STATES_NO_PRICE,
+]);`,
+    `export const ANSWERED_OUTCOMES = new Set([
+  ATTEMPT_CONFIRMED,
+  ATTEMPT_CHANGED,
+  ATTEMPT_LINK_OK,
+]);`],
+  ["only-the-page-with-no-free-tier-phrase-is-silent", STATE,
+    `  [SOURCE_CHECK_NO_TERMS, ATTEMPT_STATES_NO_PRICE],
+  [SOURCE_CHECK_NO_AMOUNT, ATTEMPT_STATES_NO_PRICE],`,
+    `  [SOURCE_CHECK_NO_TERMS, ATTEMPT_STATES_NO_PRICE],
+  [SOURCE_CHECK_NO_AMOUNT, ATTEMPT_LINK_OK],`],
+  ["a-page-that-names-somebody-else-counts-as-silence", STATE,
+    `  [SOURCE_CHECK_NOT_NAMED, ATTEMPT_SOURCE_UNUSABLE],`,
+    `  [SOURCE_CHECK_NOT_NAMED, ATTEMPT_STATES_NO_PRICE],`],
+  ["a-page-we-could-not-fetch-counts-as-silence", STATE,
+    `  [SOURCE_CHECK_UNREADABLE, ATTEMPT_FETCH_FAILED],`,
+    `  [SOURCE_CHECK_UNREADABLE, ATTEMPT_STATES_NO_PRICE],`],
+  ["a-pass-that-recorded-nothing-still-clears-a-failure", STATE,
+    `  if (!check?.checked || !checkRecordedAFinding(check)) return null;`,
+    `  if (!check?.checked) return null;`],
+  ["an-older-reading-clears-a-failure", STATE,
+    `  if (record?.last_attempt_at && check.checked <= record.last_attempt_at) return null;`,
+    `  if (record?.last_attempt_at && check.checked < record.last_attempt_at) return null;`],
+  ["a-later-reading-that-failed-clears-the-failure-too", STATE,
+    `    if (!reading || !ANSWERED_OUTCOMES.has(reading.outcome)) continue;`,
+    `    if (!reading) continue;`],
+  ["clearing-runs-over-records-whose-last-read-answered", STATE,
+    `    if (!record || !lastReadFailed(record)) continue;`,
+    `    if (!record) continue;`],
+  ["the-forecast-counts-the-attempt-rather-than-the-reading", STATE,
+    `    const latest = attemptForSourceCheck(offer?.source_check?.outcome) ?? record.last_outcome;`,
+    `    const latest = record.last_outcome;`],
+  ["the-free-tier-phrase-decides-the-attempt-again", ROLLING,
+    `    const readAPageAboutThisOffer = sourceOk || statesNoPrice;`,
+    `    const readAPageAboutThisOffer = sourceOk;`],
+  ["a-silent-page-the-model-could-not-read-is-undecided-again", ROLLING,
+    `    } else if (statesNoPrice) {
+      recorder.note(offer, ATTEMPT_STATES_NO_PRICE, check.detail);
+    } else {`,
+    `    } else if (false) {
+      recorder.note(offer, ATTEMPT_STATES_NO_PRICE, check.detail);
+    } else {`],
+  ["url-mode-calls-a-silent-page-unusable-again", ROLLING,
+    `        if (statesNoPrice) recorder.note(offer, ATTEMPT_STATES_NO_PRICE, check.detail);
+        else recorder.note(offer, ATTEMPT_SOURCE_UNUSABLE, check.detail, FAILURE_SOURCE_UNUSABLE);`,
+    `        recorder.note(offer, ATTEMPT_SOURCE_UNUSABLE, check.detail, FAILURE_SOURCE_UNUSABLE);`],
+  ["a-naming-layer-reads-as-a-finding", NAMING,
+    `  return !NAMING_LAYERS_RECORDED_INSTEAD_OF_A_FINDING.includes(detail);`,
+    `  return true;`],
+  ["an-empty-detail-reads-as-a-finding", NAMING,
+    `  if (detail === "") return false;`,
+    `  if (detail === "") return true;`],
+];
+
+function run(cmd, args) {
+  try {
+    execFileSync(cmd, args, { stdio: "pipe", encoding: "utf-8" });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+const survivors = [];
+for (const [name, file, from, to] of MUTANTS) {
+  const original = readFileSync(file, "utf-8");
+  if (!original.includes(from)) {
+    console.log(`SKIP  ${name} — the line it mutates is not in ${file}`);
+    survivors.push(`${name} (not applied)`);
+    continue;
+  }
+  writeFileSync(file, original.replace(from, to));
+  const green = run("node", ["--test", "--test-concurrency", "1", ...SUITE]);
+  writeFileSync(file, original);
+  console.log(`${green ? "SURVIVED" : "killed  "}  ${name}`);
+  if (green) survivors.push(name);
+}
+console.log(`\n${MUTANTS.length - survivors.length}/${MUTANTS.length} killed`);
+if (survivors.length > 0) console.log("survivors:", survivors.join(", "));

--- a/scripts/reverify-rolling.js
+++ b/scripts/reverify-rolling.js
@@ -35,6 +35,7 @@ import {
   ATTEMPT_FETCH_FAILED,
   ATTEMPT_LINK_OK,
   ATTEMPT_SOURCE_UNUSABLE,
+  ATTEMPT_STATES_NO_PRICE,
   ATTEMPT_UNCLEAR,
   FAILURE_AI_EXTRACTION,
   FAILURE_AI_UNDECIDED,
@@ -44,9 +45,12 @@ import {
   QUARANTINE_RETRY_DAYS,
   backfillVerificationState,
   classifyFetchError,
+  clearFailuresALaterReadingAnswered,
+  failedReadingCensus,
   failureCategoryCounts,
   isQuarantined,
   lastReadFailed,
+  pageStatesNoPrice,
   pruneToOffers,
   quarantineRetryDue,
   quarantinedRecords,
@@ -186,14 +190,17 @@ export async function runUrlMode(picked, data, dryRun, now, options = {}) {
       const offer = byIndex.get(v.index);
       const page = await fetchFn(offer.url);
       const check = applySourceCheck(offer, v.index, page, data, dryRun, now, sourceChecks);
+      const statesNoPrice = pageStatesNoPrice(check.outcome);
       if (holdsVerifiedDate(check.outcome)) {
-        recorder.note(offer, ATTEMPT_SOURCE_UNUSABLE, check.detail, FAILURE_SOURCE_UNUSABLE);
+        if (statesNoPrice) recorder.note(offer, ATTEMPT_STATES_NO_PRICE, check.detail);
+        else recorder.note(offer, ATTEMPT_SOURCE_UNUSABLE, check.detail, FAILURE_SOURCE_UNUSABLE);
         continue;
       }
       if (!dryRun) {
         data.offers[v.index].verifiedDate = staggeredDate(now);
       }
-      recorder.note(offer, ATTEMPT_LINK_OK);
+      if (statesNoPrice) recorder.note(offer, ATTEMPT_STATES_NO_PRICE, check.detail);
+      else recorder.note(offer, ATTEMPT_LINK_OK);
       verified++;
     }
     for (const f of results.flagged) {
@@ -250,12 +257,16 @@ export async function runAiMode(picked, data, dryRun, now, options = {}) {
       await sleep(rateLimitMs);
       continue;
     }
-    if (!sourceOk) {
+    const statesNoPrice = pageStatesNoPrice(check.outcome);
+    const readAPageAboutThisOffer = sourceOk || statesNoPrice;
+    if (!readAPageAboutThisOffer) {
       recorder.note(offer, ATTEMPT_SOURCE_UNUSABLE, check.detail, FAILURE_SOURCE_UNUSABLE);
     } else if (result.status === "confirmed") {
       recorder.note(offer, ATTEMPT_CONFIRMED);
     } else if (result.status === "changed") {
       recorder.note(offer, ATTEMPT_CHANGED);
+    } else if (statesNoPrice) {
+      recorder.note(offer, ATTEMPT_STATES_NO_PRICE, check.detail);
     } else {
       recorder.note(offer, ATTEMPT_UNCLEAR, result.summary ?? null, FAILURE_AI_UNDECIDED);
     }
@@ -372,7 +383,17 @@ export function quarantineLines(quarantine) {
   return lines;
 }
 
-export function summaryLines(result, { useAi, checked, oldestRemaining, total, quarantine, repicked, pickedAfterAFailedRead }) {
+export function failedReadingLines(census) {
+  if (!census) return [];
+  return [
+    `Records whose last reading did not answer: ${census.failed} of ${census.total}`,
+    `Records whose reading would not answer if we repeated it today, so bound for quarantine ` +
+      `within ${QUARANTINE_AFTER_FAILURES} passes: ${census.readAgainWouldFail}`,
+    `In quarantine now: ${census.quarantined}`,
+  ];
+}
+
+export function summaryLines(result, { useAi, checked, oldestRemaining, total, quarantine, repicked, pickedAfterAFailedRead, failedReadings }) {
   const lines = ["", "── Summary ──", `Checked: ${checked}`];
   if (pickedAfterAFailedRead !== undefined) {
     lines.push(`Drawn after a read that failed: ${pickedAfterAFailedRead} of ${checked}`);
@@ -413,6 +434,7 @@ export function summaryLines(result, { useAi, checked, oldestRemaining, total, q
   lines.push(`Publishing a price in markup the page never renders: ${sourceChecks.get(UNRENDERED) ?? 0}`);
   lines.push(`Flagged (URL/AI failure): ${result.flagged}`);
   for (const line of quarantineLines(quarantine)) lines.push(line);
+  for (const line of failedReadingLines(failedReadings)) lines.push(line);
   if (repicked !== undefined) {
     lines.push(`Checked again on the next run: ${repicked} of ${checked}`);
   }
@@ -451,6 +473,13 @@ async function main() {
   const seeded = backfillVerificationState(state, offers, { linkHealth: readLinkHealth() });
   if (seeded.length > 0) {
     console.log(`Seeded verification state for ${seeded.length} offer(s) from their recorded source check.`);
+  }
+  const answeredSince = clearFailuresALaterReadingAnswered(state, offers);
+  if (answeredSince.cleared.length > 0) {
+    console.log(
+      `Cleared a stale failure on ${answeredSince.cleared.length} offer(s) whose page has been read since, ` +
+        `${answeredSince.left.length} of them out of quarantine.`
+    );
   }
   if (args.includes("--seed-state")) {
     const written = writeVerificationState(state, { dryRun, now });
@@ -519,6 +548,7 @@ async function main() {
     quarantine,
     repicked,
     pickedAfterAFailedRead,
+    failedReadings: failedReadingCensus(state, offers),
   })) {
     console.log(line);
   }

--- a/scripts/vendor-naming.js
+++ b/scripts/vendor-naming.js
@@ -120,6 +120,14 @@ const MIN_HOST_PREFIX = 4;
 export const NAMED_IN_PAGE_TEXT = "text";
 export const NAMED_BY_A_HOST_THE_PAGE_WRITES = "host_in_text";
 
+export const NAMING_LAYERS_RECORDED_INSTEAD_OF_A_FINDING = [NAMED_IN_PAGE_TEXT, "url", "host"];
+
+export function checkRecordedAFinding(check) {
+  const detail = (check?.detail ?? "").trim();
+  if (detail === "") return false;
+  return !NAMING_LAYERS_RECORDED_INSTEAD_OF_A_FINDING.includes(detail);
+}
+
 function hostLabelMatchesVendor(label, vendor, aliases) {
   for (const form of shortNameForms(vendor, aliases)) {
     if (label === form) return true;

--- a/scripts/verification-state.js
+++ b/scripts/verification-state.js
@@ -6,7 +6,13 @@ import { fileURLToPath } from "node:url";
 import { isoDay } from "./change-log.js";
 import { offerKey } from "./change-refusals.js";
 import {
+  checkRecordedAFinding,
   holdsVerifiedDate,
+  SOURCE_CHECK_NO_AMOUNT,
+  SOURCE_CHECK_NO_TERMS,
+  SOURCE_CHECK_NOT_NAMED,
+  SOURCE_CHECK_NOT_THE_PRODUCT,
+  SOURCE_CHECK_OK,
   SOURCE_CHECK_UNREADABLE,
 } from "./vendor-naming.js";
 
@@ -22,11 +28,13 @@ export const ATTEMPT_SOURCE_UNUSABLE = "source_unusable";
 export const ATTEMPT_UNCLEAR = "unclear";
 export const ATTEMPT_FETCH_FAILED = "fetch_failed";
 export const ATTEMPT_AI_ERROR = "ai_error";
+export const ATTEMPT_STATES_NO_PRICE = "states_no_price";
 
 export const ATTEMPT_OUTCOMES = [
   ATTEMPT_CONFIRMED,
   ATTEMPT_CHANGED,
   ATTEMPT_LINK_OK,
+  ATTEMPT_STATES_NO_PRICE,
   ATTEMPT_SOURCE_UNUSABLE,
   ATTEMPT_UNCLEAR,
   ATTEMPT_FETCH_FAILED,
@@ -37,7 +45,25 @@ export const ANSWERED_OUTCOMES = new Set([
   ATTEMPT_CONFIRMED,
   ATTEMPT_CHANGED,
   ATTEMPT_LINK_OK,
+  ATTEMPT_STATES_NO_PRICE,
 ]);
+
+const ATTEMPT_FOR_SOURCE_CHECK = new Map([
+  [SOURCE_CHECK_OK, ATTEMPT_LINK_OK],
+  [SOURCE_CHECK_NO_TERMS, ATTEMPT_STATES_NO_PRICE],
+  [SOURCE_CHECK_NO_AMOUNT, ATTEMPT_STATES_NO_PRICE],
+  [SOURCE_CHECK_NOT_NAMED, ATTEMPT_SOURCE_UNUSABLE],
+  [SOURCE_CHECK_NOT_THE_PRODUCT, ATTEMPT_SOURCE_UNUSABLE],
+  [SOURCE_CHECK_UNREADABLE, ATTEMPT_FETCH_FAILED],
+]);
+
+export function attemptForSourceCheck(outcome) {
+  return ATTEMPT_FOR_SOURCE_CHECK.get(outcome) ?? null;
+}
+
+export function pageStatesNoPrice(outcome) {
+  return attemptForSourceCheck(outcome) === ATTEMPT_STATES_NO_PRICE;
+}
 
 export const FAILURE_BOT_BLOCK = "bot_block";
 export const FAILURE_UNREACHABLE = "unreachable";
@@ -124,6 +150,53 @@ export function applyAttempt(previous, attempt) {
 
 export function lastReadFailed(record) {
   return Boolean(record) && !ANSWERED_OUTCOMES.has(record.last_outcome);
+}
+
+export function readingSinceTheAttempt(record, offer) {
+  const check = offer?.source_check;
+  if (!check?.checked || !checkRecordedAFinding(check)) return null;
+  if (record?.last_attempt_at && check.checked <= record.last_attempt_at) return null;
+  const outcome = attemptForSourceCheck(check.outcome);
+  return outcome ? { date: check.checked, outcome, detail: check.detail } : null;
+}
+
+export function clearFailuresALaterReadingAnswered(state, offers) {
+  const cleared = [];
+  const left = [];
+  for (const offer of offers) {
+    const key = offerKey(offer?.vendor, offer?.url);
+    const record = state.get(key);
+    if (!record || !lastReadFailed(record)) continue;
+    const reading = readingSinceTheAttempt(record, offer);
+    if (!reading || !ANSWERED_OUTCOMES.has(reading.outcome)) continue;
+    const next = applyAttempt(record, {
+      vendor: record.vendor,
+      url: record.url,
+      outcome: reading.outcome,
+      date: reading.date,
+    });
+    state.set(key, next);
+    cleared.push(next);
+    if (isQuarantined(record)) left.push(next);
+  }
+  return { cleared, left };
+}
+
+export function failedReadingCensus(state, offers) {
+  let failed = 0;
+  let readAgainWouldFail = 0;
+  let quarantined = 0;
+  let total = 0;
+  for (const offer of offers) {
+    const record = state.get(offerKey(offer?.vendor, offer?.url));
+    if (!record) continue;
+    total++;
+    if (isQuarantined(record)) quarantined++;
+    if (lastReadFailed(record)) failed++;
+    const latest = attemptForSourceCheck(offer?.source_check?.outcome) ?? record.last_outcome;
+    if (!ANSWERED_OUTCOMES.has(latest)) readAgainWouldFail++;
+  }
+  return { failed, readAgainWouldFail, quarantined, total };
 }
 
 export function isQuarantined(record) {

--- a/test/no-price-on-the-page-is-a-reading.test.ts
+++ b/test/no-price-on-the-page-is-a-reading.test.ts
@@ -1,0 +1,400 @@
+import { describe, it } from "node:test";
+import assert from "node:assert";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { assertPopulationFloor } from "./population-floor.ts";
+
+const {
+  ATTEMPT_CHANGED,
+  ATTEMPT_CONFIRMED,
+  ATTEMPT_FETCH_FAILED,
+  ATTEMPT_LINK_OK,
+  ATTEMPT_SOURCE_UNUSABLE,
+  ATTEMPT_STATES_NO_PRICE,
+  ATTEMPT_UNCLEAR,
+  ANSWERED_OUTCOMES,
+  QUARANTINE_AFTER_FAILURES,
+  applyAttempt,
+  attemptForSourceCheck,
+  clearFailuresALaterReadingAnswered,
+  failedReadingCensus,
+  lastReadFailed,
+  pageStatesNoPrice,
+  readingSinceTheAttempt,
+} = await import("../scripts/verification-state.js");
+const { runAiMode, runUrlMode, summaryLines } = await import("../scripts/reverify-rolling.js");
+const {
+  NAMING_LAYERS_RECORDED_INSTEAD_OF_A_FINDING,
+  SOURCE_CHECK_NO_AMOUNT,
+  SOURCE_CHECK_NO_TERMS,
+  SOURCE_CHECK_NOT_NAMED,
+  SOURCE_CHECK_OK,
+  SOURCE_CHECK_OUTCOMES,
+  SOURCE_CHECK_UNREADABLE,
+  checkRecordedAFinding,
+  classifySource,
+} = await import("../scripts/vendor-naming.js");
+const { priceSignals } = await import("../scripts/change-gate.js");
+const { NAMING_TOKENS_RECORDED_INSTEAD_OF_EVIDENCE } = await import("../dist/source-check.js");
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const INDEX_PATH = path.join(__dirname, "..", "data", "index.json");
+const STATE_PATH = path.join(__dirname, "..", "data", "verification_state.json");
+
+const NOW = new Date("2026-09-10T10:00:00Z");
+const TODAY = "2026-09-10";
+
+const SILENT = "Acme Cloud. Object storage for teams. Talk to sales about a plan.";
+const SILENT_AND_FREE = "Acme Cloud. Object storage for teams. Free forever. Talk to sales about a plan.";
+
+function offerFor(vendor: string) {
+  return {
+    vendor,
+    url: `https://${vendor.toLowerCase()}.example/pricing`,
+    description: "Free tier: 10 GB",
+    category: "Storage",
+    verifiedDate: "2026-04-12",
+  };
+}
+
+function pageOf(text: string) {
+  return { ok: true, text, truncated: false };
+}
+
+async function attemptOutcomeInAiMode(text: string, status: string) {
+  const offer = { ...offerFor("Acme"), vendor: "Acme" };
+  const data = { offers: [{ ...offer }] };
+  const result = await runAiMode([{ index: 0, offer }], data, true, NOW, {
+    fetchFn: async () => pageOf(text),
+    verifyFn: async () => ({ status, summary: "the page states no limits", change_type: "limits_reduced", current_state: "Free tier: 5 GB", impact: "medium" }),
+    confirmFn: async () => ({ describes_change: true }),
+    rateLimitMs: 0,
+  });
+  return result.attempts[0];
+}
+
+async function attemptOutcomeInUrlMode(text: string) {
+  const offer = { ...offerFor("Acme"), vendor: "Acme" };
+  const data = { offers: [{ ...offer }] };
+  const result = await runUrlMode([{ index: 0, offer }], data, true, NOW, {
+    batchFn: async (batch: any[]) => ({ verified: batch.map((b) => ({ index: b.index })), flagged: [] }),
+    fetchFn: async () => pageOf(text),
+  });
+  return result.attempts[0];
+}
+
+function record(overrides: Record<string, unknown> = {}) {
+  return {
+    vendor: "Acme",
+    url: "https://acme.example/pricing",
+    last_attempt_at: "2026-08-28",
+    last_outcome: ATTEMPT_SOURCE_UNUSABLE,
+    last_error: "the page names Acme but states no amount, tier or rate we can read",
+    failure_category: "source_unusable",
+    consecutive_failures: 1,
+    last_success: "2026-07-07",
+    quarantined_since: null,
+    ...overrides,
+  };
+}
+
+function stateOf(records: Record<string, unknown>[]) {
+  return new Map(records.map((r) => [`${r.vendor}|${r.url}`, r]));
+}
+
+describe("a page our reader finds no price on reads the same whether or not it says the word free", () => {
+  it("grades the two pages differently as source checks, which is the split this rule sits above", () => {
+    const offer = offerFor("Acme");
+    assert.strictEqual(classifySource(offer, pageOf(SILENT), priceSignals(SILENT)).outcome, SOURCE_CHECK_NO_TERMS);
+    assert.strictEqual(
+      classifySource(offer, pageOf(SILENT_AND_FREE), priceSignals(SILENT_AND_FREE)).outcome,
+      SOURCE_CHECK_NO_AMOUNT,
+    );
+  });
+
+  for (const status of ["confirmed", "changed", "unclear"]) {
+    it(`records the same attempt outcome on both pages when the model says ${status}`, async () => {
+      const silent = await attemptOutcomeInAiMode(SILENT, status);
+      const alsoFree = await attemptOutcomeInAiMode(SILENT_AND_FREE, status);
+      assert.strictEqual(silent.outcome, alsoFree.outcome);
+    });
+  }
+
+  it("records the model's verdict where it gave one", async () => {
+    assert.strictEqual((await attemptOutcomeInAiMode(SILENT, "confirmed")).outcome, ATTEMPT_CONFIRMED);
+    assert.strictEqual((await attemptOutcomeInAiMode(SILENT, "changed")).outcome, ATTEMPT_CHANGED);
+  });
+
+  it("records that the page states no price where the model could not answer either", async () => {
+    const attempt = await attemptOutcomeInAiMode(SILENT, "unclear");
+    assert.strictEqual(attempt.outcome, ATTEMPT_STATES_NO_PRICE);
+    assert.notStrictEqual(attempt.outcome, ATTEMPT_UNCLEAR);
+  });
+
+  it("records the same attempt outcome on both pages in URL mode, where there is no model", async () => {
+    const silent = await attemptOutcomeInUrlMode(SILENT);
+    const alsoFree = await attemptOutcomeInUrlMode(SILENT_AND_FREE);
+    assert.strictEqual(silent.outcome, ATTEMPT_STATES_NO_PRICE);
+    assert.strictEqual(alsoFree.outcome, ATTEMPT_STATES_NO_PRICE);
+  });
+
+  it("still refuses a page that never names the offer, which is a different finding", async () => {
+    const stranger = { ...offerFor("Acme"), vendor: "Stranger" };
+    const data = { offers: [{ ...stranger }] };
+    const result = await runAiMode([{ index: 0, offer: stranger }], data, true, NOW, {
+      fetchFn: async () => pageOf("A page about something else entirely, priced at $9 per month."),
+      verifyFn: async () => ({ status: "confirmed" }),
+      confirmFn: async () => ({ describes_change: false }),
+      rateLimitMs: 0,
+    });
+    assert.strictEqual(result.attempts[0].outcome, ATTEMPT_SOURCE_UNUSABLE);
+  });
+});
+
+describe("a page that is silent on price is a reading, not a read that failed", () => {
+  it("counts as an answer, so it clears the failure count rather than adding to it", () => {
+    const next = applyAttempt(record({ consecutive_failures: 2 }), {
+      vendor: "Acme",
+      url: "https://acme.example/pricing",
+      outcome: ATTEMPT_STATES_NO_PRICE,
+      date: TODAY,
+    });
+    assert.strictEqual(next.consecutive_failures, 0);
+    assert.strictEqual(next.quarantined_since, null);
+    assert.strictEqual(lastReadFailed(next), false);
+  });
+
+  it("never quarantines a record however many times we read the same silence", () => {
+    let held: any = null;
+    for (let pass = 0; pass < QUARANTINE_AFTER_FAILURES + 2; pass++) {
+      held = applyAttempt(held, {
+        vendor: "Acme",
+        url: "https://acme.example/pricing",
+        outcome: ATTEMPT_STATES_NO_PRICE,
+        date: TODAY,
+      });
+    }
+    assert.strictEqual(held.quarantined_since, null);
+    assert.strictEqual(held.consecutive_failures, 0);
+  });
+
+  it("does not claim we confirmed the offer, so the last confirmation stands where it was", () => {
+    const next = applyAttempt(record(), {
+      vendor: "Acme",
+      url: "https://acme.example/pricing",
+      outcome: ATTEMPT_STATES_NO_PRICE,
+      date: TODAY,
+    });
+    assert.strictEqual(next.last_success, "2026-07-07");
+  });
+
+  it("still counts a page we could not fetch and a page that is about something else", () => {
+    for (const outcome of [ATTEMPT_SOURCE_UNUSABLE, ATTEMPT_FETCH_FAILED, ATTEMPT_UNCLEAR]) {
+      const next = applyAttempt(record({ consecutive_failures: 2 }), {
+        vendor: "Acme",
+        url: "https://acme.example/pricing",
+        outcome,
+        date: TODAY,
+      });
+      assert.strictEqual(next.consecutive_failures, 3, outcome);
+      assert.strictEqual(next.quarantined_since, TODAY, outcome);
+    }
+  });
+});
+
+describe("every source check outcome says which attempt outcome it implies", () => {
+  it("maps each outcome the reader can produce, and none is left to a default", () => {
+    for (const outcome of SOURCE_CHECK_OUTCOMES) {
+      assert.notStrictEqual(attemptForSourceCheck(outcome), null, outcome);
+    }
+  });
+
+  it("puts both of the price-silence outcomes on the same attempt outcome", () => {
+    assert.strictEqual(attemptForSourceCheck(SOURCE_CHECK_NO_TERMS), ATTEMPT_STATES_NO_PRICE);
+    assert.strictEqual(attemptForSourceCheck(SOURCE_CHECK_NO_AMOUNT), ATTEMPT_STATES_NO_PRICE);
+    assert.ok(pageStatesNoPrice(SOURCE_CHECK_NO_TERMS) && pageStatesNoPrice(SOURCE_CHECK_NO_AMOUNT));
+  });
+
+  it("counts a page we could not read and a page that names somebody else as reads that failed", () => {
+    assert.strictEqual(ANSWERED_OUTCOMES.has(attemptForSourceCheck(SOURCE_CHECK_UNREADABLE)), false);
+    assert.strictEqual(ANSWERED_OUTCOMES.has(attemptForSourceCheck(SOURCE_CHECK_NOT_NAMED)), false);
+    assert.strictEqual(attemptForSourceCheck(SOURCE_CHECK_OK), ATTEMPT_LINK_OK);
+  });
+});
+
+describe("when a record has been read again since its attempt was written, the later reading governs", () => {
+  const offer = { ...offerFor("Acme"), source_check: { checked: "2026-09-02", outcome: SOURCE_CHECK_OK, detail: 'the page names Acme as "acme" and states "$0.073"' } };
+
+  it("takes the later reading when it recorded what it found", () => {
+    const reading = readingSinceTheAttempt(record(), offer);
+    assert.strictEqual(reading.date, "2026-09-02");
+    assert.strictEqual(reading.outcome, ATTEMPT_LINK_OK);
+  });
+
+  it("takes nothing from a pass that recorded only which layer matched", () => {
+    for (const token of NAMING_LAYERS_RECORDED_INSTEAD_OF_A_FINDING) {
+      const bare = { ...offer, source_check: { ...offer.source_check, detail: token } };
+      assert.strictEqual(readingSinceTheAttempt(record(), bare), null, token);
+    }
+  });
+
+  it("takes nothing from a reading no newer than the attempt beside it", () => {
+    const older = { ...offer, source_check: { ...offer.source_check, checked: "2026-08-28" } };
+    assert.strictEqual(readingSinceTheAttempt(record(), older), null);
+  });
+
+  it("clears a stale failure and lets the record out of quarantine", () => {
+    const held = record({ consecutive_failures: 4, quarantined_since: "2026-08-28" });
+    const state = stateOf([held]);
+    const { cleared, left } = clearFailuresALaterReadingAnswered(state, [offer]);
+    assert.strictEqual(cleared.length, 1);
+    assert.strictEqual(left.length, 1);
+    const next = state.get(`${held.vendor}|${held.url}`) as any;
+    assert.strictEqual(next.consecutive_failures, 0);
+    assert.strictEqual(next.quarantined_since, null);
+    assert.strictEqual(next.last_attempt_at, "2026-09-02");
+  });
+
+  it("leaves a record whose later reading did not answer either", () => {
+    const unreadable = {
+      ...offer,
+      source_check: { checked: "2026-09-02", outcome: SOURCE_CHECK_UNREADABLE, detail: "page content too short" },
+    };
+    const state = stateOf([record()]);
+    const { cleared } = clearFailuresALaterReadingAnswered(state, [unreadable]);
+    assert.deepStrictEqual(cleared, []);
+    assert.strictEqual((state.get("Acme|https://acme.example/pricing") as any).consecutive_failures, 1);
+  });
+
+  it("leaves a confirmation where it is, rather than replacing it with a later reading", () => {
+    const confirmed = record({
+      last_outcome: ATTEMPT_CONFIRMED,
+      consecutive_failures: 0,
+      failure_category: null,
+      last_error: null,
+    });
+    const silent = {
+      ...offer,
+      source_check: {
+        checked: "2026-09-02",
+        outcome: SOURCE_CHECK_NO_TERMS,
+        detail: "the page names Acme but states no amount, tier or rate we can read",
+      },
+    };
+    const state = stateOf([confirmed]);
+    const { cleared } = clearFailuresALaterReadingAnswered(state, [silent]);
+    assert.deepStrictEqual(cleared, []);
+    assert.strictEqual((state.get("Acme|https://acme.example/pricing") as any).last_outcome, ATTEMPT_CONFIRMED);
+  });
+
+  it("never turns an answer into a failure, whatever the later reading found", () => {
+    const answered = record({ last_outcome: ATTEMPT_CONFIRMED, consecutive_failures: 0, failure_category: null });
+    const unreadable = {
+      ...offer,
+      source_check: { checked: "2026-09-02", outcome: SOURCE_CHECK_UNREADABLE, detail: "page content too short" },
+    };
+    const state = stateOf([answered]);
+    clearFailuresALaterReadingAnswered(state, [unreadable]);
+    assert.strictEqual((state.get("Acme|https://acme.example/pricing") as any).last_outcome, ATTEMPT_CONFIRMED);
+  });
+});
+
+describe("the quarantine forecast counts what a reading would find, not what an attempt recorded", () => {
+  it("counts a record whose attempt answered but whose page we can no longer read", () => {
+    const answered = record({ last_outcome: ATTEMPT_CONFIRMED, consecutive_failures: 0, failure_category: null });
+    const unreadable = {
+      ...offerFor("Acme"),
+      source_check: { checked: "2026-09-02", outcome: SOURCE_CHECK_UNREADABLE, detail: "page content too short" },
+    };
+    const census = failedReadingCensus(stateOf([answered]), [unreadable]);
+    assert.strictEqual(census.failed, 0);
+    assert.strictEqual(census.readAgainWouldFail, 1);
+  });
+
+  it("does not count a record whose stale failure a reading of the page has already answered", () => {
+    const silent = {
+      ...offerFor("Acme"),
+      source_check: {
+        checked: "2026-09-02",
+        outcome: SOURCE_CHECK_NO_TERMS,
+        detail: "the page names Acme but states no amount, tier or rate we can read",
+      },
+    };
+    const census = failedReadingCensus(stateOf([record()]), [silent]);
+    assert.strictEqual(census.failed, 1);
+    assert.strictEqual(census.readAgainWouldFail, 0);
+    assert.strictEqual(census.total, 1);
+  });
+});
+
+describe("a source check that passes says what it found on the page", () => {
+  const passing: [string, Record<string, string>, string][] = [
+    ["a page that names the vendor and states an amount", offerFor("Vercel"), "Vercel Hobby plan, free forever. Pro is $20/month."],
+    ["a page that writes only the domain we cite the vendor from", { ...offerFor("Tutanota"), url: "https://tuta.com/pricing" }, "Tuta — secure email, calendar and contacts. Legend from €3/month."],
+  ];
+
+  for (const [subject, offer, text] of passing) {
+    it(`records a finding rather than a naming layer on ${subject}`, () => {
+      const result = classifySource(offer, pageOf(text), priceSignals(text));
+      assert.strictEqual(result.outcome, SOURCE_CHECK_OK);
+      assert.strictEqual(checkRecordedAFinding(result), true, result.detail);
+    });
+  }
+
+  it("reads a bare naming layer as no finding at all", () => {
+    for (const token of NAMING_LAYERS_RECORDED_INSTEAD_OF_A_FINDING) {
+      assert.strictEqual(checkRecordedAFinding({ outcome: SOURCE_CHECK_OK, detail: token }), false, token);
+    }
+    assert.strictEqual(checkRecordedAFinding({ outcome: SOURCE_CHECK_OK, detail: "" }), false);
+    assert.strictEqual(checkRecordedAFinding(null), false);
+  });
+
+  it("holds the same list of naming layers as the surfaces that publish a finding", () => {
+    assert.deepStrictEqual(
+      [...NAMING_LAYERS_RECORDED_INSTEAD_OF_A_FINDING].sort(),
+      [...NAMING_TOKENS_RECORDED_INSTEAD_OF_EVIDENCE].sort(),
+    );
+  });
+});
+
+describe("what the catalogue reports about readings that did not answer", () => {
+  const offers = JSON.parse(readFileSync(INDEX_PATH, "utf-8")).offers as any[];
+  const records = JSON.parse(readFileSync(STATE_PATH, "utf-8")).records as any[];
+  const state = stateOf(records);
+
+  it("reads a real population, so the rules above are not read against an empty catalogue", () => {
+    assertPopulationFloor(offers.length, 1000, "offers in the catalogue these rules are read against");
+    assertPopulationFloor(records.length, 1000, "verification records these rules are read against");
+  });
+
+  it("clears every stale failure in one pass, so a second pass finds nothing left to clear", () => {
+    clearFailuresALaterReadingAnswered(state, offers);
+    const { cleared } = clearFailuresALaterReadingAnswered(state, offers);
+    assert.deepStrictEqual(cleared, []);
+  });
+
+  it("leaves fewer records reading as failed than it was asked to judge", () => {
+    const census = failedReadingCensus(state, offers);
+    assert.ok(
+      census.failed < census.total,
+      `every one of ${census.total} readings reads as one that did not answer`,
+    );
+  });
+
+  it("puts the count and the quarantine forecast in the summary the run prints", () => {
+    const lines = summaryLines(
+      { verified: 0, flagged: 0, changed: 0, recorded: [], suppressed: [], unclassified: [], sourceChecks: new Map() },
+      {
+        useAi: false,
+        checked: 1,
+        oldestRemaining: null,
+        total: offers.length,
+        failedReadings: { failed: 326, readAgainWouldFail: 279, quarantined: 59, total: 1525 },
+      },
+    );
+    assert.ok(lines.some((line: string) => line === "Records whose last reading did not answer: 326 of 1525"));
+    assert.ok(lines.some((line: string) => line.includes("bound for quarantine within 3 passes: 279")));
+    assert.ok(lines.some((line: string) => line === "In quarantine now: 59"));
+  });
+});


### PR DESCRIPTION
Refs #1515

## What was wrong

Our reader has one finding — *we found no price on this page* — and the pipeline scored it two ways. `states_no_terms` was a failed read for 445 records, `states_no_amount` a successful one for 74, and the only thing separating them is whether the page also carried a free-tier phrase. That is a fact about the page's marketing copy, not about whether our read succeeded.

Since https://github.com/robhunter/agentdeals/pull/1514 that distinction steers the queue and counts toward `QUARANTINE_AFTER_FAILURES`. **815 of 1,525 records** carried a last reading that did not answer.

## AC-1 — the same attempt outcome either way, and which one

`ATTEMPT_FOR_SOURCE_CHECK` maps every outcome the reader can produce to the attempt outcome it implies. Both price-silence outcomes map to `states_no_price`, and a test walks `SOURCE_CHECK_OUTCOMES` so no outcome reaches a default.

In AI mode the free-tier phrase no longer gates the model's verdict: `confirmed` and `changed` are recorded on both pages alike, and where the model cannot answer either, the attempt records `states_no_price`. Three tests run the identical page with and without *"Free forever"* through each of the model's three verdicts and assert the two agree. URL mode, which has no model, records `states_no_price` for both.

**Why that outcome and not a failure:** we fetched the page and read it. What we found is a property of the page. `does_not_name_vendor`, `does_not_name_product` and `unreadable` still fail, because in those cases we did not obtain a page about this offer.

`holdsVerifiedDate` is untouched, so a `states_no_terms` page still holds its `verifiedDate`. This changes what the pipeline *scores*, not what it publishes.

## AC-3 — a stable property of a page is not a failing read

`states_no_price` is in `ANSWERED_OUTCOMES`, so it clears `consecutive_failures` instead of adding to it, and reading the same silence any number of times never quarantines. It is not `confirmed`, so `last_success` stands where it was.

## AC-2 — which reader is authoritative, and the premise that turned out to be wrong

The issue reads the split as two readers disagreeing about one fetch. Measured, they never do.

**In all 90 `ok` / failed-attempt disagreements the source check is the later reading — 69 strictly later, 21 the same day, 0 earlier.** They are one reader at two times: a census script writes a `source_check` into the index without recording an attempt, so the queue steers on the older read.

Both controls confirm it. Run through today's reader against their live pages:

- **CrateDB** → `ok`, *the page names CrateDB as "cratedb" and states "$0.073"*. The stored `ok` detail is the bare token `text`, written before 2026-09-02; the `source_unusable` attempt is from 2026-08-28, an older reader.
- **Meilisearch** → `ok`, *renders no terms we can read, and its markup states 1 typed price (USD 0)* — byte-identical to what is stored. Whether a markup price should let a check pass is https://github.com/robhunter/agentdeals/issues/1285, out of scope here.

So the rule is not a preference: **the later reading governs, and a reading that recorded no finding is not a reading.** `readingSinceTheAttempt` requires the check to be strictly newer than the attempt *and* to have recorded a finding; `clearFailuresALaterReadingAnswered` then clears the stale failure. It only ever clears — it never adds a failure and never replaces an answer, both pinned by tests.

On today's catalogue that clears **490 records** (443 as `states_no_price`, 47 as `link_ok`), 4 of them out of quarantine, and holds back **22** whose later pass recorded only a naming layer.

## AC-4 — the number this issue exists to bound

The run prints it every day:

```
Records whose last reading did not answer: 325 of 1526
Records whose reading would not answer if we repeated it today, so bound for quarantine within 3 passes: 279
In quarantine now: 59
```

**815 → 325** the moment a run reconciles what we already read. Of the whole catalogue, **279** carry a most recent reading that would not answer — 170 pages we cannot fetch and 109 that do not name the offer. That is the population quarantine was built for in https://github.com/robhunter/agentdeals/issues/1020; at 75 a day three passes is roughly 60 days, not three runs.

## AC-5 — a pass records what it found

`classifySource` has recorded findings rather than naming layers since 2026-09-02 (`b849ec0`); the 457 records still carrying `detail: "text"` are residue dated 2026-08-28 to 2026-09-03 and are already ratcheted by the `source_checks_ok_without_quoted_evidence` budget. What is new is that the predicate is now load-bearing: `checkRecordedAFinding` is what stops a token-only pass from clearing a failure, and it holds the same list as the surface that publishes a finding, asserted against `NAMING_TOKENS_RECORDED_INSTEAD_OF_EVIDENCE`.

## Verification

- Suite **4,945 of 4,945**.
- `scripts/mutate-1515.mjs` — **14 mutants, 14 killed**.
- Ran end to end against the live catalogue in dry-run URL mode: the reconciliation cleared 490, quarantine fell 64 → 59, and the three census lines printed.
- AI mode has no verifier key here, so its branch is covered by unit tests with an injected verifier rather than by a live run.
