### PR TITLE
Say what the source check looked for, not that the page said nothing (#1264)

### DIFF
--- a/scripts/mutate-1264.mjs
+++ b/scripts/mutate-1264.mjs
@@ -1,0 +1,65 @@
+import { readFileSync, writeFileSync } from "node:fs";
+import { execFileSync } from "node:child_process";
+
+const SUITE = [
+  "test/withheld-reason-names-what-we-looked-for.test.ts",
+  "test/meta-description-withholding.test.ts",
+  "test/badge-withholding.test.ts",
+  "test/vendor-verdict.test.ts",
+  "test/comparison-verdict.test.ts",
+];
+
+const CHECK = "src/source-check.ts";
+const SERVE = "src/serve.ts";
+
+const MUTANTS = [
+  ["the-old-claim-comes-back", CHECK,
+    `export const NO_PRICE_SIGNAL_PHRASE = "states no amount, tier or rate we can read";`,
+    `export const NO_PRICE_SIGNAL_PHRASE = "states no terms we can read";`],
+  ["the-hedge-is-dropped", CHECK,
+    `export const NO_PRICE_SIGNAL_PHRASE = "states no amount, tier or rate we can read";`,
+    `export const NO_PRICE_SIGNAL_PHRASE = "states no amount, tier or rate";`],
+  ["the-sentence-stops-following-the-clause", CHECK,
+    `  states_no_terms: (subject) => \`The page we cite for \${subject} \${NO_PRICE_SIGNAL_PHRASE}.\`,`,
+    `  states_no_terms: (subject) => \`The page we cite for \${subject} states no terms we can read.\`,`],
+  ["an-agent-is-told-something-else", CHECK,
+    `  states_no_terms: WITHHELD_LEVEL_CLAUSES.states_no_terms(""),`,
+    `  states_no_terms: \`the page we cite for this offer states no terms we can read\`,`],
+  ["another-withheld-reason-drifts", CHECK,
+    `  unreadable: (subject) => \`We could not read the page we cite for \${subject}.\`,`,
+    `  unreadable: (subject) => \`The page we cite for \${subject} states no terms we can read.\`,`],
+  ["a-surface-keeps-its-own-copy", SERVE,
+    `    source_unusable: "the page we cite is not about this offer",`,
+    `    source_unusable: "the page we cite states no terms",`],
+  ["the-badge-keeps-the-old-label", SERVE,
+    `  states_no_terms: "unrated \\u2014 page states no price",`,
+    `  states_no_terms: "unrated \\u2014 page states no terms",`],
+];
+
+function run(cmd, args) {
+  try {
+    execFileSync(cmd, args, { stdio: "pipe", encoding: "utf-8" });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+const survivors = [];
+for (const [name, file, from, to] of MUTANTS) {
+  const original = readFileSync(file, "utf-8");
+  if (!original.includes(from)) {
+    console.log(`SKIP  ${name} — the line it mutates is not in ${file}`);
+    survivors.push(`${name} (not applied)`);
+    continue;
+  }
+  writeFileSync(file, original.replace(from, to));
+  const built = run("npx", ["tsc"]);
+  const green = built && run("node", ["--test", "--test-concurrency", "1", ...SUITE]);
+  writeFileSync(file, original);
+  console.log(`${green ? "SURVIVED" : "killed  "}  ${name}${built ? "" : " (build)"}`);
+  if (green) survivors.push(name);
+}
+run("npx", ["tsc"]);
+console.log(`\n${MUTANTS.length - survivors.length}/${MUTANTS.length} killed`);
+if (survivors.length > 0) console.log("survivors:", survivors.join(", "));

--- a/src/serve.ts
+++ b/src/serve.ts
@@ -883,7 +883,7 @@ const WITHHELD_BADGE_LABELS: Record<LevelWithheldReason | "no_source", string> =
   no_source: "unrated \u2014 no source",
   link_unreachable: "unrated \u2014 page unreachable",
   unreadable: "unrated \u2014 page unreadable",
-  states_no_terms: "unrated \u2014 page states no terms",
+  states_no_terms: "unrated \u2014 page states no price",
   does_not_name_vendor: "unrated \u2014 page omits vendor",
   does_not_name_product: "unrated \u2014 page omits product",
 };
@@ -45990,7 +45990,7 @@ ${globalNavCss()}
   <p class="section-desc">We analyzed ${offers.length.toLocaleString()} developer tool offerings across ${categories.length} categories, tracking ${changesInForce.length} pricing changes over 2024&ndash;2026. Here&rsquo;s what the data shows:</p>
   <ul class="key-takeaways">
     <li><strong>${vouchedPct}% of tracked services offer a free tier we can vouch for today</strong> &mdash; we hold a free-tier record for ${recordedPct}% of them, and can confirm ${freeTiers.vouched.toLocaleString()} of those ${freeTiers.recorded.toLocaleString()} against a source we have read.</li>
-    <li><strong>${freeTiers.unconfirmed.toLocaleString()} recorded free tiers we cannot confirm today</strong> &mdash; the record stands, but the page we hold for it states no terms, cannot be read, or does not name the vendor. Unconfirmed is not the same as gone.</li>
+    <li><strong>${freeTiers.unconfirmed.toLocaleString()} recorded free tiers we cannot confirm today</strong> &mdash; the record stands, but the page we hold for it states no price we can read, cannot be read at all, or does not name the vendor. Unconfirmed is not the same as gone.</li>
     <li><strong>${freeTiers.ended} free tiers we have recorded as ended</strong> &mdash; excluded from every count above, and from every category total on this site.</li>
     <li><strong>${negativeChanges.length} negative pricing changes vs ${positiveChanges.length} positive</strong> &mdash; free tier removals and restrictions outpace expansions ${directionRatioLabel(negativeChanges.length, positiveChanges.length)}.</li>
     <li><strong>${durability.stillInForce.length} free tiers completely removed</strong> &mdash; ${escHtmlServer(lastingExamples.map(e => e.vendor).join(", "))}, and more. ${escHtmlServer(removalReturnRateSentence(durability))}</li>
@@ -46161,7 +46161,7 @@ ${globalNavCss()}
   <h2>Methodology</h2>
   <p class="section-desc">How we built this dataset:</p>
   <ul style="color:var(--text-muted);font-size:.9rem;padding-left:1.25rem;margin-bottom:1rem">
-    <li style="margin-bottom:.4rem"><strong>Verification:</strong> Every offer records the date we read the vendor&rsquo;s public pricing page and the URL we read it from. That is not the same as being able to vouch for it today: ${freeTiers.unconfirmed.toLocaleString()} of the ${freeTiers.recorded.toLocaleString()} recorded free tiers have a source that states no terms, cannot be read, or does not name the vendor, and those are the ones counted as unconfirmed above.</li>
+    <li style="margin-bottom:.4rem"><strong>Verification:</strong> Every offer records the date we read the vendor&rsquo;s public pricing page and the URL we read it from. That is not the same as being able to vouch for it today: ${freeTiers.unconfirmed.toLocaleString()} of the ${freeTiers.recorded.toLocaleString()} recorded free tiers have a source that states no price we can read, cannot be read at all, or does not name the vendor, and those are the ones counted as unconfirmed above.</li>
     <li style="margin-bottom:.4rem"><strong>Change tracking:</strong> ${changesInForce.length} pricing changes tracked with date, previous state, current state, impact level, and source documentation.</li>
     <li style="margin-bottom:.4rem"><strong>Definition of &ldquo;free tier&rdquo;:</strong> Perpetual free plans, always-free offerings, and generous hobby/starter tiers without time limits. We exclude limited trials (e.g., 14-day, 30-day) and one-time credits.</li>
     <li style="margin-bottom:.4rem"><strong>Update frequency:</strong> Continuous. Our <a href="/freshness">data freshness dashboard</a> shows verification recency by category.</li>
@@ -50691,7 +50691,7 @@ function buildFreshnessPage(): string {
     empty_page: "the page rendered nothing we could read",
     ai_extraction: "our reader failed",
     ai_undecided: "our reader could not decide",
-    source_unusable: "the page we cite states no terms",
+    source_unusable: "the page we cite is not about this offer",
   };
   const quarantineReason = (code: string | null) =>
     (code && QUARANTINE_REASON_PROSE[code]) ?? "not recorded";

--- a/src/source-check.ts
+++ b/src/source-check.ts
@@ -23,11 +23,13 @@ export const LEVEL_WITHHOLDING_OUTCOMES: SourceCheckOutcome[] = [
   "unreadable",
 ];
 
+export const NO_PRICE_SIGNAL_PHRASE = "states no amount, tier or rate we can read";
+
 const WITHHELD_LEVEL_CLAUSES: Record<LevelWithheldReason, (since: string) => string> = {
   link_unreachable: (since) => `its pricing page has not resolved for us${since}`,
   does_not_name_vendor: () => `the page we cite for this offer does not name it`,
   does_not_name_product: () => `the page we cite for this offer names the platform it runs on and not the offer itself`,
-  states_no_terms: () => `the page we cite for this offer states no terms we can read`,
+  states_no_terms: () => `the page we cite for this offer ${NO_PRICE_SIGNAL_PHRASE}`,
   unreadable: () => `we could not read the page we cite for this offer`,
 };
 
@@ -35,7 +37,7 @@ const WITHHELD_LEVEL_SENTENCES: Record<LevelWithheldReason, (subject: string, si
   link_unreachable: (subject, since) => `${subject}'s pricing page has not resolved for us${since}.`,
   does_not_name_vendor: (subject) => `The page we cite for ${subject} does not name it.`,
   does_not_name_product: (subject) => `The page we cite for ${subject} names the platform it runs on and not ${subject} itself.`,
-  states_no_terms: (subject) => `The page we cite for ${subject} states no terms we can read.`,
+  states_no_terms: (subject) => `The page we cite for ${subject} ${NO_PRICE_SIGNAL_PHRASE}.`,
   unreadable: (subject) => `We could not read the page we cite for ${subject}.`,
 };
 

--- a/test/badge-withholding.test.ts
+++ b/test/badge-withholding.test.ts
@@ -36,7 +36,7 @@ const WITHHELD_LABELS: Record<string, string> = {
   no_source: "unrated — no source",
   link_unreachable: "unrated — page unreachable",
   unreadable: "unrated — page unreadable",
-  states_no_terms: "unrated — page states no terms",
+  states_no_terms: "unrated — page states no price",
   does_not_name_vendor: "unrated — page omits vendor",
   does_not_name_product: "unrated — page omits product",
   eligibility_restricted: "unrated — restricted offer",

--- a/test/comparison-verdict.test.ts
+++ b/test/comparison-verdict.test.ts
@@ -68,7 +68,7 @@ describe("comparison verdict — the free-tier claim carries its own reservation
   });
 
   it("never says a side offers a free tier when the site publishes no verdict for it", () => {
-    const why = "The page we cite for BrowserStack states no terms we can read.";
+    const why = "The page we cite for BrowserStack states no amount, tier or rate we can read.";
     const one = freeTierVerdictSentence(offering("Applitools Eyes", "Free"), unconfirmed("BrowserStack", why));
     assert.ok(!one.includes("BrowserStack offers a free tier"), one);
     assert.ok(one.includes("We are not publishing a free-tier verdict for BrowserStack."), one);
@@ -86,7 +86,7 @@ describe("comparison verdict — the free-tier claim carries its own reservation
   });
 
   it("states a withheld reason once when the free-tier claim and the stability clause share it", () => {
-    const why = "The page we cite for BrowserStack states no terms we can read.";
+    const why = "The page we cite for BrowserStack states no amount, tier or rate we can read.";
     const stableSide = side({ vendor: "Applitools Eyes", recordedChanges: 1, rating: "stable" });
     const withheldSide = side({
       vendor: "BrowserStack",
@@ -212,7 +212,7 @@ describe("comparison verdict — a withheld rating is stated, never resolved", (
       withheld("Cline", "states_no_terms"),
       withheld("Aider", "does_not_name_vendor"),
     );
-    assert.match(clause, /The page we cite for Cline states no terms we can read\./);
+    assert.match(clause, /The page we cite for Cline states no amount, tier or rate we can read\./);
     assert.match(clause, /The page we cite for Aider does not name it\./);
     assert.match(clause, /We are not comparing the two pricing histories\.$/);
   });

--- a/test/growth-limits.test.ts
+++ b/test/growth-limits.test.ts
@@ -278,11 +278,11 @@ describe("the outgrow block on a vendor page", () => {
     assert.match(outgrowAnswer(body), /^At 3 requests\/min, you'll need to upgrade\./);
   });
 
-  it("does not state a threshold read off a page that states no terms", async () => {
+  it("does not state a threshold read off a page that states no price", async () => {
     const { body } = await get("/vendor/prosecorp");
     const block = growthBlock(body);
     assert.doesNotMatch(block, /At 100 requests\/day, you'll need to upgrade/);
-    assert.match(block, /states no terms we can read/);
+    assert.match(block, /states no amount, tier or rate we can read/);
     assert.match(block, /we cannot confirm that threshold today/);
   });
 

--- a/test/source-check-pages.test.ts
+++ b/test/source-check-pages.test.ts
@@ -275,7 +275,7 @@ describe("the two withheld reasons read differently to somebody deciding whether
   });
 });
 
-describe("a vendor page whose cited source names it but states no terms we can read", () => {
+describe("a vendor page whose cited source names it but states no price we can read", () => {
   it("publishes no stability judgement", async () => {
     const { body } = await get("/vendor/prosecorp");
     assert.doesNotMatch(body, /This is a good sign — stable pricing/);
@@ -293,9 +293,9 @@ describe("a vendor page whose cited source names it but states no terms we can r
     assert.strictEqual(offer.source_check.outcome, "states_no_terms");
   });
 
-  it("says the page states no terms rather than that we could not read it", async () => {
+  it("says the page states no price rather than that we could not read it", async () => {
     const own = aboutThisVendor(await get("/vendor/prosecorp"));
-    assert.match(own, /states no terms we can read/);
+    assert.match(own, /states no amount, tier or rate we can read/);
     assert.doesNotMatch(own, /could not read the page we cite/);
     assert.doesNotMatch(own, /does not name it/);
   });
@@ -320,7 +320,7 @@ describe("a vendor page whose cited source names a plan but states no amount", (
 
   it("does not borrow the sentence written for a page that states nothing", async () => {
     const own = aboutThisVendor(await get("/vendor/plancorp"));
-    assert.doesNotMatch(own, /states no terms we can read/);
+    assert.doesNotMatch(own, /states no amount, tier or rate we can read/);
     assert.doesNotMatch(own, /could not read the page we cite/);
     assert.doesNotMatch(own, /does not name it/);
   });
@@ -369,7 +369,7 @@ describe("the question an answer engine quotes first", () => {
   for (const [slug, vendor, reason] of [
     ["fixturecorp", "Fixturecorp", /does not name it/],
     ["shellcorp", "Shellcorp", /could not read the page we cite/],
-    ["prosecorp", "Prosecorp", /states no terms we can read/],
+    ["prosecorp", "Prosecorp", /states no amount, tier or rate we can read/],
   ] as const) {
     it(`does not answer Yes for ${vendor}, and carries the reason in the answer itself`, async () => {
       const { body } = await get(`/vendor/${slug}`);
@@ -397,7 +397,7 @@ describe("an alternatives page for a vendor whose source we cannot vouch for", (
   for (const [slug, vendor, reason] of [
     ["fixturecorp", "Fixturecorp", /does not name it/],
     ["shellcorp", "Shellcorp", /could not read the page we cite/],
-    ["prosecorp", "Prosecorp", /states no terms we can read/],
+    ["prosecorp", "Prosecorp", /states no amount, tier or rate we can read/],
   ] as const) {
     it(`does not re-assert a stable risk level for ${vendor}`, async () => {
       const { body } = await get(`/alternative-to/${slug}`);
@@ -430,16 +430,16 @@ describe("a page we quote from is not also a page we say we can read nothing on"
     assert.ok(body.includes(`https://longcorp.example/pricing</a>, ${quoted}`), quoted);
   });
 
-  it("does not also say that page states no terms it can read", async () => {
+  it("does not also say that page states no price it can read", async () => {
     const { body } = await get("/vendor/longcorp");
-    assert.doesNotMatch(saidOfTheSubject(body), /states no terms we can read/);
+    assert.doesNotMatch(saidOfTheSubject(body), /states no amount, tier or rate we can read/);
   });
 
   it("keeps saying so where the quote comes from a different page", async () => {
     const { body } = await get("/vendor/prosecorp");
     const quoted = pageQuoteHtml("managed Postgres", (t: string) => t);
     assert.ok(body.includes(`dealmarket.example/offers</a>, ${quoted}`), quoted);
-    assert.match(saidOfTheSubject(body), /states no terms we can read/);
+    assert.match(saidOfTheSubject(body), /states no amount, tier or rate we can read/);
   });
 
   for (const subject of FIXTURES) {

--- a/test/source-check.test.ts
+++ b/test/source-check.test.ts
@@ -46,7 +46,7 @@ describe("an offer whose cited page cannot verify it", () => {
     assert.strictEqual(cannotVouchForLevel({ source_check: CITED_PAGE_COULD_NOT_BE_READ }, null), true);
   });
 
-  it("withholds a favourable risk level where the cited page states no terms we can read", () => {
+  it("withholds a favourable risk level where the cited page states no price we can read", () => {
     assert.strictEqual(sourceDoesNotNameVendor({ source_check: CITED_PAGE_STATES_NO_TERMS }), false);
     assert.strictEqual(cannotVouchForLevel({ source_check: CITED_PAGE_STATES_NO_TERMS }, null), true);
     assert.ok(sourceCheckNotice({ source_check: CITED_PAGE_STATES_NO_TERMS }));
@@ -190,7 +190,7 @@ describe("what the enriched record publishes for a source we could not read", ()
   });
 });
 
-describe("what the tool tells an agent about a source that states no terms we can read", () => {
+describe("what the tool tells an agent about a source that states no price we can read", () => {
   const vendorsSourcedOnlyFromPagesStatingNoTerms = (): string[] => {
     const byVendor = new Map<string, any[]>();
     for (const offer of loadOffers() as any[]) {
@@ -208,12 +208,12 @@ describe("what the tool tells an agent about a source that states no terms we ca
     const statingNoTerms = enriched.filter(
       (o) => o.source_check?.outcome === "states_no_terms" && !o.link_unreachable
     );
-    assert.ok(statingNoTerms.length > 0, "no record in the index cites a page that states no terms");
+    assert.ok(statingNoTerms.length > 0, "no record in the index cites a page that states no price we can read");
     for (const offer of statingNoTerms) {
       assert.notStrictEqual(
         offer.risk_level,
         "stable",
-        `${offer.vendor} is badged stable from a page that states no terms we can read`
+        `${offer.vendor} is badged stable from a page that states no price we can read`
       );
     }
   });
@@ -226,7 +226,7 @@ describe("what the tool tells an agent about a source that states no terms we ca
       assert.doesNotMatch(
         result.summary,
         /has a stable pricing history/,
-        `${vendor} is told it has a stable pricing history from a page that states no terms`
+        `${vendor} is told it has a stable pricing history from a page that states no price we can read`
       );
       if (++checked === 20) break;
     }
@@ -240,12 +240,12 @@ describe("what the tool tells an agent about a source that states no terms we ca
       if (result.risk_level !== null) continue;
       assert.match(
         result.summary,
-        /states no terms we can read/,
+        /states no amount, tier or rate we can read/,
         `${vendor} withholds a level without saying why`
       );
       if (++said === 20) break;
     }
-    assert.ok(said > 0, "no vendor tells a caller its cited page states no terms we can read");
+    assert.ok(said > 0, "no vendor tells a caller its cited page states no price we can read");
   });
 });
 

--- a/test/vendor-verdict.test.ts
+++ b/test/vendor-verdict.test.ts
@@ -101,7 +101,7 @@ describe("vendor verdict — one rating word, and it carries its cause", () => {
     assert.strictEqual(vendorVerdictWord(withheld), null);
     assert.strictEqual(
       vendorVerdictSentence(withheld),
-      "The page we cite for this offer states no terms we can read, so we cannot confirm these terms today.",
+      "The page we cite for this offer states no amount, tier or rate we can read, so we cannot confirm these terms today.",
     );
   });
 

--- a/test/withheld-reason-names-what-we-looked-for.test.ts
+++ b/test/withheld-reason-names-what-we-looked-for.test.ts
@@ -1,0 +1,118 @@
+import { describe, it } from "node:test";
+import assert from "node:assert";
+import { readdirSync, readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { assertPopulationFloor } from "./population-floor.ts";
+
+const {
+  LEVEL_WITHHOLDING_OUTCOMES,
+  NO_PRICE_SIGNAL_PHRASE,
+  unconfirmedTermsClause,
+  withheldLevelClause,
+  withheldLevelSentence,
+} = await import("../dist/source-check.js");
+const { unconfirmedTermsMetaSentence } = await import("../dist/vendor-verdict.js");
+const { classifySource } = await import("../scripts/vendor-naming.js");
+const { priceSignals } = await import("../scripts/change-gate.js");
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const SRC = path.join(__dirname, "..", "src");
+const INDEX_PATH = path.join(__dirname, "..", "data", "index.json");
+
+const OVERCLAIM = /states no terms/;
+
+const SENTENCES: Record<string, string> = {
+  link_unreachable: "Acme's pricing page has not resolved for us.",
+  does_not_name_vendor: "The page we cite for Acme does not name it.",
+  does_not_name_product: "The page we cite for Acme names the platform it runs on and not Acme itself.",
+  states_no_terms: "The page we cite for Acme states no amount, tier or rate we can read.",
+  unreadable: "We could not read the page we cite for Acme.",
+};
+
+const CLAUSES: Record<string, string> = {
+  link_unreachable: "its pricing page has not resolved for us",
+  does_not_name_vendor: "the page we cite for this offer does not name it",
+  does_not_name_product: "the page we cite for this offer names the platform it runs on and not the offer itself",
+  states_no_terms: "the page we cite for this offer states no amount, tier or rate we can read",
+  unreadable: "we could not read the page we cite for this offer",
+};
+
+function filesUnder(dir: string): string[] {
+  return readdirSync(dir, { withFileTypes: true }).flatMap((entry) =>
+    entry.isDirectory()
+      ? filesUnder(path.join(dir, entry.name))
+      : entry.name.endsWith(".ts")
+        ? [path.join(dir, entry.name)]
+        : [],
+  );
+}
+
+describe("what we tell a reader when we hold a rating back", () => {
+  for (const [reason, sentence] of Object.entries(SENTENCES)) {
+    it(`states the ${reason} sentence, so an edit to one cannot silently change another`, () => {
+      assert.strictEqual(withheldLevelSentence(reason as never, "Acme"), sentence);
+    });
+  }
+
+  for (const [reason, clause] of Object.entries(CLAUSES)) {
+    it(`states the ${reason} clause, so an edit to one cannot silently change another`, () => {
+      assert.strictEqual(withheldLevelClause(reason as never), clause);
+    });
+  }
+
+  it("carries the same clause into what an agent is told about unconfirmed terms", () => {
+    for (const outcome of LEVEL_WITHHOLDING_OUTCOMES) {
+      assert.strictEqual(unconfirmedTermsClause(outcome), CLAUSES[outcome], outcome);
+    }
+  });
+});
+
+describe("the sentence names what the check looked for rather than claiming the page said nothing", () => {
+  it("says what the check recorded in the field beside it, word for word", () => {
+    const text = "MinIO. Purpose-built subscription tiers support no-cost development to mission-critical production.";
+    const check = classifySource({ vendor: "MinIO", url: "https://min.io/pricing" }, { ok: true, text }, priceSignals(text));
+    assert.strictEqual(check.outcome, "states_no_terms");
+    assert.ok(check.detail.endsWith(NO_PRICE_SIGNAL_PHRASE), check.detail);
+    assert.ok(withheldLevelSentence("states_no_terms", "MinIO").includes(NO_PRICE_SIGNAL_PHRASE));
+    assert.ok(withheldLevelClause("states_no_terms").includes(NO_PRICE_SIGNAL_PHRASE));
+  });
+
+  it("says nothing about the page being silent, which is what it could not establish", () => {
+    assert.doesNotMatch(withheldLevelSentence("states_no_terms", "Acme"), OVERCLAIM);
+    assert.doesNotMatch(withheldLevelClause("states_no_terms"), OVERCLAIM);
+    assert.doesNotMatch(unconfirmedTermsMetaSentence("states_no_terms"), OVERCLAIM);
+  });
+
+  it("keeps the sentence a meta description can carry", () => {
+    assert.strictEqual(
+      unconfirmedTermsMetaSentence("states_no_terms"),
+      "Not verified — the page we cite for this offer states no amount, tier or rate we can read.",
+    );
+  });
+
+  it("leaves the outcome for a page that named a plan saying something different", () => {
+    assert.notStrictEqual(unconfirmedTermsClause("states_no_amount"), unconfirmedTermsClause("states_no_terms"));
+    assert.match(unconfirmedTermsClause("states_no_amount"), /names a plan but states no amount/);
+  });
+});
+
+describe("no surface keeps its own copy of the sentence this replaced", () => {
+  const sources = filesUnder(SRC);
+
+  it("reads the whole of src, so the scan is not looking at one file", () => {
+    assertPopulationFloor(sources.length, 60, "TypeScript files under src the scan reads");
+  });
+
+  it("finds the phrase in none of them", () => {
+    const carrying = sources.filter((file) => OVERCLAIM.test(readFileSync(file, "utf-8")));
+    assert.deepStrictEqual(carrying.map((file) => path.relative(SRC, file)), []);
+  });
+
+  it("is read against a catalogue where the outcome it describes is not empty", () => {
+    const offers = JSON.parse(readFileSync(INDEX_PATH, "utf-8")).offers as any[];
+    const stating = offers.filter((offer) => offer.source_check?.outcome === "states_no_terms");
+    assert.ok(stating.length > 0, "no record in the catalogue carries the outcome this sentence describes");
+    assertPopulationFloor(offers.length, 1000, "offers in the catalogue this sentence is read against");
+  });
+});


### PR DESCRIPTION
Refs #1264

## What changed

`classifySource` reaches `states_no_terms` when the page fetched, the page names the vendor, and `priceSignals(text)` returned nothing. What that establishes is that **we read no amount, tier or rate** — not that the page is silent. **447 records, 28% of the catalogue**, published the stronger claim.

The accurate wording was already in the codebase, and this issue is the one that pointed at it: the `detail` string the same branch records, *"the page names X but states no amount, tier or rate we can read"*. Both the published clause and the sentence now read from one exported constant, so what we publish and what the check wrote down beside it cannot drift apart. A test asserts the check's own `detail` ends with that constant.

```
the page we cite for this offer states no amount, tier or rate we can read
The page we cite for MinIO states no amount, tier or rate we can read.
```

The other four withheld reasons are byte-identical, pinned by a verbatim assertion each — clause and sentence — so the next edit to one cannot silently change another.

## The three surfaces that kept their own copy

`withheldLevelClause` covers eleven call sites, but three more in `serve.ts` carried the phrase themselves and are not reached by the constant:

- the withheld badge label, `unrated — page states no terms` → `page states no price`
- two aggregate sentences on the insights page, *"the page we hold for it states no terms, cannot be read, or does not name the vendor"* → *"states no price we can read, cannot be read at all, or does not name the vendor"*
- the quarantine table's reason prose for `source_unusable`

The last one needed a second correction rather than a rewording. **Since https://github.com/robhunter/agentdeals/pull/1516 that failure category is only written for a page that does not name the offer** — price silence no longer reaches it — so `the page we cite states no terms` was wrong twice over. It now reads `the page we cite is not about this offer`.

A source scan over every `.ts` file in `src/` holds all of it, so a copy cannot come back.

## The length ceiling

`unconfirmedTermsMetaSentence` is capped at 90 characters by `test/meta-description-withholding.test.ts`. The first wording I tried, naming all four signal shapes the reader searches for — price, tier, rate, allowance — came to 99 and failed that ceiling. The wording this ships names the three the `detail` string names and lands at exactly 90, so it sits on the boundary; the next word added to it goes red, which is the assertion doing its job.

## Verified

- Suite **4,963 of 4,963**.
- `scripts/mutate-1264.mjs` — **7 mutants, 7 killed**, including restoring each of the three surface copies.
- Rendered from a running server. MinIO itself has since moved to `ok`, read from its markup, so it is no longer in this population; `/vendor/pocketbase` is the same shape and carries both sentences four lines apart:

> **Subtypes in Databases:** `backend_platform` — bundles a database with auth, functions or storage as one product. We read that on 2026-08-31 from `pocketbase.io`, where it says: *"Open Source backend in 1 file with realtime database, authentication, file storage and admin dashboard"*

> PocketBase's free tier offers Open-source backend in a single Go binary… **The page we cite for this offer states no amount, tier or rate we can read**, so we cannot confirm these terms today.

The new wording also reaches the meta description, the `WebPage` and `FAQPage` JSON-LD, the growth block and the alternatives table, all read off the running server.
