### PR TITLE
Read a page that comes back too short with a rendering client (#1124)

### DIFF
--- a/.github/workflows/reverify.yml
+++ b/.github/workflows/reverify.yml
@@ -32,6 +32,9 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Name the rendering client a page that comes back too short is read with
+        run: node -e "import('./scripts/rendered-page.js').then((m) => console.log(m.findRenderer() ?? 'none found on this runner'))"
+
       - name: Run rolling re-verification
         id: reverify
         env:

--- a/data/index.json
+++ b/data/index.json
@@ -7918,7 +7918,7 @@
     {
       "vendor": "Kaggle",
       "category": "AI / ML",
-      "description": "Data science platform (Google) — entirely free: 30 hrs/week GPU compute (Tesla T4, 16 GB VRAM), 20 hrs/week TPU, 20 GB working disk per session. Unlimited public notebooks, datasets, and competitions",
+      "description": "Data science platform (Google) — entirely free: 30 hrs/week GPU compute (NVIDIA Tesla P100), 20 hrs/week TPU with a 9-hour cap per session, 20 GB working disk per session. Unlimited public notebooks, datasets, and competitions",
       "tier": "Free",
       "url": "https://www.kaggle.com",
       "tags": [
@@ -10963,16 +10963,17 @@
       "category": "AI / ML",
       "description": "Simulate, evaluate, and observe your AI agents. Maxim is an end-to-end evaluation and observability platform, helping teams ship their AI agents reliably and >5x faster. Free forever for indie developers and small teams (3 seats).",
       "tier": "Free",
-      "url": "https://getmaxim.ai/",
+      "url": "https://getmaxim.ai/pricing",
       "tags": [
         "developer-tools",
         "free-for-dev"
       ],
       "verifiedDate": "2026-07-30",
       "source_check": {
-        "checked": "2026-09-02",
-        "outcome": "states_no_terms",
-        "detail": "the page names Maxim AI but states no amount, tier or rate we can read"
+        "checked": "2026-09-10",
+        "outcome": "ok",
+        "detail": "the page names Maxim AI, renders \"Free Forever\" and no amount, and its markup states 1 typed price (Bifrost OSS USD 0)",
+        "read": "markup"
       },
       "product_subtypes": {
         "taxonomy": "AI / ML",

--- a/scripts/census-1124-rendered-reads.mjs
+++ b/scripts/census-1124-rendered-reads.mjs
@@ -1,0 +1,111 @@
+#!/usr/bin/env node
+
+import { readFileSync, writeFileSync } from "node:fs";
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { fetchPageText, PAGE_TOO_SHORT_ERROR } from "./verify-freshness.js";
+import { findRenderer, READ_BY_RENDERING } from "./rendered-page.js";
+import { priceSignals } from "./change-gate.js";
+import { sourceCheckRecord, SOURCE_CHECK_UNREADABLE } from "./vendor-naming.js";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const INDEX_PATH =
+  process.env.AGENTDEALS_INDEX_PATH || resolve(__dirname, "..", "data", "index.json");
+const CONCURRENCY = 4;
+
+function arg(name, fallback = null) {
+  const at = process.argv.indexOf(name);
+  return at !== -1 ? process.argv[at + 1] : fallback;
+}
+
+export function shortPageCohort(offers) {
+  return offers.filter(
+    (offer) =>
+      offer.url &&
+      offer.source_check?.outcome === SOURCE_CHECK_UNREADABLE &&
+      String(offer.source_check.detail ?? "").startsWith(PAGE_TOO_SHORT_ERROR)
+  );
+}
+
+async function mapWithConcurrency(items, limit, fn) {
+  let next = 0;
+  const workers = Array.from({ length: Math.min(limit, items.length) }, async () => {
+    while (true) {
+      const i = next++;
+      if (i >= items.length) return;
+      await fn(items[i], i);
+    }
+  });
+  await Promise.all(workers);
+}
+
+async function main() {
+  const out = arg("--out", "/tmp/census-1124.json");
+  const write = process.argv.includes("--write");
+  const checked = arg("--checked", new Date().toISOString().slice(0, 10));
+  const limit = Number(arg("--limit", "0"));
+  const only = arg("--url", null);
+
+  const renderer = findRenderer();
+  console.error(`rendering client: ${renderer ?? "none found — nothing will escalate"}`);
+  if (!renderer) process.exitCode = 2;
+
+  const data = JSON.parse(readFileSync(INDEX_PATH, "utf-8"));
+  const offers = data.offers || [];
+  let cohort = shortPageCohort(offers);
+  if (only) cohort = cohort.filter((offer) => offer.url === only);
+  if (limit > 0) cohort = cohort.slice(0, limit);
+
+  const indexOf = new Map(offers.map((offer, at) => [offer, at]));
+  console.error(`${cohort.length} records cite a page our fetcher read as too short`);
+
+  const started = Date.now();
+  const rows = [];
+  let done = 0;
+  await mapWithConcurrency(cohort, CONCURRENCY, async (offer) => {
+    const at = Date.now();
+    const page = await fetchPageText(offer.url);
+    const signals = page.ok ? priceSignals(page.text) : [];
+    const check = sourceCheckRecord(offer, page, signals, checked);
+    rows.push({
+      vendor: offer.vendor,
+      slug: offer.slug ?? null,
+      url: offer.url,
+      chars_before: page.chars_before_rendering ?? page.chars ?? null,
+      chars_after: page.ok ? page.text.length : (page.chars ?? null),
+      rendered: page.read === READ_BY_RENDERING,
+      outcome: check.outcome,
+      detail: check.detail,
+      seconds: Math.round((Date.now() - at) / 100) / 10,
+    });
+    if (write) offers[indexOf.get(offer)].source_check = check;
+    done++;
+    console.error(
+      `  ${String(done).padStart(3)}/${cohort.length} ${check.outcome.padEnd(22)} ${offer.vendor} — ${offer.url}`
+    );
+  });
+
+  rows.sort((a, b) => a.vendor.localeCompare(b.vendor));
+  writeFileSync(out, JSON.stringify(rows, null, 1) + "\n");
+  if (write) writeFileSync(INDEX_PATH, JSON.stringify(data, null, 2) + "\n");
+
+  const recovered = rows.filter((r) => r.outcome !== SOURCE_CHECK_UNREADABLE);
+  const byOutcome = new Map();
+  for (const r of rows) byOutcome.set(r.outcome, (byOutcome.get(r.outcome) ?? 0) + 1);
+
+  console.error("");
+  console.error(`cohort                       ${rows.length}`);
+  console.error(`no longer unreadable         ${recovered.length}`);
+  console.error(`still unreadable             ${rows.length - recovered.length}`);
+  for (const [outcome, count] of [...byOutcome].sort((a, b) => b[1] - a[1])) {
+    console.error(`  ${outcome.padEnd(24)} ${count}`);
+  }
+  const wall = Math.round((Date.now() - started) / 1000);
+  console.error("");
+  console.error(`renders attempted            ${rows.filter((r) => r.rendered).length}`);
+  console.error(`wall clock                   ${wall}s`);
+  console.error(`per record                   ${Math.round((wall / rows.length) * 10) / 10}s`);
+  console.error(`wrote ${out}`);
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) await main();

--- a/scripts/mutate-1124.sh
+++ b/scripts/mutate-1124.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+set -uo pipefail
+
+cd "$(dirname "$0")/.."
+
+RENDERED=scripts/rendered-page.js
+FRESHNESS=scripts/verify-freshness.js
+NAMING=scripts/vendor-naming.js
+SUITE=(test/rendered-short-pages.test.ts test/short-page-floor.test.ts test/typed-price-read.test.ts test/whole-page-read.test.ts)
+
+cp "$RENDERED" /tmp/mutate-1124-rendered.orig
+cp "$FRESHNESS" /tmp/mutate-1124-freshness.orig
+cp "$NAMING" /tmp/mutate-1124-naming.orig
+
+restore() {
+  cp /tmp/mutate-1124-rendered.orig "$RENDERED"
+  cp /tmp/mutate-1124-freshness.orig "$FRESHNESS"
+  cp /tmp/mutate-1124-naming.orig "$NAMING"
+}
+trap restore EXIT
+
+killed=0
+survived=0
+
+mutate() {
+  local name="$1" file="$2" from="$3" to="$4"
+  restore
+  FILE="$file" FROM="$from" TO="$to" python3 - <<'PY'
+import os, pathlib
+path = pathlib.Path(os.environ["FILE"])
+source = path.read_text()
+frm, to = os.environ["FROM"], os.environ["TO"]
+assert source.count(frm) == 1, f"{path}: {source.count(frm)} occurrences of {frm!r}"
+path.write_text(source.replace(frm, to))
+PY
+  if [ $? -ne 0 ]; then
+    echo "SKIPPED (no such text): $name"
+    return
+  fi
+  if TZ=UTC npx node --test "${SUITE[@]}" >/tmp/mutate-1124-run.log 2>&1; then
+    echo "SURVIVED: $name"
+    survived=$((survived + 1))
+  else
+    echo "killed:   $name"
+    killed=$((killed + 1))
+  fi
+}
+
+mutate "escalate on any failed read, not only a short one" \
+  "$FRESHNESS" "if (!tooShortToRead(read)) return read;" "if (read.ok) return read;"
+
+mutate "treat any refusal as too short" \
+  "$FRESHNESS" 'return page?.ok === false && page.error === PAGE_TOO_SHORT_ERROR;' 'return page?.ok === false;'
+
+mutate "claim a rendering client ran when none is installed" \
+  "$FRESHNESS" "if (rendered.error === NO_RENDERING_CLIENT) return short;" "if (false) return short;"
+
+mutate "accept a rendered page of any length" \
+  "$FRESHNESS" "if (text.length < (options.minLength ?? MIN_PAGE_TEXT_LENGTH)) {" "if (false) {"
+
+mutate "drop the length the fetcher read before rendering" \
+  "$FRESHNESS" "chars_before_rendering: short.chars," "chars_before_rendering: undefined,"
+
+mutate "leave no rendering marker on the record" \
+  "$NAMING" 'if (page?.read === READ_BY_RENDERING) record.rendered = true;' 'if (false) record.rendered = true;'
+
+mutate "let rendering clients run in parallel" \
+  "$RENDERED" "oneAtATime = queued.then(" "oneAtATime = Promise.resolve().then("
+
+mutate "ask for the loaded page instead of the rendered DOM" \
+  "$RENDERED" '"--dump-dom",' '"--incognito",'
+
+mutate "ignore the arguments the environment asks for" \
+  "$RENDERED" "return String(env[RENDERER_ARGS_ENV] ?? \"\").split(/\\s+/).filter(Boolean);" "return [];"
+
+mutate "render without bounding how long a page may load" \
+  "$RENDERED" '`--virtual-time-budget=${options.virtualTimeBudgetMs ?? VIRTUAL_TIME_BUDGET_MS}`,' '"--disable-logging",'
+
+mutate "guess at a rendering client when none is on the path" \
+  "$RENDERED" "return rendererCandidates(env).find(isExecutable) ?? null;" "return rendererCandidates(env)[0] ?? null;"
+
+echo ""
+echo "$killed killed, $survived survived"
+[ "$survived" -eq 0 ]

--- a/scripts/rendered-page.js
+++ b/scripts/rendered-page.js
@@ -1,0 +1,140 @@
+#!/usr/bin/env node
+
+import { spawn } from "node:child_process";
+import { accessSync, constants } from "node:fs";
+import { delimiter, join } from "node:path";
+
+export const READ_BY_RENDERING = "rendered";
+export const RENDERER_PATH_ENV = "AGENTDEALS_RENDERER";
+export const RENDERER_ARGS_ENV = "AGENTDEALS_RENDERER_ARGS";
+export const RENDER_TIMEOUT_MS = 45_000;
+export const VIRTUAL_TIME_BUDGET_MS = 20_000;
+export const MAX_RENDERED_BYTES = 16_000_000;
+
+export const NO_RENDERING_CLIENT = "no rendering client is installed";
+export const RENDER_TIMED_OUT = "the rendering client did not finish in time";
+
+export const RENDER_USER_AGENT =
+  "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36";
+
+const ENV_VARS_HOLDING_A_PATH = [
+  RENDERER_PATH_ENV,
+  "CHROME_PATH",
+  "CHROME_BIN",
+  "PUPPETEER_EXECUTABLE_PATH",
+];
+
+const EXECUTABLE_NAMES = [
+  "google-chrome-stable",
+  "google-chrome",
+  "chromium-browser",
+  "chromium",
+  "headless_shell",
+];
+
+function isExecutable(path) {
+  try {
+    accessSync(path, constants.X_OK);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function rendererCandidates(env = process.env) {
+  const named = ENV_VARS_HOLDING_A_PATH.map((name) => env[name]).filter(Boolean);
+  const directories = String(env.PATH ?? "").split(delimiter).filter(Boolean);
+  const onPath = directories.flatMap((directory) =>
+    EXECUTABLE_NAMES.map((name) => join(directory, name))
+  );
+  return [...named, ...onPath];
+}
+
+export function findRenderer(env = process.env) {
+  return rendererCandidates(env).find(isExecutable) ?? null;
+}
+
+export function environmentArguments(env = process.env) {
+  return String(env[RENDERER_ARGS_ENV] ?? "").split(/\s+/).filter(Boolean);
+}
+
+export function renderArguments(url, options = {}) {
+  return [
+    "--headless",
+    "--disable-gpu",
+    "--no-sandbox",
+    "--disable-dev-shm-usage",
+    "--disable-background-networking",
+    "--disable-extensions",
+    "--no-first-run",
+    "--no-default-browser-check",
+    `--user-agent=${options.userAgent ?? RENDER_USER_AGENT}`,
+    ...environmentArguments(options.env),
+    `--virtual-time-budget=${options.virtualTimeBudgetMs ?? VIRTUAL_TIME_BUDGET_MS}`,
+    "--dump-dom",
+    url,
+  ];
+}
+
+export function dumpDom(binary, args, limits = {}) {
+  const timeoutMs = limits.timeoutMs ?? RENDER_TIMEOUT_MS;
+  const maxBytes = limits.maxBytes ?? MAX_RENDERED_BYTES;
+  return new Promise((settle) => {
+    let child;
+    try {
+      child = spawn(binary, args, { stdio: ["ignore", "pipe", "ignore"] });
+    } catch (err) {
+      settle({ ok: false, error: err.message });
+      return;
+    }
+    const chunks = [];
+    let bytes = 0;
+    let done = false;
+    const finish = (result) => {
+      if (done) return;
+      done = true;
+      clearTimeout(timer);
+      settle(result);
+    };
+    const timer = setTimeout(() => {
+      child.kill("SIGKILL");
+      finish({ ok: false, error: RENDER_TIMED_OUT });
+    }, timeoutMs);
+    child.stdout.on("data", (chunk) => {
+      bytes += chunk.length;
+      if (bytes > maxBytes) {
+        child.kill("SIGKILL");
+        finish({ ok: false, error: `rendered page over ${maxBytes} bytes` });
+        return;
+      }
+      chunks.push(chunk);
+    });
+    child.on("error", (err) => finish({ ok: false, error: err.message }));
+    child.on("close", (code) => {
+      if (code !== 0) return finish({ ok: false, error: `the rendering client exited ${code}` });
+      finish({ ok: true, html: Buffer.concat(chunks).toString("utf-8") });
+    });
+  });
+}
+
+export async function withoutARenderingClient() {
+  return { ok: false, error: NO_RENDERING_CLIENT };
+}
+
+let oneAtATime = Promise.resolve();
+
+export function renderPageHtml(url, options = {}) {
+  const queued = oneAtATime.then(async () => {
+    const binary = options.renderer ?? findRenderer(options.env);
+    if (!binary) return { ok: false, error: NO_RENDERING_CLIENT };
+    return (options.dump ?? dumpDom)(binary, renderArguments(url, options), {
+      timeoutMs: options.timeoutMs,
+      maxBytes: options.maxBytes,
+    });
+  });
+  oneAtATime = queued.then(
+    () => undefined,
+    () => undefined
+  );
+  return queued;
+}

--- a/scripts/reverify-rolling.js
+++ b/scripts/reverify-rolling.js
@@ -25,7 +25,9 @@ import {
   READ_FROM_MARKUP,
   SOURCE_CHECK_OK,
   SOURCE_CHECK_OUTCOMES,
+  SOURCE_CHECK_UNREADABLE,
 } from "./vendor-naming.js";
+import { findRenderer } from "./rendered-page.js";
 import { isoDay } from "./change-log.js";
 import { recordRefusals, readRefusals, refusalHolds, offerKey } from "./change-refusals.js";
 import {
@@ -146,6 +148,12 @@ function applySourceCheck(offer, index, page, data, dryRun, now, counters) {
     counters.set(READ_FROM_MARKUP, (counters.get(READ_FROM_MARKUP) ?? 0) + 1);
     console.log(`  ⌗ ${offer.vendor} — ${check.detail} (${offer.url})`);
   }
+  if (check.rendered) {
+    counters.set(RENDERED, (counters.get(RENDERED) ?? 0) + 1);
+    if (check.outcome !== SOURCE_CHECK_UNREADABLE) {
+      counters.set(RENDERED_AND_READ, (counters.get(RENDERED_AND_READ) ?? 0) + 1);
+    }
+  }
   if (check.unrendered_prices) {
     counters.set(UNRENDERED, (counters.get(UNRENDERED) ?? 0) + 1);
     console.log(
@@ -160,9 +168,15 @@ function applySourceCheck(offer, index, page, data, dryRun, now, counters) {
 }
 
 const UNRENDERED = "unrendered_prices";
+const RENDERED = "rendered";
+const RENDERED_AND_READ = "rendered_and_read";
 
 function emptySourceCounters() {
-  return new Map([...SOURCE_CHECK_OUTCOMES, READ_FROM_MARKUP, UNRENDERED].map((key) => [key, 0]));
+  return new Map(
+    [...SOURCE_CHECK_OUTCOMES, READ_FROM_MARKUP, UNRENDERED, RENDERED, RENDERED_AND_READ].map(
+      (key) => [key, 0]
+    )
+  );
 }
 
 function attemptRecorder() {
@@ -430,6 +444,8 @@ export function summaryLines(result, { useAi, checked, oldestRemaining, total, q
     const label = holdsVerifiedDate(outcome) ? "Held back" : "Verified on weaker evidence";
     lines.push(`${label} (source ${outcome}): ${sourceChecks.get(outcome) ?? 0}`);
   }
+  lines.push(`Read again with a rendering client after coming back too short: ${sourceChecks.get(RENDERED) ?? 0}`);
+  lines.push(`Of those, a reading came back: ${sourceChecks.get(RENDERED_AND_READ) ?? 0}`);
   lines.push(`Graded on a price the page states in its markup, not its text: ${sourceChecks.get(READ_FROM_MARKUP) ?? 0}`);
   lines.push(`Publishing a price in markup the page never renders: ${sourceChecks.get(UNRENDERED) ?? 0}`);
   lines.push(`Flagged (URL/AI failure): ${result.flagged}`);
@@ -494,6 +510,12 @@ async function main() {
   const selection = { refusalHolds: holds, verificationState: state };
   const { picked, oldestRemaining, retriedFromQuarantine, pickedAfterAFailedRead } = pickOldestEntries(offers, limit, now, selection);
 
+  const renderer = findRenderer();
+  console.log(
+    renderer
+      ? `A page that comes back too short is read again with ${renderer}`
+      : "No rendering client is installed — a page that comes back too short stays unread"
+  );
   console.log(
     `Rolling re-verification — ${picked.length} oldest entries` +
       (retriedFromQuarantine > 0 ? `, ${retriedFromQuarantine} retried from quarantine` : "") +

--- a/scripts/vendor-naming.js
+++ b/scripts/vendor-naming.js
@@ -1,3 +1,4 @@
+import { READ_BY_RENDERING } from "./rendered-page.js";
 import { priceLabel, structuredDetail, unrenderedPrices } from "./structured-prices.js";
 
 const NAME_QUALIFIERS = new Set([
@@ -290,6 +291,7 @@ export function sourceCheckRecord(offer, page, signals, checked) {
   const { outcome, detail, read } = classifySource(offer, page, signals);
   const record = { checked, outcome, detail };
   if (read) record.read = read;
+  if (page?.read === READ_BY_RENDERING) record.rendered = true;
   const unrendered = page?.ok ? unrenderedPrices(page.structured, page.text) : [];
   if (unrendered.length > 0) {
     record.unrendered_prices = unrendered.slice(0, MAX_UNRENDERED_PRICES_RECORDED).map(priceLabel);

--- a/scripts/verify-freshness.js
+++ b/scripts/verify-freshness.js
@@ -5,6 +5,7 @@ import { resolve, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
 import { CHANGE_TYPES } from "./change-log.js";
 import { readStructuredPrices } from "./structured-prices.js";
+import { NO_RENDERING_CLIENT, READ_BY_RENDERING, renderPageHtml } from "./rendered-page.js";
 
 const CHANGE_TYPE_VALUES = CHANGE_TYPES.join(", ");
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -74,6 +75,37 @@ export function withMinimumLength(page, floor = MIN_PAGE_TEXT_LENGTH) {
   return page;
 }
 
+export function tooShortToRead(page) {
+  return page?.ok === false && page.error === PAGE_TOO_SHORT_ERROR;
+}
+
+export function tooShortForARenderingClientToo(chars) {
+  return `${PAGE_TOO_SHORT_ERROR}; a rendering client read ${chars} characters`;
+}
+
+export function renderingClientCouldNotReadIt(reason) {
+  return `${PAGE_TOO_SHORT_ERROR}; the rendering client failed: ${reason}`;
+}
+
+export function pageOnlyARenderingClientCanRead(short, rendered, options = {}) {
+  if (rendered.error === NO_RENDERING_CLIENT) return short;
+  const unread = (error, chars) => ({ ...short, error, chars, read: READ_BY_RENDERING });
+  if (!rendered.ok) return unread(renderingClientCouldNotReadIt(rendered.error), short.chars);
+  const text = stripHtml(rendered.html);
+  if (text.length < (options.minLength ?? MIN_PAGE_TEXT_LENGTH)) {
+    return unread(tooShortForARenderingClientToo(text.length), text.length);
+  }
+  return {
+    ok: true,
+    text,
+    structured: readStructuredPrices(rendered.html),
+    truncated: false,
+    finalUrl: options.finalUrl,
+    chars_before_rendering: short.chars,
+    read: READ_BY_RENDERING,
+  };
+}
+
 async function cancelBody(res) {
   try {
     await res.body?.cancel();
@@ -127,14 +159,21 @@ export async function fetchPageText(url, options = {}) {
     if (body.tooLarge) {
       return { ok: false, error: pageTooLargeError(body.bytes) };
     }
-    const text = stripHtml(body.html);
-    return withMinimumLength({
-      ok: true,
-      text,
-      structured: readStructuredPrices(body.html),
-      truncated: false,
-      finalUrl: res.url || url,
-    });
+    const finalUrl = res.url || url;
+    const floor = options.minLength ?? MIN_PAGE_TEXT_LENGTH;
+    const read = withMinimumLength(
+      {
+        ok: true,
+        text: stripHtml(body.html),
+        structured: readStructuredPrices(body.html),
+        truncated: false,
+        finalUrl,
+      },
+      floor
+    );
+    if (!tooShortToRead(read)) return read;
+    const render = options.render ?? renderPageHtml;
+    return pageOnlyARenderingClientCanRead(read, await render(url), { minLength: floor, finalUrl });
   } catch (err) {
     const reason = err.name === "AbortError" ? "timeout" : err.message;
     return { ok: false, error: reason };

--- a/test/change-gate.test.ts
+++ b/test/change-gate.test.ts
@@ -47,6 +47,7 @@ const {
 
 const { runAiMode, summaryLines } = await import("../scripts/reverify-rolling.js");
 const { fetchPageText, MAX_PAGE_TEXT_LENGTH, MIN_PAGE_TEXT_LENGTH } = await import("../scripts/verify-freshness.js");
+const { withoutARenderingClient } = await import("../scripts/rendered-page.js");
 const { CHANGE_TYPES } = await import("../scripts/change-log.js");
 
 const NOW = new Date("2026-08-28T09:00:00Z");
@@ -570,7 +571,7 @@ describe("a recorded change must describe a change", () => {
       const original = globalThis.fetch;
       globalThis.fetch = (async () => new Response(body, { status: 200 })) as typeof fetch;
       try {
-        return await fetchPageText("https://example.test/pricing");
+        return await fetchPageText("https://example.test/pricing", { render: withoutARenderingClient });
       } finally {
         globalThis.fetch = original;
       }

--- a/test/rendered-short-pages.test.ts
+++ b/test/rendered-short-pages.test.ts
@@ -1,0 +1,262 @@
+import { describe, it } from "node:test";
+import assert from "node:assert";
+import { readFileSync, readdirSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+const {
+  fetchPageText,
+  MIN_PAGE_TEXT_LENGTH,
+  PAGE_TOO_SHORT_ERROR,
+  pageOnlyARenderingClientCanRead,
+  renderingClientCouldNotReadIt,
+  tooShortForARenderingClientToo,
+  tooShortToRead,
+} = await import("../scripts/verify-freshness.js");
+const {
+  NO_RENDERING_CLIENT,
+  READ_BY_RENDERING,
+  RENDER_TIMED_OUT,
+  findRenderer,
+  renderArguments,
+  renderPageHtml,
+  withoutARenderingClient,
+} = await import("../scripts/rendered-page.js");
+const { classifyFetchError, FAILURE_EMPTY_PAGE } = await import("../scripts/verification-state.js");
+const { priceSignals } = await import("../scripts/change-gate.js");
+const { classifySource, sourceCheckRecord } = await import("../scripts/vendor-naming.js");
+
+const OFFER = {
+  vendor: "Widgetson",
+  category: "Monitoring",
+  tier: "Free",
+  description: "Free for up to 5 hosts",
+  url: "https://widgetson.example/pricing",
+};
+
+const SHELL = `<html><head><title>Widgetson</title></head><body><div id="root"></div></body></html>`;
+
+function pageOfAtLeastTheFloor(sentence: string) {
+  const filler = " Paid plans add retention, alerting and single sign-on.";
+  let body = sentence;
+  while (body.length < MIN_PAGE_TEXT_LENGTH) body += filler;
+  return `<html><body><p>${body}</p></body></html>`;
+}
+
+const RENDERED_WITH_TERMS = pageOfAtLeastTheFloor(
+  "Widgetson pricing. The Free plan is $0 per month for up to 5 hosts."
+);
+
+function renderSpy(result: unknown) {
+  const asked: string[] = [];
+  return {
+    asked,
+    render: async (url: string) => {
+      asked.push(url);
+      return result;
+    },
+  };
+}
+
+async function readWith(body: string, init: ResponseInit, options: Record<string, unknown>) {
+  const original = globalThis.fetch;
+  globalThis.fetch = (async () => new Response(body, { status: 200, ...init })) as typeof fetch;
+  try {
+    return await fetchPageText(OFFER.url, options);
+  } finally {
+    globalThis.fetch = original;
+  }
+}
+
+async function readWhenTheFetchThrows(options: Record<string, unknown>) {
+  const original = globalThis.fetch;
+  globalThis.fetch = (async () => {
+    throw new Error("ECONNREFUSED");
+  }) as typeof fetch;
+  try {
+    return await fetchPageText(OFFER.url, options);
+  } finally {
+    globalThis.fetch = original;
+  }
+}
+
+describe("a page too short to read is read again by a rendering client", () => {
+  it("returns what the rendering client read", async () => {
+    const spy = renderSpy({ ok: true, html: RENDERED_WITH_TERMS });
+    const page = await readWith(SHELL, {}, { render: spy.render });
+    assert.deepStrictEqual(spy.asked, [OFFER.url]);
+    assert.strictEqual(page.ok, true);
+    assert.ok(page.text.length >= MIN_PAGE_TEXT_LENGTH);
+    assert.strictEqual(page.read, READ_BY_RENDERING);
+  });
+
+  it("keeps the length the fetcher got, so the two readings can be compared", async () => {
+    const spy = renderSpy({ ok: true, html: RENDERED_WITH_TERMS });
+    const page = await readWith(SHELL, {}, { render: spy.render });
+    assert.ok(page.chars_before_rendering < MIN_PAGE_TEXT_LENGTH);
+  });
+
+  it("grades the record on the rendered reading", async () => {
+    const spy = renderSpy({ ok: true, html: RENDERED_WITH_TERMS });
+    const page = await readWith(SHELL, {}, { render: spy.render });
+    const grade = classifySource(OFFER, page, priceSignals(page.text));
+    assert.strictEqual(grade.outcome, "ok");
+  });
+
+  it("says on the record that a rendering client is what read the page", async () => {
+    const spy = renderSpy({ ok: true, html: RENDERED_WITH_TERMS });
+    const page = await readWith(SHELL, {}, { render: spy.render });
+    const check = sourceCheckRecord(OFFER, page, priceSignals(page.text), "2026-09-10");
+    assert.strictEqual(check.rendered, true);
+  });
+
+  it("leaves no rendering marker on a page the fetcher read on its own", async () => {
+    const spy = renderSpy({ ok: true, html: RENDERED_WITH_TERMS });
+    const page = await readWith(RENDERED_WITH_TERMS, {}, { render: spy.render });
+    const check = sourceCheckRecord(OFFER, page, priceSignals(page.text), "2026-09-10");
+    assert.strictEqual(check.rendered, undefined);
+    assert.deepStrictEqual(spy.asked, []);
+  });
+});
+
+describe("only a page that answered and came back too short is rendered", () => {
+  for (const status of [403, 404, 410, 429, 500]) {
+    it(`does not render a page that answered HTTP ${status}`, async () => {
+      const spy = renderSpy({ ok: true, html: RENDERED_WITH_TERMS });
+      const page = await readWith(SHELL, { status }, { render: spy.render });
+      assert.deepStrictEqual(spy.asked, []);
+      assert.strictEqual(page.ok, false);
+      assert.strictEqual(page.error, `HTTP ${status}`);
+    });
+  }
+
+  it("does not render a page that never answered", async () => {
+    const spy = renderSpy({ ok: true, html: RENDERED_WITH_TERMS });
+    const page = await readWhenTheFetchThrows({ render: spy.render });
+    assert.deepStrictEqual(spy.asked, []);
+    assert.strictEqual(page.ok, false);
+  });
+
+  it("recognises the one failure that escalates and no other", () => {
+    assert.strictEqual(tooShortToRead({ ok: false, error: PAGE_TOO_SHORT_ERROR }), true);
+    assert.strictEqual(tooShortToRead({ ok: false, error: "HTTP 403" }), false);
+    assert.strictEqual(tooShortToRead({ ok: false, error: "timeout" }), false);
+    assert.strictEqual(tooShortToRead({ ok: false, error: "page too large: 99 bytes" }), false);
+    assert.strictEqual(tooShortToRead({ ok: true, text: "" }), false);
+  });
+});
+
+describe("when the rendering client cannot help", () => {
+  it("says exactly what it said before when no rendering client is installed", async () => {
+    const page = await readWith(SHELL, {}, { render: withoutARenderingClient });
+    assert.strictEqual(page.ok, false);
+    assert.strictEqual(page.error, PAGE_TOO_SHORT_ERROR);
+    assert.strictEqual(page.read, undefined);
+  });
+
+  it("names the failure when the rendering client did not finish", async () => {
+    const spy = renderSpy({ ok: false, error: RENDER_TIMED_OUT });
+    const page = await readWith(SHELL, {}, { render: spy.render });
+    assert.strictEqual(page.error, renderingClientCouldNotReadIt(RENDER_TIMED_OUT));
+    assert.strictEqual(page.read, READ_BY_RENDERING);
+  });
+
+  it("reports the rendered length when the rendered page is still under the floor", async () => {
+    const spy = renderSpy({ ok: true, html: `<html><body><p>Widgetson</p></body></html>` });
+    const page = await readWith(SHELL, {}, { render: spy.render });
+    assert.strictEqual(page.error, tooShortForARenderingClientToo(9));
+    assert.strictEqual(page.chars, 9);
+  });
+
+  it("keeps every one of those refusals in the empty-page failure class", () => {
+    assert.strictEqual(classifyFetchError(PAGE_TOO_SHORT_ERROR), FAILURE_EMPTY_PAGE);
+    assert.strictEqual(classifyFetchError(tooShortForARenderingClientToo(12)), FAILURE_EMPTY_PAGE);
+    assert.strictEqual(
+      classifyFetchError(renderingClientCouldNotReadIt(RENDER_TIMED_OUT)),
+      FAILURE_EMPTY_PAGE
+    );
+  });
+
+  it("keeps the prices the markup carried when the rendering client adds nothing", () => {
+    const short = { ok: false, error: PAGE_TOO_SHORT_ERROR, chars: 40, structured: { prices: [1] } };
+    const still = pageOnlyARenderingClientCanRead(short, { ok: false, error: RENDER_TIMED_OUT });
+    assert.deepStrictEqual(still.structured, short.structured);
+  });
+});
+
+describe("what a render costs is bounded", () => {
+  it("runs one rendering client at a time", async () => {
+    let live = 0;
+    let mostAtOnce = 0;
+    const dump = async () => {
+      live++;
+      mostAtOnce = Math.max(mostAtOnce, live);
+      await new Promise((r) => setTimeout(r, 5));
+      live--;
+      return { ok: true, html: SHELL };
+    };
+    await Promise.all(
+      ["one", "two", "three"].map((host) =>
+        renderPageHtml(`https://${host}.example`, { renderer: "/bin/sh", dump })
+      )
+    );
+    assert.strictEqual(mostAtOnce, 1);
+  });
+
+  it("keeps rendering after one render fails", async () => {
+    const failing = async () => {
+      throw new Error("spawn failed");
+    };
+    await assert.rejects(renderPageHtml("https://one.example", { renderer: "/bin/sh", dump: failing }));
+    const after = await renderPageHtml("https://two.example", {
+      renderer: "/bin/sh",
+      dump: async () => ({ ok: true, html: SHELL }),
+    });
+    assert.strictEqual(after.ok, true);
+  });
+
+  it("asks for the rendered DOM and bounds how long a page may keep loading", () => {
+    const args = renderArguments(OFFER.url, { env: {} });
+    assert.ok(args.includes("--dump-dom"));
+    assert.ok(args.some((arg: string) => /^--virtual-time-budget=\d+$/.test(arg)));
+    assert.strictEqual(args.at(-1), OFFER.url);
+  });
+
+  it("passes through the arguments the environment asks for", () => {
+    const args = renderArguments(OFFER.url, {
+      env: { AGENTDEALS_RENDERER_ARGS: "--proxy-server=proxy.example:8080 --ignore-certificate-errors" },
+    });
+    assert.ok(args.includes("--proxy-server=proxy.example:8080"));
+    assert.ok(args.includes("--ignore-certificate-errors"));
+  });
+
+  it("takes the path it is handed ahead of anything on the PATH", () => {
+    assert.strictEqual(findRenderer({ AGENTDEALS_RENDERER: "/bin/sh", PATH: "/usr/bin" }), "/bin/sh");
+  });
+
+  it("reports that nothing is installed rather than guessing", async () => {
+    assert.strictEqual(findRenderer({ PATH: "/no/such/directory" }), null);
+    const nothing = await renderPageHtml(OFFER.url, { env: { PATH: "/no/such/directory" } });
+    assert.strictEqual(nothing.error, NO_RENDERING_CLIENT);
+  });
+});
+
+describe("no test spawns a rendering client of its own", () => {
+  it("stubs the rendering client wherever it stubs the network", () => {
+    const files = readdirSync(__dirname).filter((name) => name.endsWith(".test.ts"));
+    const sources = new Map(
+      files.map((name) => [name, readFileSync(path.join(__dirname, name), "utf-8")])
+    );
+    const stubbingTheNetwork = files.filter((name) => {
+      const source = sources.get(name) ?? "";
+      return source.includes("globalThis.fetch") && source.includes("fetchPageText(");
+    });
+    assert.ok(stubbingTheNetwork.length > 0);
+    assert.deepStrictEqual(
+      stubbingTheNetwork.filter((name) => !(sources.get(name) ?? "").includes("render")),
+      []
+    );
+  });
+});

--- a/test/short-page-floor.test.ts
+++ b/test/short-page-floor.test.ts
@@ -13,6 +13,7 @@ const {
   MIN_PAGE_TEXT_LENGTH,
   PAGE_TOO_SHORT_ERROR,
 } = await import("../scripts/verify-freshness.js");
+const { withoutARenderingClient } = await import("../scripts/rendered-page.js");
 const { priceSignals } = await import("../scripts/change-gate.js");
 const { classifySource } = await import("../scripts/vendor-naming.js");
 const { classifyFetchError, FAILURE_EMPTY_PAGE } = await import("../scripts/verification-state.js");
@@ -53,7 +54,7 @@ async function readWith(body: string) {
   const original = globalThis.fetch;
   globalThis.fetch = (async () => new Response(body, { status: 200 })) as typeof fetch;
   try {
-    return await fetchPageText(OFFER.url);
+    return await fetchPageText(OFFER.url, { render: withoutARenderingClient });
   } finally {
     globalThis.fetch = original;
   }

--- a/test/typed-price-read.test.ts
+++ b/test/typed-price-read.test.ts
@@ -16,6 +16,7 @@ const {
   NO_STRUCTURED_DATA,
 } = await import("../scripts/structured-prices.js");
 const { fetchPageText } = await import("../scripts/verify-freshness.js");
+const { withoutARenderingClient } = await import("../scripts/rendered-page.js");
 const { classifySource, sourceCheckRecord, READ_FROM_MARKUP } = await import("../scripts/vendor-naming.js");
 const { priceSignals } = await import("../scripts/change-gate.js");
 const { runUrlMode, summaryLines } = await import("../scripts/reverify-rolling.js");
@@ -61,7 +62,7 @@ async function readWith(body: string) {
   const original = globalThis.fetch;
   globalThis.fetch = (async () => new Response(body, { status: 200 })) as typeof fetch;
   try {
-    return await fetchPageText(OFFER.url);
+    return await fetchPageText(OFFER.url, { render: withoutARenderingClient });
   } finally {
     globalThis.fetch = original;
   }

--- a/test/whole-page-read.test.ts
+++ b/test/whole-page-read.test.ts
@@ -18,6 +18,7 @@ const {
   VERIFIER_MODEL,
   VERIFIER_BASE_URL,
 } = await import("../scripts/verify-freshness.js");
+const { withoutARenderingClient } = await import("../scripts/rendered-page.js");
 const { priceSignals } = await import("../scripts/change-gate.js");
 const { classifySource, pageNamesVendor } = await import("../scripts/vendor-naming.js");
 
@@ -38,7 +39,7 @@ async function readWith(body: string, init: ResponseInit = {}, options = {}) {
   const original = globalThis.fetch;
   globalThis.fetch = (async () => new Response(body, { status: 200, ...init })) as typeof fetch;
   try {
-    return await fetchPageText("https://example.test/pricing", options);
+    return await fetchPageText("https://example.test/pricing", { render: withoutARenderingClient, ...options });
   } finally {
     globalThis.fetch = original;
   }


### PR DESCRIPTION
Refs #1124

A source check that fetches a 2xx page and strips fewer than 500 characters out of it now reads the page again with a headless Chromium, and grades the record on whatever that reads.

## What escalates, and what does not

`fetchPageText` reaches the rendering client from one branch: the page answered, its body was read, and `withMinimumLength` refused it. A 403, a 404, a 429, a timeout, a connection failure and a page over the byte ceiling all return before that line. A machine with no rendering client on its `PATH` returns exactly the refusal it returned before, with nothing on the record claiming a browser was tried.

Renders run one at a time, each bounded by a virtual time budget and a wall-clock timeout. `AGENTDEALS_RENDERER` names a binary; `AGENTDEALS_RENDERER_ARGS` passes flags an environment needs.

## The split, measured against the live pages

`scripts/census-1124-rendered-reads.mjs` re-read all 104 records whose stored check is `unreadable` on a too-short page:

| | records |
|---|---|
| cohort | 104 (6.6% of 1,573) |
| no longer `unreadable` | **72** (69.2%) |
| — reads `ok` | 29 |
| — `states_no_terms` | 38 |
| — `does_not_name_vendor` | 3 |
| — `states_no_amount` | 2 |
| still `unreadable` | 32 |

Of the 32 that stay: 22 render something and it is still under the floor, 10 timed out at 45s. None rendered nothing at all.

The named controls come back where the issue said they would:

| URL | fetched | rendered | outcome |
|---|---|---|---|
| `rapidapi.com/pricing/` | 0 | 0 | `unreadable` |
| `colab.research.google.com/` | 32 | 32 | `unreadable` |
| `kaggle.com` | 44 | 7,736 | `ok` |
| `apidog.com/pricing/` | 0 | 8,537 | `ok` |
| `pipedream.com/pricing` | 9 | 6,071 | `ok` |
| `coda.io/pricing` | 33 | 8,673 | `does_not_name_vendor` |

## What it costs

104 renders took 861s wall clock, 8.3s each. The cohort is 6.6% of the catalogue, so a 75-record draw escalates about 5 pages — roughly 40s added to a daily run. The run log names the binary it found, or says it found none.

## The two records this corrects

**Kaggle** named Tesla T4 with 16 GB of VRAM. `kaggle.com/docs/notebooks` states "You can add a single NVIDIA Tesla P100 to your Notebook for free" and states no VRAM figure at all, so the figure goes with the wrong card. `kaggle.com/docs/tpu` states "You can use up to 20 hours per week of TPUs and up to 9h at a time in a single session" — the weekly figure was right and the session cap was missing.

**Maxim AI** cited `getmaxim.ai/`, which reads 10,829 characters today and never names Maxim AI. `getmaxim.ai/pricing` reads 12,387 and grades `ok`.

## Two of the four rows blocking #1497 are not this shape

- `llm7.io` — 158 → 8,454, reads `ok`. Fixed here.
- `getmaxim.ai` — the citation fix above. Fixed here.
- `build.nvidia.com` — 1,471 characters, which clears the floor, so it never escalates. Forcing a render gives 8,722 and grades `ok`. Reaching it means a threshold above the readability floor, which is a cost decision rather than a bug.
- `open.bigmodel.cn` — 125 → 2,354, and still `states_no_terms`. The page renders its offer in Chinese and our price signals do not read it.

## Tests

4,988 of 4,988. 11 mutants, 10 killed. The survivor swaps `!tooShortToRead(read)` for `read.ok` at the escalation branch; at that call site `withMinimumLength` can only have returned an accepted page or a too-short refusal, so the two predicates are the same expression and the mutant is vacuous.

Every test that stubs the network now stubs the rendering client too, and a source scan over `test/` keeps it that way — otherwise a runner with Chrome installed would spawn one against a fake host.
