### PR TITLE
One record per set of terms per page, whatever day the page is read

### DIFF
--- a/scripts/census-1517-retracted-rereads.mjs
+++ b/scripts/census-1517-retracted-rereads.mjs
@@ -1,0 +1,72 @@
+#!/usr/bin/env node
+
+import { readFileSync } from "node:fs";
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { buildChangeEntry, selectNewChanges, baselineKey, SUPPRESSED_SAME_TRANSITION_REGRADED } from "./change-log.js";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const stored = JSON.parse(readFileSync(resolve(__dirname, "..", "data", "deal_changes.json"), "utf-8")).changes;
+const offers = JSON.parse(readFileSync(resolve(__dirname, "..", "data", "index.json"), "utf-8")).offers;
+
+const READING = {
+  status: "changed",
+  change_type: "limits_reduced",
+  summary: "a reading of the page",
+  current_state: "terms read off the page today",
+  impact: "medium",
+};
+
+const withdrawn = stored.filter((change) => change.resolution?.state === "retracted");
+const byKey = new Map();
+for (const change of stored) {
+  const key = baselineKey(change);
+  if (key && !byKey.has(key)) byKey.set(key, change);
+}
+
+const suppressed = [];
+const letThrough = [];
+
+for (const change of withdrawn) {
+  const offer = offers.find((o) => o.vendor === change.vendor);
+  if (!offer) {
+    letThrough.push({ change, why: "the catalogue no longer holds a record for this vendor" });
+    continue;
+  }
+  const candidate = buildChangeEntry(offer, READING, { now: new Date() }).entry;
+  const result = selectNewChanges(stored, [candidate], { windowDays: 0 });
+  if (result.fresh.length > 0) {
+    const why = [];
+    if (offer.url !== change.source_url) why.push(`we now cite ${offer.url}, the withdrawn record cited ${change.source_url || "no page"}`);
+    if (offer.description !== change.previous_state) why.push("the catalogue no longer holds the terms the withdrawal restored");
+    letThrough.push({ change, why: why.join("; ") || "no earlier record covers these terms" });
+    continue;
+  }
+  const collidedWith = result.suppressed[0].collidedWith;
+  const against = stored.find((c) => c.vendor === change.vendor && collidedWith?.includes(c.change_type) && collidedWith?.includes(c.date));
+  suppressed.push({
+    change,
+    reason: result.suppressed[0].reason,
+    collidedWith,
+    againstAWithdrawnRecord: against?.resolution?.state === "retracted",
+  });
+}
+
+console.log(`Records carrying resolution.state retracted: ${withdrawn.length}`);
+console.log(`Re-read today, the rule refuses a new record for: ${suppressed.length}`);
+console.log(`Re-read today, the rule lets a new record through for: ${letThrough.length}`);
+console.log("");
+console.log("Refused:");
+for (const { change, reason, collidedWith, againstAWithdrawnRecord } of suppressed) {
+  const held = againstAWithdrawnRecord ? "against the withdrawn record itself" : "against a later record we stand behind";
+  console.log(`  ${change.vendor.padEnd(22)} ${reason} ${held} — ${collidedWith}`);
+}
+console.log("");
+console.log("Let through:");
+for (const { change, why } of letThrough) {
+  console.log(`  ${change.vendor.padEnd(22)} ${why}`);
+}
+
+const regradings = suppressed.filter((s) => s.reason === SUPPRESSED_SAME_TRANSITION_REGRADED).length;
+console.log("");
+console.log(`Of the refusals, refused as a re-grading of terms already recorded: ${regradings}`);

