### PR TITLE
A change record grades the tier it was read against, not every tier the page documents

### DIFF
--- a/data/quality_budgets.json
+++ b/data/quality_budgets.json
@@ -8,9 +8,9 @@
     "faq_answers": 166,
     "faq_answers_stating_a_figure": 77,
     "faq_answers_with_a_digit_but_no_figure": 41,
-    "records_with_superseded_terms": 181,
-    "vendor_pages_withholding_superseded_terms": 179,
-    "ungated_pages_withholding_superseded_terms": 169
+    "records_with_superseded_terms": 174,
+    "vendor_pages_withholding_superseded_terms": 172,
+    "ungated_pages_withholding_superseded_terms": 162
   },
   "raised_because": {
     "stale_fact_pages": "57 to 58 on 2026-09-09. A review that recorded review_outcome: fail used to restart the staleness clock, so finding errors on a page improved this count by more than fixing them would. The clock now starts at the last read that found nothing outstanding, which is the rule dateModifiedFor already applied to the date those pages publish. Six pages moved and /email-comparison-2026 joined the cohort; 338 stale facts became 346. Nothing about the catalogue changed — the measurement did.",

--- a/scripts/census-1526-tier-scoped-verdicts.mjs
+++ b/scripts/census-1526-tier-scoped-verdicts.mjs
@@ -1,0 +1,74 @@
+#!/usr/bin/env node
+
+import { readFileSync } from "node:fs";
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { supersedingChange } from "../dist/superseded-description.js";
+import { namesADifferentTier, readingGradesTheHostedEdition } from "../dist/change-tier.js";
+import { publishedRisk } from "../dist/data.js";
+import { changesByVendor } from "../dist/superseded-census.js";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const REPO = resolve(__dirname, "..");
+
+const AS_OF = "2026-09-10";
+const AS_OF_MS = Date.parse(`${AS_OF}T12:00:00Z`);
+
+const offers = JSON.parse(readFileSync(resolve(REPO, "data", "index.json"), "utf-8")).offers;
+const changes = JSON.parse(readFileSync(resolve(REPO, "data", "deal_changes.json"), "utf-8")).changes;
+const byVendor = changesByVendor(changes);
+
+const changeKey = (change) =>
+  change ? [change.vendor, change.change_type, change.date, change.source_url].join("|") : null;
+
+const offerKey = (offer) => [offer.vendor, offer.tier, offer.url].join("|");
+
+const rows = offers.map((offer) => {
+  const vendorChanges = byVendor.get(offer.vendor.toLowerCase()) ?? [];
+  const risk = publishedRisk(offer, vendorChanges, AS_OF, AS_OF_MS);
+  return {
+    offer: offerKey(offer),
+    withholding: changeKey(supersedingChange(offer, vendorChanges)),
+    named_tier: supersedingChange(offer, vendorChanges)?.tier ?? null,
+    risk_level: risk.risk_level,
+    risk_cause: changeKey(risk.cause),
+  };
+});
+
+if (process.argv.includes("--json")) {
+  process.stdout.write(JSON.stringify(rows, null, 2) + "\n");
+} else {
+  const withholding = rows.filter((row) => row.withholding !== null);
+  const byType = {};
+  for (const row of withholding) {
+    const type = row.withholding.split("|")[1];
+    byType[type] = (byType[type] ?? 0) + 1;
+  }
+  const named = withholding.filter((row) => row.named_tier !== null).length;
+  console.log(`offers ${rows.length}, change records ${changes.length}, as of ${AS_OF}`);
+  console.log(`withholding their stored terms: ${withholding.length}`);
+  console.log(`  the record names a tier: ${named}`);
+  console.log(`  the record names none:    ${withholding.length - named}`);
+  for (const [type, count] of Object.entries(byType).sort((a, b) => b[1] - a[1])) {
+    console.log(`  ${type}: ${count}`);
+  }
+  const demoted = rows.filter((row) => row.risk_level && row.risk_level !== "stable");
+  console.log(`rated caution or risky: ${demoted.length}`);
+
+  let pairs = 0;
+  let refusedForNamingAnotherTier = 0;
+  const refusedForReadingTheHostedEdition = [];
+  for (const offer of offers) {
+    for (const change of byVendor.get(offer.vendor.toLowerCase()) ?? []) {
+      pairs++;
+      if (namesADifferentTier(change, offer.tier)) refusedForNamingAnotherTier++;
+      if (readingGradesTheHostedEdition(change, offer)) {
+        refusedForReadingTheHostedEdition.push(`${offer.vendor} (${offer.tier}) <- ${changeKey(change)}`);
+      }
+    }
+  }
+  console.log(`offer/record pairs: ${pairs}`);
+  console.log(`  the record names another tier: ${refusedForNamingAnotherTier}`);
+  console.log(`  the reading grades the hosted edition: ${refusedForReadingTheHostedEdition.length}`);
+  for (const pair of refusedForReadingTheHostedEdition) console.log(`    ${pair}`);
+}

--- a/scripts/change-log.js
+++ b/scripts/change-log.js
@@ -116,6 +116,8 @@ export function buildChangeEntry(offer, result, options = {}) {
 
   const impact = IMPACTS.includes(result.impact) ? result.impact : DEFAULT_IMPACT;
 
+  const tierRead = typeof result.tier === "string" ? result.tier.trim() : "";
+
   return {
     entry: {
       vendor: offer.vendor,
@@ -123,6 +125,7 @@ export function buildChangeEntry(offer, result, options = {}) {
       date: statedDate ?? recordedDate,
       date_source: statedDate ? DATE_SOURCE_VENDOR_PAGE : DATE_SOURCE_DISCOVERED,
       summary,
+      ...(tierRead ? { tier: tierRead } : {}),
       previous_state: offer.description,
       current_state: currentState,
       impact,

--- a/scripts/mutate-1526.mjs
+++ b/scripts/mutate-1526.mjs
@@ -1,0 +1,108 @@
+import { readFileSync, writeFileSync } from "node:fs";
+import { execFileSync } from "node:child_process";
+
+const TIER = "src/change-tier.ts";
+const READING = "src/superseding-reading.ts";
+const RECORD = "src/free-tier-record.ts";
+const SUPERSEDED = "src/superseded-description.ts";
+const DATA = "src/data.ts";
+const VERDICT = "src/vendor-verdict.ts";
+const LOG = "scripts/change-log.js";
+
+const SUITE = [
+  "test/tier-scoped-verdicts.test.ts",
+  "test/change-log-writer.test.ts",
+  "test/superseded-terms.test.ts",
+  "test/vendor-verdict.test.ts",
+  "test/risk-badge.test.ts",
+];
+
+const MUTANTS = [
+  ["a-record-naming-another-tier-still-grades-this-one", TIER,
+    `  const named = comparableTerms(change.tier);\n  return named !== "" && named !== comparableTerms(tier);`,
+    `  return false;`],
+
+  ["a-record-naming-no-tier-grades-nothing", TIER,
+    `  const named = comparableTerms(change.tier);\n  return named !== "" && named !== comparableTerms(tier);`,
+    `  return comparableTerms(change.tier) !== comparableTerms(tier);`],
+
+  ["the-named-tier-is-read-through-neither-case-nor-whitespace", TIER,
+    `export function comparableTerms(text: string | null | undefined): string {\n  return (text ?? "").replace(/\\s+/g, " ").trim().toLowerCase();\n}`,
+    `export function comparableTerms(text: string | null | undefined): string {\n  return text ?? "";\n}`],
+
+  ["a-reading-of-the-hosted-product-grades-the-self-hosted-edition", TIER,
+    `  return namesTheVendorsHostedEdition(change.current_state ?? "", offer.vendor);`,
+    `  return false;`],
+
+  ["every-tier-reads-as-a-self-hosted-edition", TIER,
+    `  if (!tierRecordsASelfHostedEdition(offer.tier ?? "")) return false;`,
+    ``],
+
+  ["a-verdict-on-the-edition-itself-stops-grading-it", TIER,
+    `  if (VERDICTS_ABOUT_THE_EDITION_ITSELF.includes(change.change_type)) return false;`,
+    ``],
+
+  ["the-hosted-product-is-read-off-the-summary-rather-than-the-reading", TIER,
+    `  return namesTheVendorsHostedEdition(change.current_state ?? "", offer.vendor);`,
+    `  return namesTheVendorsHostedEdition(offer.tier ?? "", offer.vendor);`],
+
+  ["a-bare-mention-of-the-vendor-reads-as-its-hosted-product", READING,
+    "\\\\s+${A_HOSTED_EDITION}(?:[^A-Za-z0-9]|$)",
+    "(?:[^A-Za-z0-9]|$)"],
+
+  ["a-vendor-name-is-read-as-a-pattern-rather-than-a-name", READING,
+    "${escapeRegExp(name)}",
+    "${name}"],
+
+  ["a-community-tier-reads-as-a-self-hosted-edition", RECORD,
+    `export const A_SELF_HOSTED_EDITION = /\\boss\\b|\\bopen[\\s-]?source\\b|\\bself[\\s-]?hosted\\b/i;`,
+    `export const A_SELF_HOSTED_EDITION = /\\boss\\b|\\bopen[\\s-]?source\\b|\\bself[\\s-]?hosted\\b|\\bcommunity\\b/i;`],
+
+  ["the-withholding-stops-asking-which-tier-the-record-graded", SUPERSEDED,
+    `  if (!changeGradesTheListedTier(change, offer)) return false;`,
+    ``],
+
+  ["the-rating-stops-asking-which-tier-the-record-graded", DATA,
+    `  return vendorChanges.filter((change) => changeGradesTheListedTier(change, offer));`,
+    `  return vendorChanges;`],
+
+  ["the-history-sentence-keeps-counting-a-record-that-graded-another-tier", VERDICT,
+    `    .filter(c => offer === null || changeGradesTheListedTier(c, offer))\n`,
+    ``],
+
+  ["the-writer-drops-the-tier-the-reading-named", LOG,
+    `      ...(tierRead ? { tier: tierRead } : {}),`,
+    ``],
+
+  ["the-writer-stores-a-tier-the-reading-never-named", LOG,
+    `  const tierRead = typeof result.tier === "string" ? result.tier.trim() : "";`,
+    `  const tierRead = typeof result.tier === "string" ? result.tier.trim() : String(result.tier ?? "");`],
+];
+
+function run(cmd, args) {
+  try {
+    execFileSync(cmd, args, { stdio: "pipe", encoding: "utf-8" });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+const survivors = [];
+for (const [name, file, from, to] of MUTANTS) {
+  const original = readFileSync(file, "utf-8");
+  if (!original.includes(from)) {
+    console.log(`SKIP  ${name} — the line it mutates is not in ${file}`);
+    survivors.push(`${name} (not applied)`);
+    continue;
+  }
+  writeFileSync(file, original.replace(from, to));
+  const compiled = file.startsWith("src/") ? run("npm", ["run", "build"]) : true;
+  const green = compiled && run("node", ["--test", "--test-concurrency", "1", ...SUITE]);
+  writeFileSync(file, original);
+  if (file.startsWith("src/")) run("npm", ["run", "build"]);
+  console.log(`${green ? "SURVIVED" : "killed  "}  ${name}${compiled ? "" : " (by tsc)"}`);
+  if (green) survivors.push(name);
+}
+console.log(`\n${MUTANTS.length - survivors.length}/${MUTANTS.length} killed`);
+if (survivors.length > 0) console.log("survivors:", survivors.join(", "));

--- a/scripts/verify-freshness.js
+++ b/scripts/verify-freshness.js
@@ -267,10 +267,11 @@ Compare the stored deal info against the pricing page text. Focus on:
 Respond with EXACTLY one of these JSON objects (no other text):
 - If the deal info is still accurate: {"status":"confirmed"}
 - If the page doesn't contain enough info to verify: {"status":"unclear","summary":"<reason>"}
-- If you found a discrepancy: {"status":"changed","summary":"<what changed>","change_type":"<one of: ${CHANGE_TYPE_VALUES}>","current_state":"<what the page says the terms are now>","impact":"<high|medium|low>","effective_date":"<YYYY-MM-DD, only if the page states when this took effect>"}
+- If you found a discrepancy: {"status":"changed","summary":"<what changed>","change_type":"<one of: ${CHANGE_TYPE_VALUES}>","tier":"<the plan or edition on the page whose terms moved>","current_state":"<what the page says the terms are now>","impact":"<high|medium|low>","effective_date":"<YYYY-MM-DD, only if the page states when this took effect>"}
 
 Rules for a "changed" response:
 - current_state must describe only what the page text above says. Do not restate the stored deal info and do not infer terms the page does not state.
+- tier must name the plan or edition whose terms moved, as the page names it. This page documents several plans and the stored tier above is only one of them: where what moved is a different plan, a paid plan, or a separately priced hosted service, name that one rather than the stored tier.
 - Omit effective_date entirely unless the page gives a date.
 - If you cannot pick a change_type from that list, or cannot state current_state from the page, answer "unclear" instead.`;
 

--- a/src/change-tier.ts
+++ b/src/change-tier.ts
@@ -1,0 +1,38 @@
+import { tierRecordsASelfHostedEdition } from "./free-tier-record.js";
+import { namesTheVendorsHostedEdition } from "./superseding-reading.js";
+import type { DealChange } from "./types.js";
+
+export interface TieredChange extends Pick<DealChange, "change_type"> {
+  tier?: string | null;
+  current_state?: string | null;
+}
+
+export interface GradedOffer {
+  vendor: string;
+  tier?: string;
+}
+
+export const VERDICTS_ABOUT_THE_EDITION_ITSELF: readonly string[] = [
+  "open_source_killed",
+  "product_deprecated",
+];
+
+export function comparableTerms(text: string | null | undefined): string {
+  return (text ?? "").replace(/\s+/g, " ").trim().toLowerCase();
+}
+
+export function namesADifferentTier(change: TieredChange, tier: string | undefined): boolean {
+  const named = comparableTerms(change.tier);
+  return named !== "" && named !== comparableTerms(tier);
+}
+
+export function readingGradesTheHostedEdition(change: TieredChange, offer: GradedOffer): boolean {
+  if (VERDICTS_ABOUT_THE_EDITION_ITSELF.includes(change.change_type)) return false;
+  if (!tierRecordsASelfHostedEdition(offer.tier ?? "")) return false;
+  return namesTheVendorsHostedEdition(change.current_state ?? "", offer.vendor);
+}
+
+export function changeGradesTheListedTier(change: TieredChange, offer: GradedOffer): boolean {
+  if (namesADifferentTier(change, offer.tier)) return false;
+  return !readingGradesTheHostedEdition(change, offer);
+}

--- a/src/data.ts
+++ b/src/data.ts
@@ -4,6 +4,7 @@ import { fileURLToPath } from "node:url";
 import type { Offer, EnrichedOffer, OfferIndex, DealChange, DealChangesIndex, ChangeDateSource, StabilityClass, Referral, RiskCause, RatingWithheld, LinkUnreachable, SourceCheck } from "./types.js";
 import { isUrlSuspended } from "./referral-health.js";
 import { CHANGE_DIRECTION, type ChangeDirection } from "./change-direction.js";
+import { changeGradesTheListedTier } from "./change-tier.js";
 import { rankForListing, gateFor, utcDate, type TieBreak, type Gate, type GateCode } from "./ranking.js";
 import { unreachableNoticeForUrl, resetLinkHealthCache } from "./link-health.js";
 import { quarantineSummary, resetVerificationStateCache, type QuarantineSummary } from "./verification-state.js";
@@ -384,10 +385,10 @@ export function withheldStability(
 export function publishedStabilityFor(vendorName: string): StabilityClass | null {
   const key = vendorName.toLowerCase();
   const vendorChanges = loadDealChanges().filter((c) => c.vendor.toLowerCase() === key);
-  const stability = classifyStability(vendorChanges);
   const offer = loadOffers().find((o) => o.vendor.toLowerCase() === key);
-  if (!offer) return stability;
-  return withheldStability(unreachableNoticeForUrl(offer.url), stability, vendorChanges);
+  if (!offer) return classifyStability(vendorChanges);
+  const grading = changesGradingTheListedTier(offer, vendorChanges);
+  return withheldStability(unreachableNoticeForUrl(offer.url), classifyStability(grading), grading);
 }
 
 export function getStabilityMap(): Map<string, StabilityClass> {
@@ -399,9 +400,16 @@ export function getStabilityMap(): Map<string, StabilityClass> {
     vendorChangesMap.get(key)!.push(c);
   }
 
+  const listed = new Map<string, Offer>();
+  for (const offer of loadOffers()) {
+    const key = offer.vendor.toLowerCase();
+    if (!listed.has(key)) listed.set(key, offer);
+  }
+
   const result = new Map<string, StabilityClass>();
   for (const [vendor, vendorChanges] of vendorChangesMap) {
-    result.set(vendor, classifyStability(vendorChanges));
+    const offer = listed.get(vendor);
+    result.set(vendor, classifyStability(offer ? changesGradingTheListedTier(offer, vendorChanges) : vendorChanges));
   }
   return result;
 }
@@ -454,10 +462,12 @@ export function enrichOffers(offers: Offer[]): EnrichedOffer[] {
       now.getTime(),
     );
 
+    const grading = changesGradingTheListedTier(offer, vendorAllChangesList.get(key) ?? []);
+
     const stability = withheldStability(
       link_unreachable,
-      classifyStability(vendorAllChangesList.get(key) ?? []),
-      vendorAllChangesList.get(key) ?? [],
+      classifyStability(grading),
+      grading,
     );
 
     const days_since_verified = Math.floor(
@@ -891,13 +901,20 @@ export interface PublishedRisk {
   gate: Gate | null;
 }
 
+export function changesGradingTheListedTier(
+  offer: Pick<Offer, "vendor" | "tier">,
+  vendorChanges: DealChange[],
+): DealChange[] {
+  return vendorChanges.filter((change) => changeGradesTheListedTier(change, offer));
+}
+
 export function publishedRisk(
   offer: Offer,
   vendorChanges: DealChange[],
   servedOn: string = utcDate(),
   nowMs: number = Date.now(),
 ): PublishedRisk {
-  const assessment = vendorRiskAssessment(vendorChanges, nowMs);
+  const assessment = vendorRiskAssessment(changesGradingTheListedTier(offer, vendorChanges), nowMs);
   const link_unreachable = unreachableNoticeForUrl(offer.url, nowMs);
   const gate = gateFor(offer, servedOn);
   const withheld =
@@ -952,7 +969,7 @@ export function checkVendorRisk(
 
   const published = publishedRisk(offer, vendorChanges);
   const gate = published.gate;
-  const assessment = vendorRiskAssessment(vendorChanges);
+  const assessment = vendorRiskAssessment(changesGradingTheListedTier(offer, vendorChanges));
   const linkUnreachable = published.link_unreachable;
   const riskLevel = assessment.level;
 

--- a/src/free-tier-record.ts
+++ b/src/free-tier-record.ts
@@ -14,3 +14,9 @@ export function tierRecordsAFreeTier(tier: string): boolean {
   const label = tier.toLowerCase();
   return label.includes("free") || RECORDED_FREE_TIER_LABELS.has(label);
 }
+
+export const A_SELF_HOSTED_EDITION = /\boss\b|\bopen[\s-]?source\b|\bself[\s-]?hosted\b/i;
+
+export function tierRecordsASelfHostedEdition(tier: string): boolean {
+  return A_SELF_HOSTED_EDITION.test(tier);
+}

--- a/src/serve.ts
+++ b/src/serve.ts
@@ -969,6 +969,7 @@ function buildVendorVerdictContext(vendorName: string, servedOn: string): Vendor
     unconfirmableSince,
     input: {
       vendor: vendorName,
+      tier: primary.tier,
       level: enriched.risk_level ?? null,
       historyLevel: publishedRisk(primary, vendorChanges, servedOn).history_level,
       cause: enriched.risk_cause,
@@ -5104,7 +5105,7 @@ ${allCompareLinks.join("\n")}
     : riskLevel === null
     ? `${levelWithheldBecause}`
     : riskLevel === "stable"
-    ? `${vendorName}'s free tier is considered stable.${vendorChanges.length > 0 ? ` ${narrowingSentence(vendorChanges)} See the pricing history below.` : ""}`
+    ? `${vendorName}'s free tier is considered stable.${vendorChanges.length > 0 ? ` ${narrowingSentence(vendorChanges, primary)} See the pricing history below.` : ""}`
     : riskLevel === "caution"
     ? `${vendorName}'s free tier requires caution because of one specific recorded change${riskCause ? `, ${changeDateClause(riskCause)}: ${changeSummaryText(riskCause)}` : "."}`
     : `${vendorName}'s free tier is considered risky because of one specific recorded change${riskCause ? `, ${changeDateClause(riskCause)}: ${changeSummaryText(riskCause)}` : "."} Consider alternatives.`;
@@ -5118,7 +5119,7 @@ ${allCompareLinks.join("\n")}
     ? `${withheldLevelSentence(levelWithheld, vendorName, unconfirmableSince)} We cannot confirm what this offer provides today, so we are not recommending it for production or for anything else until we can.`
     : hasFree
     ? (riskLevel === "stable" || (primaryGate && historyLevel === "stable")
-      ? `${vendorName}'s free tier can be suitable for small production workloads and side projects. ${primaryGate ? "It" : "We rate it stable and it"} offers ${escHtmlServer(keyLimit)}, so it's a reasonable starting point.${vendorChanges.length > 0 ? ` ${narrowingSentence(vendorChanges)}` : ""} Monitor your usage against the limits and have an upgrade plan ready.`
+      ? `${vendorName}'s free tier can be suitable for small production workloads and side projects. ${primaryGate ? "It" : "We rate it stable and it"} offers ${escHtmlServer(keyLimit)}, so it's a reasonable starting point.${vendorChanges.length > 0 ? ` ${narrowingSentence(vendorChanges, primary)}` : ""} Monitor your usage against the limits and have an upgrade plan ready.`
       : riskLevel === null
       ? `${vendorName}'s free tier is usable for prototyping and development. ${primaryGate ? vendorHistorySentence(vendorName, historyLevel, riskCause) : levelWithheldBecause}`
       : `${vendorName}'s free tier is usable for prototyping and development, but we rate it ${riskLevel}${riskCause ? ` because of one recorded ${changeKindNoun(riskCause.change_type)}, ${changeDateClause(riskCause)}` : ""}. Consider alternatives with more stable pricing for critical services.`)
@@ -5552,7 +5553,7 @@ ${renderAuditBlock(altRanking.tie_break)}
     : riskLevel === null
     ? `${altWithheldBecause} Our stored record says ${vendorName} offers a free tier (${primary.tier}), and we are not publishing a stability judgement over it.`
     : riskLevel === "stable"
-    ? `Yes, ${vendorName} currently offers a free tier (${primary.tier}). ${vendorChanges.length === 0 ? "No pricing changes have been recorded." : narrowingSentence(vendorChanges)}`
+    ? `Yes, ${vendorName} currently offers a free tier (${primary.tier}). ${vendorChanges.length === 0 ? "No pricing changes have been recorded." : narrowingSentence(vendorChanges, primary)}`
     : riskLevel === "caution"
     ? `${vendorName} has a free tier (${primary.tier}), but it's flagged as "caution" because of one specific recorded change${riskCause ? `, ${changeDateClause(riskCause)}: ${changeSummaryText(riskCause)}` : "."}`
     : `${vendorName}'s free tier (${primary.tier}) is considered risky because of one specific recorded change${riskCause ? `, ${changeDateClause(riskCause)}: ${changeSummaryText(riskCause)}` : "."} Consider migrating to a more stable alternative.`;

--- a/src/superseded-description.ts
+++ b/src/superseded-description.ts
@@ -2,6 +2,7 @@ import { changeCitesASource, changeSummaryText, citationLabel } from "./change-c
 import { changeDateClause } from "./change-dates.js";
 import { narrowsTheStoredTerms } from "./change-direction.js";
 import { isNoLongerInForce } from "./change-resolution.js";
+import { changeGradesTheListedTier, comparableTerms } from "./change-tier.js";
 import { tierRecordsAFreeTier } from "./free-tier-record.js";
 import { describesOnlyATrial, openingOfAReading } from "./superseding-reading.js";
 import { punctuated } from "./terms-opening.js";
@@ -10,6 +11,7 @@ import type { ChangeResolution, DealChange } from "./types.js";
 
 export interface QuotingChange extends Pick<DealChange, "date" | "date_source" | "change_type"> {
   summary: string;
+  tier?: string | null;
   previous_state?: string | null;
   current_state?: string | null;
   source_url?: string | null;
@@ -30,19 +32,19 @@ export interface SourcedReading {
   terms: string;
 }
 
-function comparableTerms(text: string | null | undefined): string {
-  return (text ?? "").replace(/\s+/g, " ").trim().toLowerCase();
-}
-
 export function quotesTheStoredTermsAsPrevious(change: QuotingChange, description: string): boolean {
   const quoted = comparableTerms(change.previous_state);
   return quoted !== "" && quoted === comparableTerms(description);
 }
 
-export function supersedesTheStoredTerms(change: QuotingChange, description: string): boolean {
+export function supersedesTheStoredTerms(
+  change: QuotingChange,
+  offer: Pick<StoredTerms, "vendor" | "description" | "tier">,
+): boolean {
   if (isNoLongerInForce(change)) return false;
   if (!narrowsTheStoredTerms(change.change_type)) return false;
-  return quotesTheStoredTermsAsPrevious(change, description);
+  if (!changeGradesTheListedTier(change, offer)) return false;
+  return quotesTheStoredTermsAsPrevious(change, offer.description);
 }
 
 export function readingPricesNothingButATrial(
@@ -55,12 +57,12 @@ export function readingPricesNothingButATrial(
 }
 
 export function supersedingChange<T extends QuotingChange>(
-  offer: Pick<StoredTerms, "description" | "tier">,
+  offer: Pick<StoredTerms, "vendor" | "description" | "tier">,
   vendorChanges: readonly T[],
 ): T | null {
   let newest: T | null = null;
   for (const change of vendorChanges) {
-    if (!supersedesTheStoredTerms(change, offer.description)) continue;
+    if (!supersedesTheStoredTerms(change, offer)) continue;
     if (readingPricesNothingButATrial(change, offer)) continue;
     if (!newest || change.date > newest.date) newest = change;
   }
@@ -68,7 +70,7 @@ export function supersedingChange<T extends QuotingChange>(
 }
 
 export function storedTermsAreSuperseded(
-  offer: Pick<StoredTerms, "description" | "tier">,
+  offer: Pick<StoredTerms, "vendor" | "description" | "tier">,
   vendorChanges: readonly QuotingChange[],
 ): boolean {
   return supersedingChange(offer, vendorChanges) !== null;

--- a/src/superseding-reading.ts
+++ b/src/superseding-reading.ts
@@ -1,4 +1,17 @@
+import { escapeRegExp } from "./page-reviews.js";
 import { CLIPPED_TERMS_MARKER, openingOfTerms } from "./terms-opening.js";
+
+export const A_HOSTED_EDITION = "(?:Cloud|Hosted|SaaS)";
+
+export function namesTheVendorsHostedEdition(reading: string, vendor: string): boolean {
+  const name = vendor.trim();
+  if (name === "") return false;
+  const named = new RegExp(
+    `(?:^|[^A-Za-z0-9])${escapeRegExp(name)}\\s+${A_HOSTED_EDITION}(?:[^A-Za-z0-9]|$)`,
+    "i",
+  );
+  return named.test(reading);
+}
 
 export const A_FREE_PLAN =
   /\b(?:always\s+free|free\s+forever|forever\s+free)\b|\bfree[\s'"’-]{0,3}(?:plans?|tiers?|editions?|versions?|accounts?|keys?|api)\b|\b(?:plans?|tiers?|editions?|versions?|accounts?)\b[^.!?]{0,24}?\bis\s+free\b|\bfree\s+for(?:ever)?\b(?!\s+(?:\d|a\s+(?:limited|month|year)|the\s+first))|[$€£]\s?0(?:\.00)?\s*(?:\/\s*|per\s+)(?:mo|month|user|seat|year|yr)\b|\bfree\b\s*[:=]\s*[$€£]\s?0\b/i;

--- a/src/types.ts
+++ b/src/types.ts
@@ -162,6 +162,7 @@ export interface DealChange {
   reports?: import("./change-reporting.js").ChangeReportSubject;
   date: string;
   summary: string;
+  tier?: string | null;
   previous_state: string;
   current_state: string;
   impact: "high" | "medium" | "low";

--- a/src/vendor-verdict.ts
+++ b/src/vendor-verdict.ts
@@ -1,5 +1,6 @@
 import type { DealChange, RatingWithheld, RiskCause, SourceCheckOutcome } from "./types.js";
 import { CHANGE_DIRECTION, isACorrectionToOurOwnRecord } from "./data.js";
+import { changeGradesTheListedTier, type GradedOffer } from "./change-tier.js";
 import { isNoLongerInForce, theEventNeverHappened } from "./change-resolution.js";
 import { changeIsUncited, ratingWithheldForNoSourceSentence } from "./change-citation.js";
 import { changeDateClause } from "./change-dates.js";
@@ -39,10 +40,11 @@ export function changeKindNoun(changeType: string): string {
 
 export interface VendorVerdictInput {
   vendor: string;
+  tier?: string;
   level: PublishedRiskLevel | null;
   historyLevel: PublishedRiskLevel;
   cause: RiskCause | null;
-  changes: Array<Pick<DealChange, "date" | "date_source" | "change_type"> & { source_url?: string | null } & { resolution?: DealChange["resolution"] }>;
+  changes: Array<Pick<DealChange, "date" | "date_source" | "change_type"> & { source_url?: string | null } & { tier?: string | null; current_state?: string | null } & { resolution?: DealChange["resolution"] }>;
   levelWithheld: LevelWithheldReason | null;
   unconfirmableSince: string;
   ratingWithheld?: RatingWithheld | null;
@@ -76,9 +78,11 @@ function capitalise(text: string): string {
 
 function narrowingChanges(
   changes: VendorVerdictInput["changes"],
+  offer: GradedOffer | null,
 ): VendorVerdictInput["changes"] {
   return changes
     .filter(c => CHANGE_DIRECTION[c.change_type] === "negative" && !isNoLongerInForce(c))
+    .filter(c => offer === null || changeGradesTheListedTier(c, offer))
     .slice()
     .sort((a, b) => b.date.localeCompare(a.date));
 }
@@ -171,7 +175,10 @@ export function isOurOwnBookkeeping(
   return isACorrectionToOurOwnRecord(change) || theEventNeverHappened(change);
 }
 
-export function narrowingSentence(changes: VendorVerdictInput["changes"]): string {
+export function narrowingSentence(
+  changes: VendorVerdictInput["changes"],
+  offer: GradedOffer | null = null,
+): string {
   const cited = changes.filter(c => !changeIsUncited(c));
   const withdrawn = cited.filter(theEventNeverHappened);
   const corrections = cited.filter(c => isACorrectionToOurOwnRecord(c) && !theEventNeverHappened(c));
@@ -184,7 +191,7 @@ export function narrowingSentence(changes: VendorVerdictInput["changes"]): strin
       ? `The one record we hold corrects our own earlier entry rather than reporting a change the vendor made.`
       : `All ${corrections.length} records we hold correct our own earlier entries rather than reporting changes the vendor made.`;
   }
-  const narrowing = narrowingChanges(byTheVendor);
+  const narrowing = narrowingChanges(byTheVendor, offer);
   if (narrowing.length === 0) {
     return total === 1
       ? `The one change we have recorded did not narrow the terms.`
@@ -214,5 +221,5 @@ export function vendorVerdictSentence(input: VendorVerdictInput): string {
   }
 
   if (input.changes.length === 0) return `It's stable — zero pricing changes recorded.`;
-  return `We rate it stable. ${narrowingSentence(input.changes)}`;
+  return `We rate it stable. ${narrowingSentence(input.changes, { vendor: input.vendor, tier: input.tier })}`;
 }

--- a/test/alternative-to-record-claims.test.ts
+++ b/test/alternative-to-record-claims.test.ts
@@ -3,7 +3,8 @@ import assert from "node:assert";
 import { spawn, type ChildProcess } from "node:child_process";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import { CHANGE_DIRECTION, loadDealChanges } from "../dist/data.js";
+import { CHANGE_DIRECTION, loadDealChanges, loadOffers } from "../dist/data.js";
+import { changeGradesTheListedTier } from "../dist/change-tier.js";
 import { CHANGE_KIND_NOUN, narrowingSentence } from "../dist/vendor-verdict.js";
 import { isNoLongerInForce } from "../dist/change-resolution.js";
 import { vendorSlugMap } from "../dist/vendor-slug.js";
@@ -18,6 +19,14 @@ const SENTENCE_BREAK = /(?<=[.!?])\s+/;
 
 function heldBy(vendor: string, changes: DealChange[]): DealChange[] {
   return changes.filter(c => c.vendor.toLowerCase() === vendor.toLowerCase());
+}
+
+const listed = loadOffers();
+
+function gradingTheListedTier(vendor: string, changes: DealChange[]): DealChange[] {
+  const held = heldBy(vendor, changes);
+  const offer = listed.find(o => o.vendor.toLowerCase() === vendor.toLowerCase());
+  return offer ? held.filter(c => changeGradesTheListedTier(c, offer)) : held;
 }
 
 function negativeKinds(records: DealChange[]): string[] {
@@ -101,7 +110,7 @@ describe("#1297 the answer about our records reads the records", () => {
     for (const [slug, vendor] of holders) {
       const answer = answers.get(slug);
       if (answer === undefined) continue;
-      const kinds = negativeKinds(heldBy(vendor, changes));
+      const kinds = negativeKinds(gradingTheListedTier(vendor, changes));
       if (kinds.length === 0) continue;
       checked++;
       const absent = kindsCalledAbsent(answer, kinds);
@@ -117,7 +126,7 @@ describe("#1297 the answer about our records reads the records", () => {
     for (const [slug, vendor] of holders) {
       const answer = answers.get(slug);
       if (answer === undefined || !answer.startsWith("Yes, ")) continue;
-      if (negativeKinds(heldBy(vendor, changes)).length > 0) continue;
+      if (negativeKinds(gradingTheListedTier(vendor, changes)).length > 0) continue;
       checked++;
       const beyondTheTier = answer.split(SENTENCE_BREAK).slice(1).join(" ").trim();
       if (beyondTheTier === "") silent.push(`/alternative-to/${slug}`);
@@ -133,7 +142,7 @@ describe("#1297 the answer about our records reads the records", () => {
     for (const [slug, vendor] of holders) {
       const answer = answers.get(slug);
       if (answer === undefined || !answer.startsWith("Yes, ")) continue;
-      const narrowing = stillNarrowing(heldBy(vendor, changes));
+      const narrowing = stillNarrowing(gradingTheListedTier(vendor, changes));
       if (narrowing.length === 0) continue;
       if (narrowing.length === 1) {
         named++;

--- a/test/change-log-only-vendors.test.ts
+++ b/test/change-log-only-vendors.test.ts
@@ -169,7 +169,7 @@ describe("marking a comparison slot whose vendor has no catalogue entry", () => 
       .filter(slot => !REMOVAL_MARKER.test(slot.markup))
       .map(slot => `${slot.path}: ${slot.kind} ${slot.label}`);
     assert.deepStrictEqual(unmarked, []);
-    assert.ok(named.length >= 8, `only ${named.length} slots name a vendor the badge calls ended`);
+    assert.ok(named.length >= 4, `only ${named.length} slots name a vendor the badge calls ended`);
   });
 
   it("sends no marker to a vendor page that does not exist", () => {

--- a/test/change-log-writer.test.ts
+++ b/test/change-log-writer.test.ts
@@ -105,6 +105,28 @@ describe("change log writer", () => {
       assert.strictEqual(entry.date, "2026-08-27");
     });
 
+    it("records which plan on the page the reading was about", () => {
+      const { entry } = buildChangeEntry(OFFER, { ...DETECTION, tier: " Examplebase Cloud Pro " }, { now: NOW });
+      assert.strictEqual(entry.tier, "Examplebase Cloud Pro");
+    });
+
+    it("names no plan where the reading named none, so the verdict falls where it did", () => {
+      for (const named of [undefined, null, "", "   ", 7]) {
+        const { entry } = buildChangeEntry(OFFER, { ...DETECTION, tier: named }, { now: NOW });
+        assert.ok(!("tier" in entry), `tier ${JSON.stringify(named)} must leave no field behind`);
+      }
+    });
+
+    it("asks the page reader which plan moved, and says the stored one is only one of them", () => {
+      const source = readFileSync(path.join(REPO, "scripts", "verify-freshness.js"), "utf-8");
+      const from = source.indexOf("export async function verifyOfferAgainstPage");
+      const to = source.indexOf("return parseVerifierResponse", from);
+      assert.ok(from !== -1 && to > from);
+      const prompt = source.slice(from, to);
+      assert.match(prompt, /"tier":"<[^"]*plan or edition[^"]*>"/);
+      assert.match(prompt, /- tier must name the plan or edition whose terms moved/);
+    });
+
     it("writes no entry when the change type is not one we publish", () => {
       const { entry, missing } = buildChangeEntry(OFFER, { ...DETECTION, change_type: "got_worse" }, { now: NOW });
       assert.strictEqual(entry, null);

--- a/test/free-tier-vouched-share.test.ts
+++ b/test/free-tier-vouched-share.test.ts
@@ -146,7 +146,7 @@ describe("the free tier report counts what the site is prepared to vouch for", (
     assertPopulationFloor(census.vouched, 300, "offers are vouched");
     assertPopulationFloor(census.unconfirmed, 100, "recorded offers are unconfirmed");
     assert.ok(
-      censusOf(offers.filter((o) => tierRecordsAFreeTier(o.tier))).ended >= 20,
+      censusOf(offers.filter((o) => tierRecordsAFreeTier(o.tier))).ended >= 14,
       "no offer whose tier records a free tier is also recorded as ended, so the exclusion is untested",
     );
   });

--- a/test/one-verdict-engine.test.ts
+++ b/test/one-verdict-engine.test.ts
@@ -15,6 +15,7 @@ import {
   demotionInForce,
   loadDealChanges,
   loadOffers,
+  publishedRisk,
   vendorRiskAssessment,
   verdictHasLapsed,
 } from "../dist/data.js";
@@ -204,6 +205,14 @@ describe("#1206 the badge and the vendor page read the same scale", () => {
       if (!held.has(key)) held.set(key, []);
       held.get(key)!.push(c);
     }
+    const offers = loadOffers();
+    const scaleFor = (vendor: string) => {
+      const listed = offers.find(o => o.vendor === vendor);
+      const records = held.get(vendor.toLowerCase()) ?? [];
+      if (!listed) return vendorRiskAssessment(records);
+      const risk = publishedRisk(listed, records);
+      return { level: risk.history_level, rating_withheld: risk.rating_withheld };
+    };
     const slugs = [...vendorSlugMap.entries()];
     const disagreeing: string[] = [];
     let queue = 0;
@@ -217,7 +226,7 @@ describe("#1206 the badge and the vendor page read the same scale", () => {
         if (label === "not found") continue;
         if (label === ENDED_BADGE_LABEL) continue;
         if (label === UNRATED_BADGE_LABEL) {
-          if (vendorRiskAssessment(held.get(vendor.toLowerCase()) ?? []).rating_withheld === null) {
+          if (scaleFor(vendor).rating_withheld === null) {
             disagreeing.push(`/badge/${slug}.svg withholds a rating the risk scale reached`);
           }
           continue;
@@ -225,7 +234,7 @@ describe("#1206 the badge and the vendor page read the same scale", () => {
         if (label.startsWith(WITHHELD_BADGE_PREFIX)) continue;
         const level = LEVEL_FOR_BADGE[label];
         if (level === undefined) { disagreeing.push(`/badge/${slug}.svg reads "${label}"`); continue; }
-        const expected = vendorRiskAssessment(held.get(vendor.toLowerCase()) ?? []).level;
+        const expected = scaleFor(vendor).level;
         if (level !== expected) disagreeing.push(`/badge/${slug}.svg reads ${level}, the risk scale reads ${expected}`);
       }
     };

--- a/test/tier-scoped-verdicts.test.ts
+++ b/test/tier-scoped-verdicts.test.ts
@@ -1,0 +1,248 @@
+import { describe, it } from "node:test";
+import assert from "node:assert";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { assertPopulationFloor } from "./population-floor.ts";
+
+const {
+  changeGradesTheListedTier,
+  namesADifferentTier,
+  readingGradesTheHostedEdition,
+  VERDICTS_ABOUT_THE_EDITION_ITSELF,
+} = await import("../dist/change-tier.js");
+const { namesTheVendorsHostedEdition } = await import("../dist/superseding-reading.js");
+const { tierRecordsASelfHostedEdition } = await import("../dist/free-tier-record.js");
+const { supersedingChange } = await import("../dist/superseded-description.js");
+const { changesGradingTheListedTier, publishedRisk } = await import("../dist/data.js");
+const { narrowingSentence } = await import("../dist/vendor-verdict.js");
+
+type Offer = import("../src/types.ts").Offer;
+type DealChange = import("../src/types.ts").DealChange;
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO = path.join(__dirname, "..");
+
+const offers: Offer[] = JSON.parse(readFileSync(path.join(REPO, "data", "index.json"), "utf-8")).offers;
+const changes: DealChange[] = JSON.parse(
+  readFileSync(path.join(REPO, "data", "deal_changes.json"), "utf-8"),
+).changes;
+
+const changesByVendor = new Map<string, DealChange[]>();
+for (const change of changes) {
+  const key = change.vendor.toLowerCase();
+  const held = changesByVendor.get(key);
+  if (held) held.push(change);
+  else changesByVendor.set(key, [change]);
+}
+
+const changesFor = (vendor: string): DealChange[] => changesByVendor.get(vendor.toLowerCase()) ?? [];
+
+const A_SELF_HOSTED_OFFER = {
+  vendor: "Dashcorp",
+  category: "Monitoring",
+  description:
+    "Dashcorp OSS — the self-hosted dashboarding front end, free under AGPL-3.0. You run it yourself; " +
+    "Dashcorp Cloud is the hosted product and is priced separately.",
+  tier: "Free OSS",
+  url: "https://dashcorp.example/oss/dashcorp/",
+  tags: ["monitoring"],
+  verifiedDate: "2026-09-01",
+};
+
+const A_READING_OF_THE_HOSTED_PRODUCT = {
+  vendor: "Dashcorp",
+  change_type: "pricing_restructured",
+  date: "2026-09-09",
+  date_source: "discovered",
+  summary: "The free tier now includes 10k metrics, 50GB logs and 3 users.",
+  previous_state: A_SELF_HOSTED_OFFER.description,
+  current_state: "Dashcorp Cloud includes a free tier with 10k metrics, 50GB logs and 3 users.",
+  impact: "medium",
+  source_url: A_SELF_HOSTED_OFFER.url,
+  category: "Monitoring",
+  alternatives: [],
+};
+
+const A_READING_OF_THE_SELF_HOSTED_EDITION = {
+  ...A_READING_OF_THE_HOSTED_PRODUCT,
+  summary: "The self-hosted edition is now capped at 1,000 monthly active users.",
+  current_state: "Self-hosted: free, capped at 1,000 monthly active users. Community support.",
+};
+
+const THE_SAME_PAGE_LISTED_AS_A_HOSTED_TIER = { ...A_SELF_HOSTED_OFFER, tier: "Free" };
+
+describe("#1526 a record names the tier it read, and only that tier's verdict follows from it", () => {
+  it("decides nothing when the record names no tier", () => {
+    for (const named of [undefined, null, "", "   "]) {
+      assert.strictEqual(
+        namesADifferentTier({ ...A_READING_OF_THE_HOSTED_PRODUCT, tier: named }, "Free OSS"),
+        false,
+        `tier ${JSON.stringify(named)} must leave the verdict where it was`,
+      );
+    }
+  });
+
+  it("reads the named tier through whitespace and case", () => {
+    for (const named of ["Free OSS", "free oss", "  Free   OSS "]) {
+      assert.strictEqual(
+        namesADifferentTier({ ...A_READING_OF_THE_HOSTED_PRODUCT, tier: named }, "Free OSS"),
+        false,
+        `tier ${JSON.stringify(named)} names the listed tier`,
+      );
+    }
+  });
+
+  it("holds the record off a tier it does not name", () => {
+    const named = { ...A_READING_OF_THE_HOSTED_PRODUCT, tier: "Dashcorp Cloud Free" };
+    assert.strictEqual(namesADifferentTier(named, "Free OSS"), true);
+    assert.strictEqual(changeGradesTheListedTier(named, A_SELF_HOSTED_OFFER), false);
+    assert.strictEqual(namesADifferentTier(named, "Dashcorp Cloud Free"), false);
+  });
+
+  it("leaves every record stored today deciding exactly what it decided before", () => {
+    let pairs = 0;
+    for (const offer of offers) {
+      for (const change of changesFor(offer.vendor)) {
+        pairs++;
+        assert.strictEqual(
+          namesADifferentTier(change, offer.tier),
+          false,
+          `${change.vendor} ${change.change_type} ${change.date} would stop grading ${offer.tier}`,
+        );
+      }
+    }
+    assertPopulationFloor(pairs, 300, "offer/record pairs replayed through the tier test");
+  });
+});
+
+describe("#1526 a reading of the vendor's hosted product does not grade its self-hosted edition", () => {
+  it("recognises the hosted product by the vendor's own name", () => {
+    assert.strictEqual(namesTheVendorsHostedEdition("Dashcorp Cloud includes a free tier.", "Dashcorp"), true);
+    assert.strictEqual(namesTheVendorsHostedEdition("Dashcorp Hosted starts at $49.", "Dashcorp"), true);
+    assert.strictEqual(namesTheVendorsHostedEdition("Dashcorp SaaS starts at $49.", "Dashcorp"), true);
+  });
+
+  it("does not read a bare mention of the vendor as its hosted product", () => {
+    assert.strictEqual(namesTheVendorsHostedEdition("Dashcorp is now $49/month.", "Dashcorp"), false);
+    assert.strictEqual(namesTheVendorsHostedEdition("Cloud plans start at $9/mo.", "Dashcorp"), false);
+  });
+
+  it("reads a vendor name literally, punctuation and all", () => {
+    assert.strictEqual(namesTheVendorsHostedEdition("OCR.Space Cloud is $5/month.", "OCR.Space"), true);
+    assert.strictEqual(namesTheVendorsHostedEdition("OCRxSpace Cloud is $5/month.", "OCR.Space"), false);
+  });
+
+  it("names which tier labels record a self-hosted edition", () => {
+    for (const tier of ["Free OSS", "Open Source", "Community (Self-hosted)", "OSS License", "Self-Hosted"]) {
+      assert.strictEqual(tierRecordsASelfHostedEdition(tier), true, `${tier} records a self-hosted edition`);
+    }
+    for (const tier of ["Free", "Starter", "Community", "Always Free", "Developer"]) {
+      assert.strictEqual(tierRecordsASelfHostedEdition(tier), false, `${tier} does not name one`);
+    }
+  });
+
+  it("holds the reading off the self-hosted edition and lets it grade a hosted listing", () => {
+    assert.strictEqual(
+      readingGradesTheHostedEdition(A_READING_OF_THE_HOSTED_PRODUCT, A_SELF_HOSTED_OFFER),
+      true,
+    );
+    assert.strictEqual(
+      readingGradesTheHostedEdition(A_READING_OF_THE_HOSTED_PRODUCT, THE_SAME_PAGE_LISTED_AS_A_HOSTED_TIER),
+      false,
+    );
+  });
+
+  it("lets a reading of the self-hosted edition itself grade it", () => {
+    assert.strictEqual(
+      readingGradesTheHostedEdition(A_READING_OF_THE_SELF_HOSTED_EDITION, A_SELF_HOSTED_OFFER),
+      false,
+    );
+    assert.strictEqual(
+      changeGradesTheListedTier(A_READING_OF_THE_SELF_HOSTED_EDITION, A_SELF_HOSTED_OFFER),
+      true,
+    );
+  });
+
+  it("lets a record that ends the edition itself grade it, whatever the reading names", () => {
+    for (const change_type of VERDICTS_ABOUT_THE_EDITION_ITSELF) {
+      assert.strictEqual(
+        readingGradesTheHostedEdition({ ...A_READING_OF_THE_HOSTED_PRODUCT, change_type }, A_SELF_HOSTED_OFFER),
+        false,
+        `${change_type} is a verdict on the edition itself`,
+      );
+    }
+  });
+});
+
+describe("#1526 the withholding and the rating read the same record the same way", () => {
+  it("publishes the self-hosted terms and withholds them from a listing of the hosted tier", () => {
+    assert.strictEqual(supersedingChange(A_SELF_HOSTED_OFFER, [A_READING_OF_THE_HOSTED_PRODUCT]), null);
+    assert.strictEqual(
+      supersedingChange(THE_SAME_PAGE_LISTED_AS_A_HOSTED_TIER, [A_READING_OF_THE_HOSTED_PRODUCT]),
+      A_READING_OF_THE_HOSTED_PRODUCT,
+    );
+  });
+
+  it("rates the self-hosted edition off the same record the withholding refused", () => {
+    assert.deepStrictEqual(
+      changesGradingTheListedTier(A_SELF_HOSTED_OFFER, [A_READING_OF_THE_HOSTED_PRODUCT as DealChange]),
+      [],
+    );
+    const held = publishedRisk(
+      A_SELF_HOSTED_OFFER as Offer,
+      [A_READING_OF_THE_HOSTED_PRODUCT as DealChange],
+      "2026-09-10",
+      Date.parse("2026-09-10T12:00:00Z"),
+    );
+    assert.strictEqual(held.history_level, "stable");
+    assert.strictEqual(held.cause, null);
+
+    const rated = publishedRisk(
+      THE_SAME_PAGE_LISTED_AS_A_HOSTED_TIER as Offer,
+      [A_READING_OF_THE_HOSTED_PRODUCT as DealChange],
+      "2026-09-10",
+      Date.parse("2026-09-10T12:00:00Z"),
+    );
+    assert.strictEqual(rated.history_level, "caution");
+    assert.strictEqual(rated.cause, A_READING_OF_THE_HOSTED_PRODUCT);
+  });
+
+  it("says the terms narrowed only where the record graded the tier being rated", () => {
+    const held = [A_READING_OF_THE_HOSTED_PRODUCT];
+    assert.match(
+      narrowingSentence(held, THE_SAME_PAGE_LISTED_AS_A_HOSTED_TIER),
+      /One recorded pricing restructure narrowed the terms/,
+    );
+    assert.strictEqual(
+      narrowingSentence(held, A_SELF_HOSTED_OFFER),
+      "The one change we have recorded did not narrow the terms.",
+    );
+  });
+
+  it("withholds no offer's terms on a record that may not grade its tier", () => {
+    for (const offer of offers) {
+      const withholding = supersedingChange(offer, changesFor(offer.vendor));
+      if (!withholding) continue;
+      assert.strictEqual(
+        changeGradesTheListedTier(withholding, offer),
+        true,
+        `${offer.vendor} (${offer.tier}) withholds on ${withholding.change_type} ${withholding.date}`,
+      );
+    }
+  });
+
+  it("rates no offer off a record that may not grade its tier", () => {
+    const servedOn = "2026-09-10";
+    const nowMs = Date.parse(`${servedOn}T12:00:00Z`);
+    for (const offer of offers) {
+      const cause = publishedRisk(offer, changesFor(offer.vendor), servedOn, nowMs).cause;
+      if (!cause) continue;
+      assert.strictEqual(
+        changeGradesTheListedTier(cause, offer),
+        true,
+        `${offer.vendor} (${offer.tier}) is rated off ${cause.change_type} ${cause.date}`,
+      );
+    }
+  });
+});

--- a/test/vendor-risk.test.ts
+++ b/test/vendor-risk.test.ts
@@ -39,18 +39,20 @@ describe("checkVendorRisk logic", () => {
   });
 
   it("reports the level the risk engine reached for every vendor it demotes", async () => {
-    const { checkVendorRisk, loadOffers, loadDealChanges, vendorRiskAssessment } = await import("../dist/data.js");
+    const { checkVendorRisk, loadOffers, loadDealChanges, publishedRisk } = await import("../dist/data.js");
     const changes = loadDealChanges();
+    const offers = loadOffers();
     const forVendor = (v: string) => changes.filter(c => c.vendor.toLowerCase() === v.toLowerCase());
-    const demoted = [...new Set(loadOffers().map(o => o.vendor))]
-      .filter(v => vendorRiskAssessment(forVendor(v)).level !== "stable");
+    const listedAs = (v: string) => offers.find(o => o.vendor === v)!;
+    const levelFor = (v: string) => publishedRisk(listedAs(v), forVendor(v)).history_level;
+    const demoted = [...new Set(offers.map(o => o.vendor))].filter(v => levelFor(v) !== "stable");
     assert.ok(demoted.length > 0, "the index holds no vendor the risk scale demotes");
     let published = 0;
     for (const vendor of demoted) {
       const result = checkVendorRisk(vendor);
       if ("error" in result || result.result.risk_level === null) continue;
       published++;
-      assert.strictEqual(result.result.risk_level, vendorRiskAssessment(forVendor(vendor)).level, vendor);
+      assert.strictEqual(result.result.risk_level, levelFor(vendor), vendor);
       assert.ok(result.result.changes.length > 0, `${vendor} carries a level with no record behind it`);
     }
     assert.ok(published > 0, "no demoted vendor published a level");

--- a/test/vendor-verdict.test.ts
+++ b/test/vendor-verdict.test.ts
@@ -306,6 +306,7 @@ interface VendorRow {
   withheld: ReturnType<typeof levelWithheldReason>;
   badgeRendered: boolean;
   sentence: string;
+  tier: string;
   changes: DealChange[];
   gate: Gate | null;
   cause: RiskCause | null;
@@ -338,6 +339,7 @@ function vendorRows(): VendorRow[] {
       badgeRendered: ended || !(gate || enriched.risk_level === null || (enriched.link_unreachable && expected === "stable")),
       sentence: vendorVerdictSentence({
         vendor,
+        tier: primary.tier,
         level: enriched.risk_level ?? null,
         historyLevel: publishedRisk(primary, vendorChanges).history_level,
         cause: enriched.risk_cause ?? null,
@@ -348,6 +350,7 @@ function vendorRows(): VendorRow[] {
         offerEnded: ended,
         gate: gate?.code ?? null,
       }),
+      tier: primary.tier,
       changes: vendorChanges,
       gate,
       cause: enriched.risk_cause ?? null,
@@ -565,7 +568,7 @@ describe("vendor verdict — as rendered", () => {
             if (!answers.reliable.includes(row.expected)) {
               wrong.push(`${row.slug}: the reliability answer does not carry the ${row.expected} rating`);
             }
-            if (row.expected === "stable" && !answers.reliable.includes(narrowingSentence(row.changes))) {
+            if (row.expected === "stable" && !answers.reliable.includes(narrowingSentence(row.changes, row))) {
               wrong.push(`${row.slug}: the reliability answer does not say what the records it holds did — ${answers.reliable}`);
             }
           }
@@ -613,7 +616,7 @@ describe("vendor verdict — as rendered", () => {
       digitalocean.gate,
       "/vendor/digitalocean renders an ungated record again, so assert this on the page rather than on the composer",
     );
-    const composed = narrowingSentence(digitalocean.changes);
+    const composed = narrowingSentence(digitalocean.changes, digitalocean);
     assert.match(composed, /One recorded restriction/);
     assert.doesNotMatch(composed, /2 recorded changes narrowed the terms/);
     assert.doesNotMatch(composed, /corrects our own earlier entry/);


### PR DESCRIPTION
A change record is scoped to a page. A verdict is scoped to a tier. `narrowsTheStoredTerms()` looked up `change_type` in a static map and nothing in the path asked whether the change touched the tier we list, so a reading of a vendor's hosted price list withheld the terms of its AGPL-3.0 self-hosted edition and rated it caution.

Refs #1526

## The mechanism

`src/change-tier.ts` holds one predicate, `changeGradesTheListedTier(change, offer)`, and both consumers call it:

- **the withholding** — `supersedesTheStoredTerms()` now takes the offer rather than its description, and returns false where the record does not grade the offer's tier;
- **the rating** — `publishedRisk()` assesses the records that grade the listed tier, so the level, its cause, the badge and the stability class all read the same set.

Two things decide it.

**A record names the tier it read.** `DealChange.tier` is new and optional. The detector asks the page reader which plan moved and says the stored tier is only one of the plans the page documents; `buildChangeEntry` writes the field when the reading names one and omits it otherwise. A record naming no tier behaves exactly as before.

**A reading of the vendor's hosted product does not grade its self-hosted edition.** Where the offer's tier records a self-hosted edition and the reading names `<Vendor> Cloud`, `<Vendor> Hosted` or `<Vendor> SaaS`, the record grades that product and not this one. `open_source_killed` and `product_deprecated` are verdicts on the edition itself and are exempt whatever the reading names. This is the same shape as `readingPricesNothingButATrial`, which already sat in this path.

## The measurements

**AC-3 — the tier test decides nothing today, replayed both ways.** Every offer joined to its vendor's records is 460 pairs. `namesADifferentTier` is true for **0 of 460**: no record stored today names a tier, so the diff from that half is empty. `test/tier-scoped-verdicts.test.ts` replays it.

**The hosted-edition test fires on 5 of those 460 pairs, over 4 vendors** — Grafana, SigNoz, Tyk and DBOS, the last holding two records. Replaying the whole catalogue and diffing withholding, risk level and risk cause per offer: **4 rows of 1,547 move**, and they are those four vendors.

| vendor | tier | before | after |
|---|---|---|---|
| Grafana | Free OSS | withheld · caution | published · stable |
| SigNoz | Free OSS | withheld · caution | published · stable |
| Tyk | Open Source | withheld · caution | published · stable |
| DBOS | Free (open-source library) | rated risky | stable |

**AC-5 — the census re-run.** 177 offers withheld their stored terms on `main` this morning, not 183: eight retractions landed with #1523. After this change **174 withhold, 0 on a record that names a tier and 174 on a record that names none** — `limits_reduced` 88, `pricing_restructured` 52 (was 55), `pricing_model_change` 14, `free_tier_removed` 12, `restriction` 4, `product_deprecated` 4. `scripts/census-1526-tier-scoped-verdicts.mjs` prints it.

**AC-4 — verified against a running server.** `/vendor/grafana` publishes the AGPL-3.0 terms, `/vendor/signoz` publishes the community edition's, `/vendor/tyk` publishes MPL-2.0, and none of the three carries a superseded notice. `/vendor/netlify` still withholds, unchanged. The three badges read `active` where they read `at-risk`.

**AC-6** — `data/deal_changes.json` is untouched.

## DBOS, which was not in the census

The rule found a fourth record of the same shape, outside the 183 because it never withheld — it only rated. DBOS's `free_tier_removed` record says in its own summary: *"DBOS Cloud free tier … no longer appears … Only the open-source DBOS Transact library remains free"*. We list the library. The site published `removed` on its badge — that this vendor's free tier has gone — over a record stating that the tier we list is still free. It reads `active` now.

## Three surfaces had to be brought along

The rating moving without them would have made the next defect rather than fixed one.

- **the stability class** — `classifyStability` reads a vendor's records with no offer in hand, so Grafana would have shipped `stable` beside `volatile`. `enrichOffers`, `publishedStabilityFor` and `getStabilityMap` classify the records that grade the listed tier.
- **the history sentence** — `/vendor/grafana` said *"We rate it stable. One recorded pricing restructure narrowed the terms"* beside terms it publishes in full. `narrowingSentence` takes the offer; the page now reads *"The one change we have recorded did not narrow the terms."*
- **`checkVendorRisk`** — took the unfiltered assessment beside a filtered `publishedRisk` in the same function.

## Tests

`test/tier-scoped-verdicts.test.ts` is new: the predicates over fixtures, the replay over the whole log, and two invariants over live data — no offer withholds its terms on a record that may not grade its tier, and none is rated off one.

Two tests held a second copy of the rating rule and were restated on the production path rather than deleted: `one-verdict-engine` and `vendor-risk` each rebuilt the expected level with `vendorRiskAssessment` over the unfiltered records. They read `publishedRisk` now, which is the function the badge reads.

Two non-vacuity guards lost a member and were lowered to clear the 25% headroom the framework asks for: offers whose tier records a free tier and that are recorded as ended, 20 → 19 (floor 20 → 14), and slots naming a vendor the badge calls ended, 8 → 6 (floor 8 → 4). DBOS is the member both lost.

The three superseded budgets are lowered to what the change measures, in the same commit.

15 mutants, 15 killed — `scripts/mutate-1526.mjs`. One survived the first run: the test I had restated on the production path became a mirror of it rather than a control, so `narrowingSentence` is now locked on a fixture instead.
