### PR TITLE
A record we withdrew stops holding its page against every later reading

### DIFF
--- a/scripts/change-log.js
+++ b/scripts/change-log.js
@@ -1,6 +1,7 @@
 import { readFileSync, writeFileSync } from "node:fs";
 import { resolve, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
+import { theEventNeverHappened } from "../src/change-resolution.ts";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
@@ -62,6 +63,32 @@ export function baselineKey(change) {
   return [change.vendor, page, previous].join("|");
 }
 
+export function baselineHolder(change) {
+  return {
+    key: changeKey(change),
+    changeType: change.change_type,
+    withdrawn: theEventNeverHappened(change),
+  };
+}
+
+export function baselineHolders(changes) {
+  const held = new Map();
+  for (const change of changes) {
+    const baseline = baselineKey(change);
+    if (!baseline) continue;
+    const holders = held.get(baseline);
+    if (holders) holders.push(baselineHolder(change));
+    else held.set(baseline, [baselineHolder(change)]);
+  }
+  return held;
+}
+
+export function holderRefusing(holders, candidate) {
+  const stoodBehind = (holders ?? []).find((holder) => !holder.withdrawn);
+  if (stoodBehind) return stoodBehind;
+  return (holders ?? []).find((holder) => holder.changeType === candidate.change_type) ?? null;
+}
+
 export function isoDay(now) {
   return new Date(now).toISOString().slice(0, 10);
 }
@@ -112,15 +139,13 @@ export function buildChangeEntry(offer, result, options = {}) {
 export function selectNewChanges(existing, candidates, options = {}) {
   const windowDays = options.windowDays ?? DEFAULT_REPICK_WINDOW_DAYS;
   const keys = new Set(existing.map(changeKey));
-  const baselines = new Map();
+  const baselines = baselineHolders(existing);
   const recent = new Map();
   for (const change of existing) {
     const stamp = change.recorded_date || change.date;
     const pair = `${change.vendor}|${change.change_type}`;
     const previous = recent.get(pair);
     if (!previous || stamp > previous) recent.set(pair, stamp);
-    const baseline = baselineKey(change);
-    if (baseline && !baselines.has(baseline)) baselines.set(baseline, changeKey(change));
   }
 
   const fresh = [];
@@ -132,11 +157,13 @@ export function selectNewChanges(existing, candidates, options = {}) {
       continue;
     }
     const baseline = baselineKey(candidate);
-    if (baseline && baselines.has(baseline)) {
+    const holder = baseline ? holderRefusing(baselines.get(baseline), candidate) : null;
+    if (holder) {
       suppressed.push({
         candidate,
         reason: SUPPRESSED_SAME_TRANSITION_REGRADED,
-        collidedWith: baselines.get(baseline),
+        collidedWith: holder.key,
+        collidedWithWithdrawn: holder.withdrawn,
       });
       continue;
     }
@@ -148,7 +175,11 @@ export function selectNewChanges(existing, candidates, options = {}) {
     }
     fresh.push(candidate);
     keys.add(key);
-    if (baseline) baselines.set(baseline, key);
+    if (baseline) {
+      const holders = baselines.get(baseline);
+      if (holders) holders.push(baselineHolder(candidate));
+      else baselines.set(baseline, [baselineHolder(candidate)]);
+    }
     recent.set(pair, candidate.recorded_date);
   }
   return { fresh, suppressed };

--- a/scripts/mutate-1524.mjs
+++ b/scripts/mutate-1524.mjs
@@ -1,0 +1,87 @@
+import { readFileSync, writeFileSync } from "node:fs";
+import { execFileSync } from "node:child_process";
+
+const LOG = "scripts/change-log.js";
+const ROLLING = "scripts/reverify-rolling.js";
+const RESOLUTION = "src/change-resolution.ts";
+const DATA = "src/data.ts";
+
+const SUITE = [
+  "test/change-log-writer.test.ts",
+  "test/weekly-window-provenance.test.ts",
+  "test/change-refusals.test.ts",
+];
+
+const MUTANTS = [
+  ["a-withdrawn-record-holds-its-baseline-against-every-reading", LOG,
+    `    withdrawn: theEventNeverHappened(change),`,
+    `    withdrawn: false,`],
+
+  ["every-record-reads-as-withdrawn", LOG,
+    `    withdrawn: theEventNeverHappened(change),`,
+    `    withdrawn: true,`],
+
+  ["a-withdrawn-baseline-takes-the-reading-we-withdrew-again", LOG,
+    `  return (holders ?? []).find((holder) => holder.changeType === candidate.change_type) ?? null;`,
+    `  return null;`],
+
+  ["a-standing-record-stops-holding-its-baseline", LOG,
+    `  const stoodBehind = (holders ?? []).find((holder) => !holder.withdrawn);`,
+    `  const stoodBehind = (holders ?? []).find((holder) => holder.withdrawn);`],
+
+  ["any-holder-refuses-whatever-we-did-with-it", LOG,
+    `  const stoodBehind = (holders ?? []).find((holder) => !holder.withdrawn);\n  if (stoodBehind) return stoodBehind;`,
+    `  const stoodBehind = (holders ?? [])[0];\n  if (stoodBehind) return stoodBehind;`],
+
+  ["a-baseline-remembers-only-the-first-record-on-it", LOG,
+    `    const holders = held.get(baseline);\n    if (holders) holders.push(baselineHolder(change));\n    else held.set(baseline, [baselineHolder(change)]);`,
+    `    if (!held.has(baseline)) held.set(baseline, [baselineHolder(change)]);`],
+
+  ["a-correction-registers-no-baseline-for-the-rest-of-the-batch", LOG,
+    `      const holders = baselines.get(baseline);\n      if (holders) holders.push(baselineHolder(candidate));\n      else baselines.set(baseline, [baselineHolder(candidate)]);`,
+    ``],
+
+  ["a-reversal-reads-as-a-withdrawal", RESOLUTION,
+    `  return change.resolution?.state === "retracted";`,
+    `  return Boolean(change.resolution);`],
+
+  ["the-weekly-digest-counts-what-we-withdrew", DATA,
+    `  const allChanges = recordsStillInForce(loadDealChanges());\n  const now = new Date();`,
+    `  const allChanges = loadDealChanges();\n  const now = new Date();`],
+
+  ["the-refusal-log-stops-saying-the-holder-was-withdrawn", ROLLING,
+    `      detail: collidedWithWithdrawn\n        ? \`graded as \${collidedWith}, a record we withdrew\`\n        : \`same vendor, source_url and previous_state as \${collidedWith}\`,`,
+    `      detail: \`same vendor, source_url and previous_state as \${collidedWith}\`,`],
+
+  ["the-run-summary-stops-splitting-the-refusals", ROLLING,
+    `      collidedWithWithdrawn\n        ? \`  \${candidate?.vendor ?? "(unnamed)"} (\${candidate?.change_type ?? "unclassified"}) grades those terms as \${collidedWith}, a record we withdrew\`\n        : \`  \${candidate?.vendor ?? "(unnamed)"} (\${candidate?.change_type ?? "unclassified"}) reads the same terms we already recorded as \${collidedWith}\``,
+    `      \`  \${candidate?.vendor ?? "(unnamed)"} (\${candidate?.change_type ?? "unclassified"}) reads the same terms we already recorded as \${collidedWith}\``],
+];
+
+function run(cmd, args) {
+  try {
+    execFileSync(cmd, args, { stdio: "pipe", encoding: "utf-8" });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+const survivors = [];
+for (const [name, file, from, to] of MUTANTS) {
+  const original = readFileSync(file, "utf-8");
+  if (!original.includes(from)) {
+    console.log(`SKIP  ${name} — the line it mutates is not in ${file}`);
+    survivors.push(`${name} (not applied)`);
+    continue;
+  }
+  writeFileSync(file, original.replace(from, to));
+  const compiled = file.startsWith("src/") ? run("npm", ["run", "build"]) : true;
+  const green = compiled && run("node", ["--test", "--test-concurrency", "1", ...SUITE]);
+  writeFileSync(file, original);
+  if (file.startsWith("src/")) run("npm", ["run", "build"]);
+  console.log(`${green ? "SURVIVED" : "killed  "}  ${name}${compiled ? "" : " (by tsc)"}`);
+  if (green) survivors.push(name);
+}
+console.log(`\n${MUTANTS.length - survivors.length}/${MUTANTS.length} killed`);
+if (survivors.length > 0) console.log("survivors:", survivors.join(", "));

--- a/scripts/reverify-rolling.js
+++ b/scripts/reverify-rolling.js
@@ -365,18 +365,23 @@ export function repickWindowDays(total, batchSize) {
 export function regradeRefusals(suppressed) {
   return (suppressed ?? [])
     .filter((entry) => entry.reason === SUPPRESSED_SAME_TRANSITION_REGRADED)
-    .map(({ candidate, reason, collidedWith }) => ({
+    .map(({ candidate, reason, collidedWith, collidedWithWithdrawn }) => ({
       candidate,
       reason,
-      detail: `same vendor, source_url and previous_state as ${collidedWith}`,
+      detail: collidedWithWithdrawn
+        ? `graded as ${collidedWith}, a record we withdrew`
+        : `same vendor, source_url and previous_state as ${collidedWith}`,
       collidedWith,
+      collidedWithWithdrawn: Boolean(collidedWithWithdrawn),
     }));
 }
 
 export function regradedVendorLines(suppressed) {
   return regradeRefusals(suppressed).map(
-    ({ candidate, collidedWith }) =>
-      `  ${candidate?.vendor ?? "(unnamed)"} (${candidate?.change_type ?? "unclassified"}) reads the same terms we already recorded as ${collidedWith}`
+    ({ candidate, collidedWith, collidedWithWithdrawn }) =>
+      collidedWithWithdrawn
+        ? `  ${candidate?.vendor ?? "(unnamed)"} (${candidate?.change_type ?? "unclassified"}) grades those terms as ${collidedWith}, a record we withdrew`
+        : `  ${candidate?.vendor ?? "(unnamed)"} (${candidate?.change_type ?? "unclassified"}) reads the same terms we already recorded as ${collidedWith}`
   );
 }
 

--- a/test/change-log-writer.test.ts
+++ b/test/change-log-writer.test.ts
@@ -19,6 +19,7 @@ const {
   changeLogFreshness,
   changeKey,
   baselineKey,
+  baselineHolder,
   CHANGE_TYPES,
   DETECTED_BY_AI,
   SUPPRESSED_SAME_TRANSITION_REGRADED,
@@ -300,22 +301,82 @@ describe("change log writer", () => {
       assert.strictEqual(suppressed[0].collidedWith, changeKey(monday));
     });
 
-    it("keeps a record we have withdrawn as evidence about the page it cites", () => {
-      const withdrawn = {
-        ...candidate(),
-        date: "2026-08-28",
-        recorded_date: "2026-08-28",
-        resolution: { state: "retracted", date: "2026-09-09", detail: "the page still states the terms" },
-      };
-      const reRead = {
-        ...candidate(),
-        change_type: "limits_increased",
-        date: "2026-09-10",
-        recorded_date: "2026-09-10",
-      };
-      const { fresh, suppressed } = selectNewChanges([withdrawn], [reRead], { windowDays: 21 });
+    const withdrawn = (over: Record<string, unknown> = {}) => ({
+      ...candidate(),
+      date: "2026-08-28",
+      recorded_date: "2026-08-28",
+      resolution: { state: "retracted", date: "2026-09-09", detail: "the page still states the terms" },
+      ...over,
+    });
+
+    const reReadAs = (change_type: string) => ({
+      ...candidate(),
+      change_type,
+      date: "2026-09-10",
+      recorded_date: "2026-09-10",
+    });
+
+    it("keeps a record we have withdrawn as evidence against the reading we withdrew", () => {
+      const first = withdrawn();
+      const { fresh, suppressed } = selectNewChanges([first], [reReadAs(first.change_type)], { windowDays: 21 });
       assert.strictEqual(fresh.length, 0);
       assert.strictEqual(suppressed[0].reason, SUPPRESSED_SAME_TRANSITION_REGRADED);
+      assert.strictEqual(suppressed[0].collidedWith, changeKey(first));
+      assert.strictEqual(suppressed[0].collidedWithWithdrawn, true);
+    });
+
+    it("writes the correction to a page whose only record we have withdrawn", () => {
+      const first = withdrawn();
+      const corrected = reReadAs("limits_increased");
+      assert.notStrictEqual(corrected.change_type, first.change_type);
+      assert.strictEqual(baselineKey(first), baselineKey(corrected));
+      const { fresh, suppressed } = selectNewChanges([first], [corrected], { windowDays: 21 });
+      assert.strictEqual(fresh.length, 1);
+      assert.strictEqual(suppressed.length, 0);
+    });
+
+    it("holds the baseline against every reading once the correction is in", () => {
+      const first = withdrawn();
+      const { fresh } = selectNewChanges(
+        [first],
+        [reReadAs("limits_increased"), reReadAs("new_free_tier")],
+        { windowDays: 21 }
+      );
+      assert.deepStrictEqual(fresh.map((c: { change_type: string }) => c.change_type), ["limits_increased"]);
+    });
+
+    it("keeps a reversed record holding its baseline, because that change did happen", () => {
+      const reversed = withdrawn({
+        resolution: { state: "reversed", date: "2026-09-09", detail: "the vendor put the tier back" },
+      });
+      const { fresh, suppressed } = selectNewChanges([reversed], [reReadAs("limits_increased")], { windowDays: 21 });
+      assert.strictEqual(fresh.length, 0);
+      assert.strictEqual(suppressed[0].reason, SUPPRESSED_SAME_TRANSITION_REGRADED);
+      assert.strictEqual(suppressed[0].collidedWithWithdrawn, false);
+    });
+
+    it("keeps a baseline held while one record on it stands, whatever we withdrew beside it", () => {
+      const first = withdrawn();
+      const stands = { ...candidate(), change_type: "restriction", date: "2026-09-01", recorded_date: "2026-09-01" };
+      assert.strictEqual(baselineKey(first), baselineKey(stands));
+      const { fresh, suppressed } = selectNewChanges([first, stands], [reReadAs("limits_increased")], {
+        windowDays: 21,
+      });
+      assert.strictEqual(fresh.length, 0);
+      assert.strictEqual(suppressed[0].collidedWith, changeKey(stands));
+      assert.strictEqual(suppressed[0].collidedWithWithdrawn, false);
+    });
+
+    it("names the withdrawn record it graded the same way in the refusal log", () => {
+      const first = withdrawn();
+      const { suppressed } = selectNewChanges([first], [reReadAs(first.change_type)], { windowDays: 21 });
+      const refusals = regradeRefusals(suppressed);
+      assert.strictEqual(refusals[0].collidedWithWithdrawn, true);
+      assert.match(refusals[0].detail, /a record we withdrew/);
+      assert.ok(
+        regradedVendorLines(suppressed)[0].includes("a record we withdrew"),
+        regradedVendorLines(suppressed)[0]
+      );
     });
 
     it("hears the same page again about terms the catalogue has moved on from", () => {
@@ -421,38 +482,64 @@ describe("change log writer", () => {
       assert.deepStrictEqual(lost, []);
     });
 
-    it("reads a page we have withdrawn a record about without writing another, however it grades it", () => {
+    const withdrawnRecordsStillDescribingPublishedTerms = () => {
       const offers = JSON.parse(
         readFileSync(path.join(REPO, "data", "index.json"), "utf-8")
       ).offers as Array<Record<string, string>>;
-      const stillCited = stored
+      return stored
         .filter(change => (change as any).resolution?.state === "retracted")
-        .map(change =>
-          offers.find(
+        .map(change => ({
+          change,
+          offer: offers.find(
             offer =>
               offer.vendor === change.vendor &&
               offer.url === change.source_url &&
               offer.description === change.previous_state
-          )
-        )
-        .filter(Boolean) as Array<Record<string, string>>;
-      assert.ok(stillCited.length > 0, "no withdrawn record still describes terms the catalogue publishes");
+          ),
+        }))
+        .filter((pair): pair is { change: Record<string, string>; offer: Record<string, string> } =>
+          Boolean(pair.offer)
+        );
+    };
 
-      for (const changeType of ["free_tier_removed", "limits_increased", "limits_reduced"]) {
-        const readAgain = stillCited.map(
-          offer =>
-            buildChangeEntry(
-              offer,
-              { ...DETECTION, change_type: changeType, effective_date: null },
-              { now: new Date("2026-09-10T13:46:00Z") }
-            ).entry
+    const readAgainAs = (offer: Record<string, string>, changeType: string) =>
+      buildChangeEntry(
+        offer,
+        { ...DETECTION, change_type: changeType, effective_date: null },
+        { now: new Date("2026-09-10T13:46:00Z") }
+      ).entry;
+
+    it("reads a page we have withdrawn a record about and refuses the reading we withdrew", () => {
+      const withdrawn = withdrawnRecordsStillDescribingPublishedTerms();
+      assert.ok(withdrawn.length > 0, "no withdrawn record still describes terms the catalogue publishes");
+
+      const readAgain = withdrawn.map(({ change, offer }) => readAgainAs(offer, change.change_type));
+      const { fresh, suppressed } = selectNewChanges(stored, readAgain, { windowDays: 0 });
+      assert.deepStrictEqual(fresh.map(c => c.vendor), []);
+      assert.deepStrictEqual(
+        [...new Set(suppressed.map((s: any) => s.reason))],
+        [SUPPRESSED_SAME_TRANSITION_REGRADED]
+      );
+    });
+
+    it("writes the correction when that page is read again and graded another way", () => {
+      const heldOnlyByWithdrawnRecords = withdrawnRecordsStillDescribingPublishedTerms().filter(({ change }) =>
+        stored
+          .filter(other => baselineKey(other) === baselineKey(change))
+          .every(other => (other as any).resolution?.state === "retracted")
+      );
+      assert.ok(
+        heldOnlyByWithdrawnRecords.length > 0,
+        "every page we have withdrawn a record about also holds one we stand behind"
+      );
+
+      for (const { change, offer } of heldOnlyByWithdrawnRecords) {
+        const held = new Set(
+          stored.filter(other => baselineKey(other) === baselineKey(change)).map(other => other.change_type)
         );
-        const { fresh, suppressed } = selectNewChanges(stored, readAgain, { windowDays: 0 });
-        assert.deepStrictEqual(fresh.map(c => c.vendor), [], `${changeType} was written again`);
-        assert.deepStrictEqual(
-          [...new Set(suppressed.map((s: any) => s.reason))],
-          [SUPPRESSED_SAME_TRANSITION_REGRADED]
-        );
+        const unheld = CHANGE_TYPES.find((type: string) => !held.has(type))!;
+        const { fresh } = selectNewChanges(stored, [readAgainAs(offer, unheld)], { windowDays: 0 });
+        assert.strictEqual(fresh.length, 1, `${change.vendor} cannot be corrected by the pipeline`);
       }
     });
 
@@ -488,6 +575,25 @@ describe("change log writer", () => {
     it("is not vacuous — most of the log carries a baseline the rule can read", () => {
       const withBaseline = stored.filter(c => baselineKey(c) !== null);
       assert.ok(withBaseline.length > stored.length / 2, `records carrying a baseline: ${withBaseline.length}`);
+    });
+
+    it("calls the same records withdrawn as the pages that publish them do", async () => {
+      const { recordsWeStandBehind } = await import("../dist/change-resolution.js");
+      const standing = new Set(recordsWeStandBehind(stored));
+      const withdrawnByTheWriter = stored.filter(c => baselineHolder(c).withdrawn);
+      assert.ok(withdrawnByTheWriter.length > 0, "the log holds no withdrawn record, so this checks nothing");
+      assert.deepStrictEqual(
+        withdrawnByTheWriter.map(changeKey).sort(),
+        stored.filter(c => !standing.has(c)).map(changeKey).sort()
+      );
+    });
+
+    it("reads that decision off the site's own module rather than keeping a copy", () => {
+      const writer = readFileSync(path.join(REPO, "scripts", "change-log.js"), "utf-8");
+      assert.match(writer, /import \{ theEventNeverHappened \} from "\.\.\/src\/change-resolution\.ts"/);
+      const state = ["retr", "acted"].join("");
+      assert.ok(!writer.includes(state), `${path.join("scripts", "change-log.js")} names the state itself`);
+      assert.doesNotMatch(writer, /\.resolution\b/);
     });
   });
 

--- a/test/weekly-window-provenance.test.ts
+++ b/test/weekly-window-provenance.test.ts
@@ -1,9 +1,10 @@
 import { describe, it, afterEach } from "node:test";
 import assert from "node:assert";
-import { spawn, type ChildProcess } from "node:child_process";
-import { readFileSync } from "node:fs";
+import { spawn, spawnSync, type ChildProcess } from "node:child_process";
+import { readFileSync, writeFileSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
 import path from "node:path";
-import { fileURLToPath } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
 import {
   isoWeekWindow,
   withinWindow,
@@ -13,13 +14,20 @@ import {
   partitionByDateProvenance,
 } from "../dist/change-dates.js";
 import { FEED_CORRECTIONS } from "../dist/feed-corrections.js";
+import { recordsStillInForce } from "../dist/change-resolution.js";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const REPO = path.join(__dirname, "..");
 
 const publishedChanges = JSON.parse(
   readFileSync(path.join(REPO, "data", "deal_changes.json"), "utf-8")
-).changes as Array<{ date: string; date_source: string; change_type: string; vendor: string }>;
+).changes as Array<{
+  date: string;
+  date_source: string;
+  change_type: string;
+  vendor: string;
+  resolution?: { state: string; date: string } | null;
+}>;
 
 function eventDated(c: { date_source?: string }): boolean {
   return c.date_source === "vendor_page" || c.date_source === "hand_written";
@@ -41,6 +49,20 @@ async function mostRecentWeekWithADiscoveryBatch() {
   throw new Error(
     `no week in the last ${WEEKS_OF_ARCHIVE} carries a page read for the first time, so the split between the two counts cannot be checked`
   );
+}
+
+function digestOver(changesPath: string) {
+  const dataModule = pathToFileURL(path.join(REPO, "dist", "data.js")).href;
+  const run = spawnSync(
+    "node",
+    [
+      "-e",
+      `import(${JSON.stringify(dataModule)}).then((m) => process.stdout.write(JSON.stringify(m.getFormattedWeeklyDigest(0, 200))))`,
+    ],
+    { env: { ...process.env, AGENTDEALS_CHANGES_PATH: changesPath, TZ: "UTC" }, encoding: "utf-8" }
+  );
+  assert.strictEqual(run.status, 0, run.stderr);
+  return JSON.parse(run.stdout);
 }
 
 async function digestForWeekStarting(weekStart: string) {
@@ -151,8 +173,9 @@ describe("a weekly digest counts only changes with an effective date", () => {
     const { getFormattedWeeklyDigest } = await import("../dist/data.js");
     const digest = getFormattedWeeklyDigest(0, 200);
     const window = { start: digest.week_of, end: digest.week_ending };
-    const expectedDated = publishedChanges.filter((c) => eventDated(c) && withinWindow(c.date, window));
-    const expectedDiscovered = publishedChanges.filter((c) => !eventDated(c) && withinWindow(c.date, window));
+    const countable = recordsStillInForce(publishedChanges);
+    const expectedDated = countable.filter((c) => eventDated(c) && withinWindow(c.date, window));
+    const expectedDiscovered = countable.filter((c) => !eventDated(c) && withinWindow(c.date, window));
 
     assert.strictEqual(digest.changes_in_week, expectedDated.length);
     assert.strictEqual(digest.discovered_in_week, expectedDiscovered.length);
@@ -164,7 +187,9 @@ describe("a weekly digest counts only changes with an effective date", () => {
     const { getFormattedWeeklyDigest } = await import("../dist/data.js");
     const digest = getFormattedWeeklyDigest(0, 200);
     const window = { start: digest.week_of, end: digest.week_ending };
-    const inWeek = publishedChanges.filter((c) => eventDated(c) && withinWindow(c.date, window));
+    const inWeek = recordsStillInForce(publishedChanges).filter(
+      (c) => eventDated(c) && withinWindow(c.date, window)
+    );
     const count = (t: string) => inWeek.filter((c) => c.change_type === t).length;
     assert.strictEqual(digest.summary.free_tiers_removed, count("free_tier_removed"));
     assert.strictEqual(digest.summary.limits_reduced, count("limits_reduced"));
@@ -172,6 +197,47 @@ describe("a weekly digest counts only changes with an effective date", () => {
     assert.strictEqual(digest.summary.limits_increased, count("limits_increased"));
     assert.strictEqual(digest.summary.products_deprecated, count("product_deprecated"));
     assert.strictEqual(digest.summary.pricing_restructured, count("pricing_restructured"));
+  });
+
+  it("leaves a record we have withdrawn out of the week its date falls in", () => {
+    const week = isoWeekWindow(new Date());
+    const template = publishedChanges.find((c) => !eventDated(c))!;
+    const standingRecord = { ...template, vendor: "Weekly Window Control", date: week.start, resolution: null };
+    const withdrawnRecord = {
+      ...template,
+      vendor: "Weekly Window Withdrawal",
+      date: week.start,
+      resolution: { state: "retracted", date: week.start },
+    };
+
+    const file = JSON.parse(readFileSync(path.join(REPO, "data", "deal_changes.json"), "utf-8"));
+    file.changes.push(standingRecord, withdrawnRecord);
+    const dir = mkdtempSync(path.join(tmpdir(), "weekly-window-"));
+    const changesPath = path.join(dir, "deal_changes.json");
+    writeFileSync(changesPath, JSON.stringify(file));
+
+    try {
+      const digest = digestOver(changesPath);
+      const discoveredInWeek = (records: typeof file.changes) =>
+        records.filter((c: { date: string }) => !eventDated(c) && withinWindow(c.date, week)).length;
+
+      const vendorsCounted = digest.discovered_changes.map((c: { vendor: string }) => c.vendor);
+      assert.strictEqual(digest.week_of, week.start);
+      assert.strictEqual(
+        vendorsCounted.length,
+        digest.discovered_in_week,
+        "the week holds more records than the digest lists, so the two names below prove nothing"
+      );
+      assert.strictEqual(digest.discovered_in_week, discoveredInWeek(recordsStillInForce(file.changes)));
+      assert.ok(
+        digest.discovered_in_week < discoveredInWeek(file.changes),
+        "counting the raw file and counting what is in force agree, so this proves nothing"
+      );
+      assert.ok(vendorsCounted.includes(standingRecord.vendor), vendorsCounted.join(", "));
+      assert.ok(!vendorsCounted.includes(withdrawnRecord.vendor), vendorsCounted.join(", "));
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
   });
 
   it("never states the combined total as a number of changes", async () => {


### PR DESCRIPTION
`selectNewChanges` built its baseline map from every stored record and never read `resolution`. A retracted record held `vendor|source_url|previous_state` for good, and a retraction is the one case where the offer description does not move either, so nothing ever freed the slot. The pipeline could not write the correction to a record it had withdrawn.

Refs #1524

## The rule

A baseline is held by any record we stand behind. Where **every** holder is retracted, the slot is free for a candidate typed differently, and still refused for a candidate repeating the type we withdrew. A `reversed` record keeps holding its baseline — that change did happen.

The writer no longer carries its own definition of a withdrawal. It imports `theEventNeverHappened` from `src/change-resolution.ts`, the predicate the vendor pages use to emit `schema.org/EventCancelled`, and a test scans `scripts/change-log.js` for a second copy.

## Controls

Replaying the whole log in recorded order and applying the guard at `test/change-log-writer.test.ts:546`:

| | shipped rule | this rule |
|---|---|---|
| against `main` | lost: `[]` | lost: `[]` |
| against #1523's data | lost: `[Amplitude, Infisical, Svix]` | lost: `[]` |

Both halves of that table matter. `main` replays identically — 587 admitted, the same 6 refused — because no colliding holder on `main` is retracted. #1523's data replays 592 of 594 against 587 before.

Re-deciding the seven `same_transition_graded_differently` refusals of 2026-09-10 from `data/change_refusals.json`:

```
Deepgram          pricing_restructured  -> refused (holder in force)
Grafana k6 Cloud  limits_reduced        -> refused (holder in force)
IPTrace           free_tier_removed     -> refused (holder in force)
Plausible         free_tier_removed     -> refused (holder in force)
Roboflow          limits_reduced        -> refused (holder in force)
ScraperAPI        limits_increased      -> ADMITTED (every holder withdrawn, typed differently)
Semaphore CI      pricing_restructured  -> refused (repeats the type we withdrew)
```

ScraperAPI is the record #1524 was filed about, and Semaphore CI is the control beside it.

## The population

On `main`, 453 baselines: 22 held only by retracted records, 9 only by reversed, 422 with at least one holder in force. Under #1523's data the first figure is 24 — Kong and Harness Feature Flags each gain a second retracted holder, so a candidate repeating **either** of their two withdrawn types stays refused.

## Three tests held a second copy of the old rule

Each asserted that a withdrawal binds every later reading of the page, which is what this changes. Each is restated on the case the rule still refuses, and a new test states the case it now admits:

- `keeps a record we have withdrawn as evidence against the reading we withdrew` — was `…as evidence about the page it cites`
- `reads a page we have withdrawn a record about and refuses the reading we withdrew` — was `…without writing another, however it grades it`
- `writes the correction to a page whose only record we have withdrawn`, and the same over the stored log for every withdrawn record whose terms the catalogue still publishes

## The weekly digest

`test/weekly-window-provenance.test.ts:150` was a separate, test-side defect and fires for any in-week retraction, not just #1523's. `getFormattedWeeklyDigest` filters through `recordsStillInForce`; the test recomputed its expectation from the raw file. It reads the same population the digest does now, and a new test serves a changes file carrying one withdrawn and one standing record dated inside the current week and asserts the digest counts one of them. That test is non-vacuous by construction — `main` holds no resolved record dated in the current week today.

## The run report

`same_transition_graded_differently` refusals now say which kind of holder refused them, in the run summary and in `data/change_refusals.json`:

```
  ScraperAPI (limits_increased) grades those terms as <key>, a record we withdrew
  Deepgram (pricing_restructured) reads the same terms we already recorded as <key>
```

## Verification

Suite green. `node scripts/mutate-1524.mjs` — 11 mutants over the rule, the predicate, the digest filter and the report.

## What this does not do

Nothing bounds how many corrections a page can take. Once the correction is admitted it is a record we stand behind, so the baseline is held again and the next differently-graded reading is refused — one new record per withdrawal, not a queue of them. `test/change-log-writer.test.ts` states that as `holds the baseline against every reading once the correction is in`.