--- a/scripts/change-log.js
+++ b/scripts/change-log.js
@@ -57,8 +57,9 @@ export function changeKey(change) {
 
 export function baselineKey(change) {
   const previous = typeof change?.previous_state === "string" ? change.previous_state.trim() : "";
-  if (!previous) return null;
-  return [change.vendor, change.date, change.source_url, previous].join("|");
+  const page = typeof change?.source_url === "string" ? change.source_url.trim() : "";
+  if (!previous || !page) return null;
+  return [change.vendor, page, previous].join("|");
 }
 
 export function isoDay(now) {

--- a/scripts/e2e-1517.mjs
+++ b/scripts/e2e-1517.mjs
@@ -1,0 +1,54 @@
+#!/usr/bin/env node
+
+import { readFileSync } from "node:fs";
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { runAiMode, summaryLines } from "./reverify-rolling.js";
+import { fetchPageText } from "./verify-freshness.js";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const INDEX_PATH = resolve(__dirname, "..", "data", "index.json");
+
+const PAGE = process.argv[2] ?? "https://www.scraperapi.com/pricing/";
+
+const READING_THE_RUN_GOT = {
+  status: "changed",
+  change_type: "limits_increased",
+  summary: "The free tier now offers 5,000 API credits and a 7-day trial instead of 1,000 credits/month.",
+  current_state: "Start collecting data with our 7-day trial and 5,000 API credits. No credit card required.",
+  impact: "medium",
+};
+
+const data = JSON.parse(readFileSync(INDEX_PATH, "utf-8"));
+const index = data.offers.findIndex((offer) => offer.url === PAGE);
+if (index === -1) {
+  console.error(`No catalogue record cites ${PAGE}`);
+  process.exit(2);
+}
+const offer = data.offers[index];
+
+console.log(`Re-reading ${offer.vendor} at ${offer.url}`);
+console.log(`The catalogue holds: ${offer.description}`);
+console.log(`The reading being replayed: ${READING_THE_RUN_GOT.change_type} — ${READING_THE_RUN_GOT.current_state}`);
+console.log("");
+
+const now = new Date();
+const result = await runAiMode([{ index, offer }], data, true, now, {
+  fetchFn: fetchPageText,
+  verifyFn: async () => READING_THE_RUN_GOT,
+  confirmFn: async () => ({ verdict: "yes", reason: "replayed" }),
+  rateLimitMs: 0,
+});
+
+for (const line of summaryLines(result, {
+  useAi: true,
+  checked: 1,
+  oldestRemaining: null,
+  total: data.offers.length,
+})) {
+  console.log(line);
+}
+
+console.log("");
+console.log(`Records this run would write to data/deal_changes.json: ${result.recorded.length}`);
+process.exit(result.recorded.length === 0 ? 0 : 1);

--- a/scripts/mutate-1517.mjs
+++ b/scripts/mutate-1517.mjs
@@ -1,0 +1,70 @@
+import { readFileSync, writeFileSync } from "node:fs";
+import { execFileSync } from "node:child_process";
+
+const SUITE = [
+  "test/change-log-writer.test.ts",
+  "test/change-refusals.test.ts",
+  "test/reverify-rolling.test.ts",
+];
+
+const LOG = "scripts/change-log.js";
+const ROLLING = "scripts/reverify-rolling.js";
+
+const MUTANTS = [
+  ["the-key-carries-the-detection-date-again", LOG,
+    `  return [change.vendor, page, previous].join("|");`,
+    `  return [change.vendor, change.date, page, previous].join("|");`],
+  ["a-record-naming-no-page-still-registers-a-baseline", LOG,
+    `  if (!previous || !page) return null;`,
+    `  if (!previous) return null;`],
+  ["a-record-naming-no-terms-still-registers-a-baseline", LOG,
+    `  if (!previous || !page) return null;`,
+    `  if (!page) return null;`],
+  ["the-key-forgets-which-terms-the-record-moves-away-from", LOG,
+    `  return [change.vendor, page, previous].join("|");`,
+    `  return [change.vendor, page].join("|");`],
+  ["the-key-forgets-which-page-was-read", LOG,
+    `  return [change.vendor, page, previous].join("|");`,
+    `  return [change.vendor, previous].join("|");`],
+  ["the-key-forgets-whose-record-it-is", LOG,
+    `  return [change.vendor, page, previous].join("|");`,
+    `  return [page, previous].join("|");`],
+  ["a-re-grading-registers-no-baseline-for-the-rest-of-the-batch", LOG,
+    `    if (baseline) baselines.set(baseline, key);`,
+    `    if (false) baselines.set(baseline, key);`],
+  ["the-run-summary-names-nobody", ROLLING,
+    `    for (const line of regradedVendorLines(result.suppressed)) lines.push(line);`,
+    ``],
+  ["the-run-summary-names-every-suppression", ROLLING,
+    `  return regradeRefusals(suppressed).map(`,
+    `  return (suppressed ?? []).map(`],
+  ["the-refusal-no-longer-says-what-it-collided-on", ROLLING,
+    `      detail: \`same vendor, source_url and previous_state as \${collidedWith}\`,`,
+    `      detail: \`a record we already hold\`,`],
+];
+
+function run(cmd, args) {
+  try {
+    execFileSync(cmd, args, { stdio: "pipe", encoding: "utf-8" });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+const survivors = [];
+for (const [name, file, from, to] of MUTANTS) {
+  const original = readFileSync(file, "utf-8");
+  if (!original.includes(from)) {
+    console.log(`SKIP  ${name} — the line it mutates is not in ${file}`);
+    survivors.push(`${name} (not applied)`);
+    continue;
+  }
+  writeFileSync(file, original.replace(from, to));
+  const green = run("node", ["--test", "--test-concurrency", "1", ...SUITE]);
+  writeFileSync(file, original);
+  console.log(`${green ? "SURVIVED" : "killed  "}  ${name}`);
+  if (green) survivors.push(name);
+}
+console.log(`\n${MUTANTS.length - survivors.length}/${MUTANTS.length} killed`);
+if (survivors.length > 0) console.log("survivors:", survivors.join(", "));

--- a/scripts/reverify-rolling.js
+++ b/scripts/reverify-rolling.js
@@ -368,9 +368,16 @@ export function regradeRefusals(suppressed) {
     .map(({ candidate, reason, collidedWith }) => ({
       candidate,
       reason,
-      detail: `same vendor, date, source_url and previous_state as ${collidedWith}`,
+      detail: `same vendor, source_url and previous_state as ${collidedWith}`,
       collidedWith,
     }));
+}
+
+export function regradedVendorLines(suppressed) {
+  return regradeRefusals(suppressed).map(
+    ({ candidate, collidedWith }) =>
+      `  ${candidate?.vendor ?? "(unnamed)"} (${candidate?.change_type ?? "unclassified"}) reads the same terms we already recorded as ${collidedWith}`
+  );
 }
 
 export function refusedVendorLines(rejected) {
@@ -434,6 +441,7 @@ export function summaryLines(result, { useAi, checked, oldestRemaining, total, q
     const regraded = regradeRefusals(result.suppressed).length;
     lines.push(`Already recorded, not written again: ${result.suppressed.length - regraded}`);
     lines.push(`Same transition re-read and graded differently, not written again: ${regraded}`);
+    for (const line of regradedVendorLines(result.suppressed)) lines.push(line);
     lines.push(`Detected but not recordable: ${result.unclassified.length}`);
   } else {
     lines.push("Change detection: not run. URL mode compares nothing and cannot report a change.");

--- a/test/change-log-writer.test.ts
+++ b/test/change-log-writer.test.ts
@@ -24,7 +24,7 @@ const {
   SUPPRESSED_SAME_TRANSITION_REGRADED,
 } = await import("../scripts/change-log.js");
 
-const { runUrlMode, runAiMode, summaryLines, repickWindowDays, regradeRefusals } = await import("../scripts/reverify-rolling.js");
+const { runUrlMode, runAiMode, summaryLines, repickWindowDays, regradeRefusals, regradedVendorLines } = await import("../scripts/reverify-rolling.js");
 const { firstSeenDates } = await import("../scripts/backfill-change-recorded-dates.js");
 const { report, DEFAULT_THRESHOLD_DAYS, detectorSchedule, flagTokens, DETECTOR_CLI_OPTIONS, WORKFLOW_PATH, changeLogAtRef } = await import("../scripts/check-change-log-staleness.js");
 const { VERIFIER_API_KEY_ENV, VERIFIER_MODEL } = await import("../scripts/verify-freshness.js");
@@ -164,14 +164,41 @@ describe("change log writer", () => {
       const today = { ...candidate(), recorded_date: "2026-08-27", date: "2026-08-27" };
       const { fresh, suppressed } = selectNewChanges([yesterday], [today], { windowDays: 21 });
       assert.strictEqual(fresh.length, 0);
+      assert.strictEqual(suppressed[0].reason, SUPPRESSED_SAME_TRANSITION_REGRADED);
+    });
+
+    it("holds a second change of the same kind back until the catalogue comes round again", () => {
+      const yesterday = { ...candidate(), recorded_date: "2026-08-26", date: "2026-08-26" };
+      const today = {
+        ...candidate(),
+        recorded_date: "2026-08-27",
+        date: "2026-08-27",
+        previous_state: yesterday.current_state,
+      };
+      const { fresh, suppressed } = selectNewChanges([yesterday], [today], { windowDays: 21 });
+      assert.strictEqual(fresh.length, 0);
       assert.strictEqual(suppressed[0].reason, "recorded_within_repick_window");
     });
 
-    it("records a later change of the same kind once the window has passed", () => {
+    it("records a later change of the same kind once the window has passed and the catalogue holds the terms the first one left", () => {
       const old = { ...candidate(), recorded_date: "2026-06-01", date: "2026-06-01" };
-      const now = { ...candidate(), recorded_date: "2026-08-27", date: "2026-08-27" };
+      const now = {
+        ...candidate(),
+        recorded_date: "2026-08-27",
+        date: "2026-08-27",
+        previous_state: old.current_state,
+      };
       const { fresh } = selectNewChanges([old], [now], { windowDays: 21 });
       assert.strictEqual(fresh.length, 1);
+    });
+
+    it("refuses a later change read from terms the log already has a record about", () => {
+      const old = { ...candidate(), recorded_date: "2026-06-01", date: "2026-06-01" };
+      const now = { ...candidate(), recorded_date: "2026-08-27", date: "2026-08-27" };
+      const { fresh, suppressed } = selectNewChanges([old], [now], { windowDays: 21 });
+      assert.strictEqual(fresh.length, 0);
+      assert.strictEqual(suppressed[0].reason, SUPPRESSED_SAME_TRANSITION_REGRADED);
+      assert.strictEqual(suppressed[0].collidedWith, changeKey(old));
     });
 
     it("suppresses a repeat against a hand-written entry that carries no recorded date", () => {
@@ -179,7 +206,7 @@ describe("change log writer", () => {
       delete handWritten.recorded_date;
       delete handWritten.detected_by;
       const { fresh, suppressed } = selectNewChanges([handWritten], [
-        { ...candidate(), date: "2026-08-27", recorded_date: "2026-08-27" },
+        { ...candidate(), date: "2026-08-27", recorded_date: "2026-08-27", previous_state: handWritten.current_state },
       ], { windowDays: 21 });
       assert.strictEqual(fresh.length, 0);
       assert.strictEqual(suppressed[0].reason, "recorded_within_repick_window");
@@ -258,6 +285,76 @@ describe("change log writer", () => {
       assert.strictEqual(suppressed.length, 0);
     });
 
+    it("reads one transition the same way whichever day the page was read", () => {
+      const monday = { ...candidate(), date: "2026-08-28", recorded_date: "2026-08-28" };
+      const fortnightLater = {
+        ...candidate(),
+        change_type: "limits_increased",
+        date: "2026-09-10",
+        recorded_date: "2026-09-10",
+      };
+      assert.strictEqual(baselineKey(monday), baselineKey(fortnightLater));
+      const { fresh, suppressed } = selectNewChanges([monday], [fortnightLater], { windowDays: 21 });
+      assert.strictEqual(fresh.length, 0);
+      assert.strictEqual(suppressed[0].reason, SUPPRESSED_SAME_TRANSITION_REGRADED);
+      assert.strictEqual(suppressed[0].collidedWith, changeKey(monday));
+    });
+
+    it("keeps a record we have withdrawn as evidence about the page it cites", () => {
+      const withdrawn = {
+        ...candidate(),
+        date: "2026-08-28",
+        recorded_date: "2026-08-28",
+        resolution: { state: "retracted", date: "2026-09-09", detail: "the page still states the terms" },
+      };
+      const reRead = {
+        ...candidate(),
+        change_type: "limits_increased",
+        date: "2026-09-10",
+        recorded_date: "2026-09-10",
+      };
+      const { fresh, suppressed } = selectNewChanges([withdrawn], [reRead], { windowDays: 21 });
+      assert.strictEqual(fresh.length, 0);
+      assert.strictEqual(suppressed[0].reason, SUPPRESSED_SAME_TRANSITION_REGRADED);
+    });
+
+    it("hears the same page again about terms the catalogue has moved on from", () => {
+      const withdrawn = {
+        ...candidate(),
+        date: "2026-08-28",
+        recorded_date: "2026-08-28",
+        resolution: { state: "retracted", date: "2026-09-09", detail: "the page still states the terms" },
+      };
+      const laterTerms = {
+        ...candidate(),
+        change_type: "limits_reduced",
+        date: "2026-09-10",
+        recorded_date: "2026-09-10",
+        previous_state: "500 MB storage and 2 GB egress per month, free for 14 days",
+      };
+      const { fresh, suppressed } = selectNewChanges([withdrawn], [laterTerms], { windowDays: 21 });
+      assert.strictEqual(fresh.length, 1);
+      assert.strictEqual(suppressed.length, 0);
+    });
+
+    it("hears a second page about the same terms", () => {
+      const homepage = { ...candidate(), source_url: "https://examplebase.dev/", date: "2026-08-28", recorded_date: "2026-08-28" };
+      const pricingPage = { ...candidate(), change_type: "limits_reduced", date: "2026-09-10", recorded_date: "2026-09-10" };
+      assert.notStrictEqual(homepage.source_url, pricingPage.source_url);
+      const { fresh, suppressed } = selectNewChanges([homepage], [pricingPage], { windowDays: 21 });
+      assert.strictEqual(fresh.length, 1);
+      assert.strictEqual(suppressed.length, 0);
+    });
+
+    it("reads no baseline off a record that names no page", () => {
+      const pageless = { ...candidate(), source_url: "" };
+      assert.strictEqual(baselineKey(pageless), null);
+      const { fresh } = selectNewChanges([pageless], [{ ...candidate(), change_type: "limits_increased" }], {
+        windowDays: 0,
+      });
+      assert.strictEqual(fresh.length, 1);
+    });
+
     it("hands the collided key to the refusal log", () => {
       const first = candidate();
       const { suppressed } = selectNewChanges([first], [{ ...candidate(), change_type: "limits_increased" }], {
@@ -282,18 +379,102 @@ describe("change log writer", () => {
       readFileSync(path.join(REPO, "data", "deal_changes.json"), "utf-8")
     ).changes as Array<Record<string, string>>;
 
-    it("stores no two records for one vendor, date, page and baseline", () => {
-      const groups = new Map<string, Array<Record<string, string>>>();
-      for (const change of stored) {
+    const ONE_RECORD_PER_BASELINE_SINCE = "2026-09-10";
+
+    const recordedOn = (change: Record<string, string>) => change.recorded_date || change.date;
+    const inRecordedOrder = () =>
+      [...stored].sort((a, b) => recordedOn(a).localeCompare(recordedOn(b)));
+
+    const replay = () => {
+      const admitted: Array<Record<string, string>> = [];
+      const regraded: Array<Record<string, string>> = [];
+      for (const change of inRecordedOrder()) {
+        const { fresh, suppressed } = selectNewChanges(admitted, [change], { windowDays: 0 });
+        if (fresh.length === 1) admitted.push(change);
+        else if (suppressed[0].reason === SUPPRESSED_SAME_TRANSITION_REGRADED) regraded.push(change);
+      }
+      return { admitted, regraded };
+    };
+
+    it("stores no record written since one page held one record about one set of terms", () => {
+      const written = replay()
+        .regraded.filter(change => recordedOn(change) >= ONE_RECORD_PER_BASELINE_SINCE)
+        .map(change => `${change.vendor} ${recordedOn(change)}: ${change.change_type}`);
+      assert.deepStrictEqual(written, []);
+    });
+
+    it("stores every later record read from terms the catalogue had moved on to", () => {
+      const earlierOnThePage = new Map<string, Set<string>>();
+      const movedOn: Array<Record<string, string>> = [];
+      for (const change of inRecordedOrder()) {
         const key = baselineKey(change);
         if (!key) continue;
-        if (!groups.has(key)) groups.set(key, []);
-        groups.get(key)!.push(change);
+        const page = `${change.vendor}|${change.source_url}`;
+        const seen = earlierOnThePage.get(page);
+        if (seen && !seen.has(key)) movedOn.push(change);
+        if (!seen) earlierOnThePage.set(page, new Set([key]));
+        else seen.add(key);
       }
-      const collisions = [...groups.values()]
-        .filter(group => group.length > 1)
-        .map(group => `${group[0].vendor} ${group[0].date}: ${group.map(c => c.change_type).join(" + ")}`);
-      assert.deepStrictEqual(collisions, []);
+      assert.ok(movedOn.length > 0, "no page in the log holds a second record read from later terms");
+      const regraded = new Set(replay().regraded);
+      const lost = movedOn.filter(change => regraded.has(change)).map(change => `${change.vendor} ${recordedOn(change)}`);
+      assert.deepStrictEqual(lost, []);
+    });
+
+    it("reads a page we have withdrawn a record about without writing another, however it grades it", () => {
+      const offers = JSON.parse(
+        readFileSync(path.join(REPO, "data", "index.json"), "utf-8")
+      ).offers as Array<Record<string, string>>;
+      const stillCited = stored
+        .filter(change => (change as any).resolution?.state === "retracted")
+        .map(change =>
+          offers.find(
+            offer =>
+              offer.vendor === change.vendor &&
+              offer.url === change.source_url &&
+              offer.description === change.previous_state
+          )
+        )
+        .filter(Boolean) as Array<Record<string, string>>;
+      assert.ok(stillCited.length > 0, "no withdrawn record still describes terms the catalogue publishes");
+
+      for (const changeType of ["free_tier_removed", "limits_increased", "limits_reduced"]) {
+        const readAgain = stillCited.map(
+          offer =>
+            buildChangeEntry(
+              offer,
+              { ...DETECTION, change_type: changeType, effective_date: null },
+              { now: new Date("2026-09-10T13:46:00Z") }
+            ).entry
+        );
+        const { fresh, suppressed } = selectNewChanges(stored, readAgain, { windowDays: 0 });
+        assert.deepStrictEqual(fresh.map(c => c.vendor), [], `${changeType} was written again`);
+        assert.deepStrictEqual(
+          [...new Set(suppressed.map((s: any) => s.reason))],
+          [SUPPRESSED_SAME_TRANSITION_REGRADED]
+        );
+      }
+    });
+
+    it("keeps every record we wrote about a vendor after withdrawing an earlier one", () => {
+      const withdrawnFrom = new Map<string, string>();
+      for (const change of stored) {
+        if ((change as any).resolution?.state !== "retracted") continue;
+        const first = withdrawnFrom.get(change.vendor);
+        if (!first || recordedOn(change) < first) withdrawnFrom.set(change.vendor, recordedOn(change));
+      }
+      const written = stored.filter(
+        change =>
+          !(change as any).resolution &&
+          withdrawnFrom.has(change.vendor) &&
+          recordedOn(change) > withdrawnFrom.get(change.vendor)!
+      );
+      assert.ok(written.length > 0, "we have withdrawn a record and written nothing about that vendor since");
+      const regraded = new Set(replay().regraded);
+      const lost = written
+        .filter(change => regraded.has(change))
+        .map(change => `${change.vendor} ${recordedOn(change)}: ${change.change_type}`);
+      assert.deepStrictEqual(lost, []);
     });
 
     it("keeps both records where one page moved two products on one day", () => {
@@ -337,6 +518,30 @@ describe("change log writer", () => {
       const lines = summaryLines({ ...aiResult, suppressed }, { ...context, useAi: true });
       assert.ok(lines.includes("Already recorded, not written again: 2"));
       assert.ok(lines.includes("Same transition re-read and graded differently, not written again: 1"));
+    });
+
+    it("names the vendor and the record a re-grading was refused against", () => {
+      const suppressed = [
+        { candidate: {}, reason: "already_recorded" },
+        {
+          candidate: { vendor: "Examplebase", change_type: "limits_increased" },
+          reason: SUPPRESSED_SAME_TRANSITION_REGRADED,
+          collidedWith: "Examplebase|free_tier_removed|2026-08-28|https://examplebase.dev/pricing",
+        },
+      ];
+      const lines = summaryLines({ ...aiResult, suppressed }, { ...context, useAi: true });
+      const named = lines.filter((line: string) => /Examplebase \(limits_increased\)/.test(line));
+      assert.strictEqual(named.length, 1);
+      assert.match(named[0], /Examplebase\|free_tier_removed\|2026-08-28/);
+      assert.strictEqual(
+        lines.indexOf(named[0]),
+        lines.indexOf("Same transition re-read and graded differently, not written again: 1") + 1
+      );
+    });
+
+    it("names nothing where the re-reads agreed with what we hold", () => {
+      assert.deepStrictEqual(regradedVendorLines([{ candidate: {}, reason: "already_recorded" }]), []);
+      assert.deepStrictEqual(regradedVendorLines(undefined), []);
     });
 
     it("derives the re-pick window from how long the catalogue takes to come round", () => {


### PR DESCRIPTION
Refs #1517.

`regradeRefusals`'s key carried the detection date, so the one guard against re-recording a transition deduplicated within a single run and had no memory across days. `baselineKey` now reads **vendor, source_url and previous_state**, and returns nothing where either the page or the terms are missing.

That single change makes the log's own withdrawals data the detector reads: a retracted record still sits in `data/deal_changes.json`, so it registers the terms it restored against the page it cites, and a later reading of that page from those terms is refused.

## The record this was filed for

A live fetch of `scraperapi.com/pricing/` with the 13:46Z run's reading replayed through `runAiMode`, against the real change log, in dry run — `scripts/e2e-1517.mjs`:

```
  ⚠ ScraperAPI (Web Scraping, limits_increased): The free tier now offers 5,000 API credits and a 7-day trial instead of 1,000 credits/month.
  – ScraperAPI (limits_increased) not recorded: same_transition_graded_differently (collides with ScraperAPI|free_tier_removed|2026-08-28|https://www.scraperapi.com/pricing/)
  → 1 refusal(s) written to data/change_refusals.json

Recorded to data/deal_changes.json: 0
Already recorded, not written again: 0
Same transition re-read and graded differently, not written again: 1
  ScraperAPI (limits_increased) reads the same terms we already recorded as ScraperAPI|free_tier_removed|2026-08-28|https://www.scraperapi.com/pricing/
```

The same script on this branch's parent writes the record: `Recorded to data/deal_changes.json: 1`.

## What it does not touch

Both counter-examples on the issue survive, and the reason is not a special case in either instance.

- **ploi.io** — the withdrawn record cites `https://ploi.io/`, the record written after it cites `https://ploi.io/pricing`. Different page, different key. Replayed against the log as it stood on 2026-09-07, it is written.
- **Storyblok** — the withdrawn record cites no page at all, so it registers no baseline. Its 2026-09-07 `limits_increased` is written.

## What it costs

A genuine second change read from a baseline the catalogue has not moved on from is refused too. That case has never occurred: of 33 vendor+page pairs holding more than one record, 26 moved their baseline between records — the healthy path, where the earlier record was applied to the catalogue and the description advanced. Every one of the 7 that did not is a re-grading of one transition. The refusal is written to `data/change_refusals.json` with the record it collided with, and the release valve is resolving the standing record, which moves the baseline.

## Replaying the rule over the stored log

581 of 588 records are admitted. Six are refused, every one recorded on 2026-09-09 against a 2026-08-28 record on the same page from the same terms — Segment, Harness Feature Flags, Infisical, Amplitude, Kong and Svix. Two of the six are direct contradictions: Svix and Infisical each hold `limits_reduced` and `limits_increased` about the same figures. Those are data, reported on the issue rather than corrected here.

`test/change-log-writer.test.ts` states the invariant as a ratchet over the whole log — no record written since the rule took effect may be a re-grading — so the six do not need removing for it to be green, and removing them needs no test edit.

## Tests

5,000 of 5,000. Three existing tests changed their subject rather than their expectation: two asserted the repick-window reason on a re-read that shares its baseline, which the baseline rule now reaches first, and one asserted that a later change of the same kind is written after the window has passed. Each now reads its property with the baseline moved, and the case it used to cover has its own test.
