### PR TITLE
One refused reading costs one vendor, not the batch it arrived in

### DIFF
--- a/.github/workflows/reverify.yml
+++ b/.github/workflows/reverify.yml
@@ -75,17 +75,24 @@ jobs:
             data/index.json data/deal_changes.json data/change_refusals.json data/verification_state.json data/quality_budgets.json data/page-lastmod.json artifacts/free-llm-api-index/README.md
 
       - name: Say where it can be seen what the gate did with this run's data
-        if: always() && (steps.gate.outputs.quarantined == 'true' || steps.gate.outputs.pushed_over_failures == 'true')
+        if: always() && (steps.gate.outputs.quarantined == 'true' || steps.gate.outputs.pushed_over_failures == 'true' || steps.gate.outputs.held_back_vendors != '')
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           QUARANTINED: ${{ steps.gate.outputs.quarantined }}
           QUARANTINE_REF: ${{ steps.gate.outputs.quarantine_ref }}
           QUARANTINE_REASON: ${{ steps.gate.outputs.quarantine_reason }}
+          PUSHED_OVER_FAILURES: ${{ steps.gate.outputs.pushed_over_failures }}
           NON_BLOCKING_FILES: ${{ steps.gate.outputs.non_blocking_files }}
+          HELD_BACK_VENDORS: ${{ steps.gate.outputs.held_back_vendors }}
         run: |
           if [ "$QUARANTINED" = "true" ]; then
             bash scripts/report-data-push-outcome.sh "Daily rolling re-verification" refused "$QUARANTINE_REF" "$QUARANTINE_REASON"
-          else
+            exit 0
+          fi
+          if [ -n "$HELD_BACK_VENDORS" ]; then
+            bash scripts/report-data-push-outcome.sh "Daily rolling re-verification" held-back-a-vendor "$HELD_BACK_VENDORS"
+          fi
+          if [ "$PUSHED_OVER_FAILURES" = "true" ]; then
             bash scripts/report-data-push-outcome.sh "Daily rolling re-verification" shipped-over-failures "$NON_BLOCKING_FILES"
           fi
 

--- a/scripts/gate-data-push.sh
+++ b/scripts/gate-data-push.sh
@@ -9,6 +9,7 @@ fi
 QUARANTINE_PREFIX="$1"
 MESSAGE="$2"
 shift 2
+COMMITTABLE=("$@")
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 OUTPUT="${GITHUB_OUTPUT:-/dev/null}"
@@ -58,12 +59,16 @@ LOG="$(mktemp)"
 VERDICT="$(mktemp)"
 GATE_FAILING_FILES="$(mktemp)"
 SUBPROCESS_OUTPUT="$(mktemp)"
+HELD_BACK_LIST="$(mktemp)"
 export GATE_FAILING_FILES
 export GITHUB_OUTPUT="$SUBPROCESS_OUTPUT"
-trap 'rm -f "$LOG" "$VERDICT" "$GATE_FAILING_FILES" "$SUBPROCESS_OUTPUT"' EXIT
+trap 'rm -f "$LOG" "$VERDICT" "$GATE_FAILING_FILES" "$SUBPROCESS_OUTPUT" "$HELD_BACK_LIST"' EXIT
 
 REPLAYS=0
 REPLAYS_ONTO_A_MOVED_MAIN="${GATE_REPLAYS_ONTO_A_MOVED_MAIN:-2}"
+HELD_BACK_VENDORS=""
+BATCH_AS_THE_RUN_WROTE_IT=""
+BATCH_COMMIT_AS_THE_RUN_WROTE_IT=""
 
 push_to_main() {
   git push origin HEAD:main
@@ -80,19 +85,81 @@ replay_onto_main() {
 
 quarantine() {
   local why="$1"
-  local ref="${QUARANTINE_PREFIX}-$(date -u +%Y%m%dT%H%M%SZ)-${COMMIT}"
+  local refused="${BATCH_AS_THE_RUN_WROTE_IT:-$(git rev-parse HEAD)}"
+  local shown="${BATCH_COMMIT_AS_THE_RUN_WROTE_IT:-$COMMIT}"
+  local ref="${QUARANTINE_PREFIX}-$(date -u +%Y%m%dT%H%M%SZ)-${shown}"
   {
     echo "quarantined=true"
     echo "quarantine_ref=$ref"
-    echo "quarantined_commit=$COMMIT"
+    echo "quarantined_commit=$shown"
     echo "quarantine_reason=$why"
   } >>"$OUTPUT"
-  if git push origin "HEAD:refs/heads/$ref"; then
-    echo "Held back because $why — $COMMIT is on $ref and main is unchanged."
+  if git push origin "$refused:refs/heads/$ref"; then
+    echo "Held back because $why — $shown is on $ref and main is unchanged."
   else
-    echo "Held back because $why — $COMMIT could not be pushed to $ref and main is unchanged. This run's data exists only in its own workspace."
+    echo "Held back because $why — $shown could not be pushed to $ref and main is unchanged. This run's data exists only in its own workspace."
   fi
   exit 1
+}
+
+amend_with_what_the_derivation_moved() {
+  if [ -n "$(git status --porcelain -- "${COMMITTABLE[@]}")" ]; then
+    git add -- "${COMMITTABLE[@]}"
+    git commit -q --amend --no-edit --allow-empty
+    COMMIT="$(git rev-parse --short HEAD)"
+    echo "$1"
+  fi
+}
+
+derive_from_the_data() {
+  if [ -n "$RATCHET_BUDGETS" ]; then
+    echo "── Lowering any quality budget this run's data has earned ──"
+    if ! npm run ratchet:budgets; then
+      echo "The budgets could not be measured. That decides nothing about whether this run's data is right, so the data is held rather than discarded."
+      quarantine "the quality budgets could not be measured"
+    fi
+    amend_with_what_the_derivation_moved "A budget fell to what this run's data measures, in the same commit as the data that earned it."
+  fi
+
+  if [ -n "$UPDATE_PAGE_LASTMOD" ]; then
+    echo "── Reading every page this run renders, to date the ones whose output moved ──"
+    if node "$SCRIPT_DIR/update-page-lastmod.js"; then
+      amend_with_what_the_derivation_moved "The pages whose output this run moved are dated today, in the same commit as the data that moved them."
+    else
+      echo "The pages could not be read, so each one keeps the day it last changed. That says nothing about whether this run's data is right, so the data goes on to the suite."
+    fi
+  fi
+
+  if [ -n "$REGENERATE_LLM_INDEX" ]; then
+    echo "── Regenerating the AI and LLM free-tier index from the records this run moved ──"
+    if node "$SCRIPT_DIR/generate-llm-api-readme.js"; then
+      amend_with_what_the_derivation_moved "The published index reads this run's records, in the same commit as the records it reads."
+    else
+      echo "The index could not be generated, so the one already published stands rather than a new stale one. That says nothing about whether this run's data is right, so the data goes on to the suite, and the job that regenerates the index on every push to main fails loudly on its own."
+    fi
+  fi
+}
+
+hold_back_the_vendors_a_failing_test_named() {
+  if [ -n "$HELD_BACK_VENDORS" ]; then
+    echo "── A set of vendors has already been held back on this run and the suite is still red, so the batch stands or falls as one ──"
+    return 1
+  fi
+  local baseline named
+  baseline="$(git rev-parse HEAD^)" || return 1
+  : >"$HELD_BACK_LIST"
+  node "$SCRIPT_DIR/gate-hold-back-vendors.js" \
+    --baseline "$baseline" --failures "$LOG" --vendors-to "$HELD_BACK_LIST" -- "${COMMITTABLE[@]}" || return 1
+  named="$(tr '\n' ' ' <"$HELD_BACK_LIST" | sed 's/ *$//')"
+  [ -n "$named" ] || return 1
+
+  BATCH_AS_THE_RUN_WROTE_IT="$(git rev-parse HEAD)"
+  BATCH_COMMIT_AS_THE_RUN_WROTE_IT="$COMMIT"
+  HELD_BACK_VENDORS="$named"
+  echo "── Held back: $HELD_BACK_VENDORS. What is left is derived again and read by the suite again, and only that reaches main ──"
+  amend_with_what_the_derivation_moved "The vendors a failing test named read as main already has them, in this run's commit."
+  derive_from_the_data
+  return 0
 }
 
 summarize() {
@@ -105,47 +172,7 @@ if ! npm run build >"$LOG" 2>&1; then
   quarantine "the build does not compile"
 fi
 
-if [ -n "$RATCHET_BUDGETS" ]; then
-  echo "── Lowering any quality budget this run's data has earned ──"
-  if ! npm run ratchet:budgets; then
-    echo "The budgets could not be measured. That decides nothing about whether this run's data is right, so the data is held rather than discarded."
-    quarantine "the quality budgets could not be measured"
-  fi
-  if [ -n "$(git status --porcelain -- "$@")" ]; then
-    git add -- "$@"
-    git commit -q --amend --no-edit
-    COMMIT="$(git rev-parse --short HEAD)"
-    echo "A budget fell to what this run's data measures, in the same commit as the data that earned it."
-  fi
-fi
-
-if [ -n "$UPDATE_PAGE_LASTMOD" ]; then
-  echo "── Reading every page this run renders, to date the ones whose output moved ──"
-  if node "$SCRIPT_DIR/update-page-lastmod.js"; then
-    if [ -n "$(git status --porcelain -- "$@")" ]; then
-      git add -- "$@"
-      git commit -q --amend --no-edit
-      COMMIT="$(git rev-parse --short HEAD)"
-      echo "The pages whose output this run moved are dated today, in the same commit as the data that moved them."
-    fi
-  else
-    echo "The pages could not be read, so each one keeps the day it last changed. That says nothing about whether this run's data is right, so the data goes on to the suite."
-  fi
-fi
-
-if [ -n "$REGENERATE_LLM_INDEX" ]; then
-  echo "── Regenerating the AI and LLM free-tier index from the records this run moved ──"
-  if node "$SCRIPT_DIR/generate-llm-api-readme.js"; then
-    if [ -n "$(git status --porcelain -- "$@")" ]; then
-      git add -- "$@"
-      git commit -q --amend --no-edit
-      COMMIT="$(git rev-parse --short HEAD)"
-      echo "The published index reads this run's records, in the same commit as the records it reads."
-    fi
-  else
-    echo "The index could not be generated, so the one already published stands rather than a new stale one. That says nothing about whether this run's data is right, so the data goes on to the suite, and the job that regenerates the index on every push to main fails loudly on its own."
-  fi
-fi
+derive_from_the_data
 
 while :; do
   : >"$LOG"
@@ -163,6 +190,7 @@ while :; do
     fi
     if ! node "$SCRIPT_DIR/gate-verdict.js" "$GATE_FAILING_FILES" >"$VERDICT" 2>&1; then
       cat "$VERDICT"
+      if hold_back_the_vendors_a_failing_test_named; then continue; fi
       quarantine "the suite refused it"
     fi
     cat "$VERDICT"
@@ -170,6 +198,10 @@ while :; do
   fi
 
   if push_to_main; then
+    if [ -n "$HELD_BACK_VENDORS" ]; then
+      echo "held_back_vendors=$HELD_BACK_VENDORS" >>"$OUTPUT"
+      echo "Held back and left for the next run to read again: $HELD_BACK_VENDORS. Every other vendor this run read is on main."
+    fi
     if [ -n "$SUITE_WAS_RED" ]; then
       {
         echo "quarantined=false"

--- a/scripts/gate-hold-back-vendors.js
+++ b/scripts/gate-hold-back-vendors.js
@@ -1,0 +1,120 @@
+import { execFileSync } from "node:child_process";
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+
+import {
+  DERIVED_FROM_THE_VENDOR_DATA,
+  VENDOR_KEYED_DATA,
+  holdbackVerdict,
+  serializeVendorData,
+  vendorsMoved,
+  vendorsNamedInFailure,
+  withVendorsAsTheyWereBefore,
+} from "../dist/data-push-holdback.js";
+
+const HELP = `Hold back the vendors a red suite names, so one bad reading costs one vendor rather than the batch.
+
+Reads the run's data out of the working tree and the same files out of the baseline commit, works
+out which vendors this run moved, and intersects that with the vendor names the failing tests
+printed. Where the intersection is a proper, non-empty subset, every held vendor's rows are put
+back the way the baseline had them and the files derived from those rows are reset, so the caller
+can re-derive them and run the suite again. Nothing is pushed by this script and nothing is
+decided by it: what reaches main is still only what the suite has passed.
+
+Usage: node scripts/gate-hold-back-vendors.js --baseline <ref> --failures <log> --vendors-to <file> -- <committable path>...
+
+Writes the held vendor names to the --vendors-to file, one per line, and says why on stdout.
+Exit status: 0 vendors were held back, 1 the batch stands as it is, 2 the arguments were wrong.
+`;
+
+function parseArgs(argv) {
+  const out = { baseline: "", failures: "", vendorsTo: "", paths: [] };
+  let i = 0;
+  while (i < argv.length) {
+    const arg = argv[i];
+    if (arg === "--baseline") {
+      out.baseline = argv[i + 1] ?? "";
+      i += 2;
+    } else if (arg === "--failures") {
+      out.failures = argv[i + 1] ?? "";
+      i += 2;
+    } else if (arg === "--vendors-to") {
+      out.vendorsTo = argv[i + 1] ?? "";
+      i += 2;
+    } else if (arg === "--") {
+      out.paths.push(...argv.slice(i + 1));
+      break;
+    } else {
+      return null;
+    }
+  }
+  return out.baseline && out.failures && out.vendorsTo && out.paths.length > 0 ? out : null;
+}
+
+function atBaseline(ref, path) {
+  try {
+    return JSON.parse(execFileSync("git", ["show", `${ref}:${path}`], { encoding: "utf8", maxBuffer: 256 * 1024 * 1024 }));
+  } catch {
+    return null;
+  }
+}
+
+function inTheWorkingTree(path) {
+  if (!existsSync(path)) return null;
+  try {
+    return JSON.parse(readFileSync(path, "utf8"));
+  } catch {
+    return null;
+  }
+}
+
+const args = parseArgs(process.argv.slice(2));
+if (!args) {
+  console.log(HELP);
+  process.exit(process.argv.slice(2).some((a) => a === "--help" || a === "-h") ? 0 : 2);
+}
+
+const committable = new Set(args.paths);
+const log = existsSync(args.failures) ? readFileSync(args.failures, "utf8") : "";
+
+const files = [];
+const moved = new Map();
+for (const entry of VENDOR_KEYED_DATA) {
+  if (!committable.has(entry.path)) continue;
+  const before = atBaseline(args.baseline, entry.path);
+  const after = inTheWorkingTree(entry.path);
+  if (before === null || after === null) continue;
+  files.push({ ...entry, before, after });
+  for (const vendor of vendorsMoved(before, after, entry.arrayKey)) {
+    moved.set(vendor.toLowerCase(), vendor);
+  }
+}
+
+if (files.length === 0) {
+  console.log("None of the files a vendor's rows live in is among the paths this run may commit, so there is nothing to hold back.");
+  process.exit(1);
+}
+
+const movedNames = [...moved.values()].sort((a, b) => a.localeCompare(b));
+const verdict = holdbackVerdict(vendorsNamedInFailure(log, movedNames), movedNames);
+console.log(verdict.reason);
+if (verdict.decision !== "hold-back") process.exit(1);
+
+for (const file of files) {
+  const reduced = serializeVendorData(withVendorsAsTheyWereBefore(file.before, file.after, file.arrayKey, verdict.vendors));
+  if (reduced === readFileSync(file.path, "utf8")) continue;
+  writeFileSync(file.path, reduced);
+  console.log(`${file.path}: ${verdict.vendors.join(", ")} put back the way ${args.baseline} had them.`);
+}
+
+const derived = DERIVED_FROM_THE_VENDOR_DATA.filter((path) => committable.has(path));
+for (const path of derived) {
+  try {
+    execFileSync("git", ["checkout", args.baseline, "--", path], { stdio: "pipe" });
+    console.log(`${path}: reset to ${args.baseline}, to be derived again from the data that is left.`);
+  } catch {
+    console.log(`${path}: could not be reset to ${args.baseline}, so it still reads the data this run held back.`);
+    process.exit(1);
+  }
+}
+
+writeFileSync(args.vendorsTo, verdict.vendors.map((v) => `${v}\n`).join(""));

--- a/scripts/mutate-1337.mjs
+++ b/scripts/mutate-1337.mjs
@@ -1,0 +1,100 @@
+import { readFileSync, writeFileSync } from "node:fs";
+import { execFileSync } from "node:child_process";
+
+const SUITE = ["test/data-push-holdback.test.ts", "test/data-push-gate.test.ts"];
+
+const MUTANTS = [
+  ["the-blame-reads-the-whole-log-rather-than-the-failure-report", "src/data-push-holdback.ts",
+    "  const at = log.lastIndexOf(FAILING_TESTS_MARKER);\n  return at === -1 ? \"\" : log.slice(at);",
+    "  return log;"],
+
+  ["a-vendor-name-is-matched-as-a-fragment-of-a-longer-word", "src/data-push-holdback.ts",
+    "  return new RegExp(`(?<![\\\\p{L}\\\\p{N}])${escaped}(?![\\\\p{L}\\\\p{N}])`, \"iu\").test(text);",
+    "  return new RegExp(escaped, \"iu\").test(text);"],
+
+  ["the-blame-is-not-narrowed-to-the-vendors-this-run-moved", "src/data-push-holdback.ts",
+    "  const attributable = named.filter((v) => movedKeys.has(vendorKey(v)));",
+    "  const attributable = named;"],
+
+  ["blaming-every-vendor-the-run-moved-still-counts-as-a-holdback", "src/data-push-holdback.ts",
+    "  if (attributable.length >= moved.length) {",
+    "  if (attributable.length > moved.length) {"],
+
+  ["only-the-first-row-of-a-held-vendor-is-put-back", "src/data-push-holdback.ts",
+    "    for (const was of restored.get(key) ?? []) out.push(was);",
+    "    out.push((restored.get(key) ?? [])[0]);"],
+
+  ["a-row-the-run-added-for-a-held-vendor-is-kept", "src/data-push-holdback.ts",
+    "    if (placed.has(key)) continue;\n    placed.add(key);\n    for (const was of restored.get(key) ?? []) out.push(was);",
+    "    out.push(row);"],
+
+  ["a-held-vendor-is-matched-only-in-the-case-the-failure-printed", "src/data-push-holdback.ts",
+    "  return typeof name === \"string\" ? name.trim().toLowerCase() : \"\";",
+    "  return typeof name === \"string\" ? name.trim() : \"\";"],
+
+  ["a-vendor-whose-row-stood-still-counts-as-moved", "src/data-push-holdback.ts",
+    "    if (JSON.stringify(was.get(key) ?? null) === JSON.stringify(now.get(key) ?? null)) continue;",
+    "    if (false) continue;"],
+
+  ["the-file-is-written-without-the-newline-the-shipped-files-end-in", "src/data-push-holdback.ts",
+    "  return `${JSON.stringify(doc, null, 2)}\\n`;",
+    "  return JSON.stringify(doc, null, 2);"],
+
+  ["the-gate-holds-a-second-set-of-vendors-back-on-the-same-run", "scripts/gate-data-push.sh",
+    "  if [ -n \"$HELD_BACK_VENDORS\" ]; then\n    echo \"── A set of vendors has already been held back on this run and the suite is still red, so the batch stands or falls as one ──\"\n    return 1\n  fi\n",
+    ""],
+
+  ["the-reduced-batch-is-pushed-without-the-suite-reading-it", "scripts/gate-data-push.sh",
+    "      if hold_back_the_vendors_a_failing_test_named; then continue; fi",
+    "      if hold_back_the_vendors_a_failing_test_named; then break; fi"],
+
+  ["the-quarantine-ref-carries-the-reduced-batch-rather-than-the-one-the-run-wrote", "scripts/gate-data-push.sh",
+    "  local refused=\"${BATCH_AS_THE_RUN_WROTE_IT:-$(git rev-parse HEAD)}\"",
+    "  local refused=\"$(git rev-parse HEAD)\""],
+
+  ["the-run-that-held-a-vendor-back-says-so-nowhere", "scripts/gate-data-push.sh",
+    "      echo \"held_back_vendors=$HELD_BACK_VENDORS\" >>\"$OUTPUT\"",
+    "      : >>\"$OUTPUT\""],
+
+  ["the-held-vendor-names-never-reach-the-caller", "scripts/gate-hold-back-vendors.js",
+    "writeFileSync(args.vendorsTo, verdict.vendors.map((v) => `${v}\\n`).join(\"\"));",
+    "writeFileSync(args.vendorsTo, \"\");"],
+
+  ["a-run-committing-no-vendor-keyed-file-is-treated-as-having-held-back", "scripts/gate-hold-back-vendors.js",
+    "if (files.length === 0) {\n  console.log(\"None of the files a vendor's rows live in is among the paths this run may commit, so there is nothing to hold back.\");\n  process.exit(1);\n}",
+    "if (files.length === 0) {\n  process.exit(1);\n}"],
+];
+
+function run(cmd, args) {
+  try {
+    execFileSync(cmd, args, { stdio: "pipe", encoding: "utf-8" });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+const survivors = [];
+const uncompiled = [];
+const skipped = [];
+for (const [name, file, from, to] of MUTANTS) {
+  const original = readFileSync(file, "utf-8");
+  if (!original.includes(from)) {
+    console.log(`SKIP  ${name} — the line it mutates is not in ${file}`);
+    skipped.push(name);
+    continue;
+  }
+  writeFileSync(file, original.replace(from, to));
+  const built = run("npm", ["run", "build"]);
+  const green = built && run("node", ["--test", "--test-concurrency", "1", ...SUITE]);
+  writeFileSync(file, original);
+  if (!built) uncompiled.push(name);
+  console.log(`${green ? "SURVIVED" : built ? "killed  " : "DID NOT COMPILE"}  ${name}`);
+  if (green) survivors.push(name);
+}
+run("npm", ["run", "build"]);
+const killed = MUTANTS.length - survivors.length - uncompiled.length - skipped.length;
+console.log(`\n${killed}/${MUTANTS.length} killed`);
+if (survivors.length > 0) console.log("survivors:", survivors.join(", "));
+if (uncompiled.length > 0) console.log("did not compile:", uncompiled.join(", "));
+if (skipped.length > 0) console.log("skipped — target string moved, so these scored nothing:", skipped.join(", "));

--- a/scripts/report-data-push-outcome.sh
+++ b/scripts/report-data-push-outcome.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 if [ "$#" -lt 2 ]; then
-  echo "usage: report-data-push-outcome.sh <job-name> refused|shipped-over-failures [detail] [reason]" >&2
+  echo "usage: report-data-push-outcome.sh <job-name> refused|shipped-over-failures|held-back-a-vendor [detail] [reason]" >&2
   exit 2
 fi
 
@@ -54,6 +54,21 @@ case "$OUTCOME" in
       echo "\`main\` is red until somebody clears these. Nothing is blocked, which is why this needs saying out loud: a scheduled push carries no \`tests.yml\` run behind it, so this is the only place the redness shows."
       echo
       echo "What to do: clear the entries that put the measurement over its budget, then \`npm run ratchet:budgets\`."
+    } >"$BODY"
+    ;;
+  held-back-a-vendor)
+    MARKER="data-push-vendorholdback"
+    TITLE="A scheduled run keeps reading a vendor the suite will not publish"
+    LABEL="priority/medium"
+    COMMENT_EVERY_TIME="yes"
+    {
+      echo "\`$JOB\` produced data the suite would not pass, and the failing tests named \`${DETAIL:-nobody}\`. Those vendors are on \`main\` the way it already had them, and everything else the run read is on \`main\` too. The catalogue advanced."
+      echo
+      echo "This is the good outcome of a bad reading: one vendor costs one vendor rather than the batch it arrived in. It still says that a reading we take every time that vendor is drawn is one the suite will not publish, so the same holdback repeats until either the reading or the rule behind it changes."
+      echo
+      echo "The run: $RUN_URL"
+      echo
+      echo "What to do: read the run for what went red on \`${DETAIL:-that vendor}\`, and decide which of the two is wrong."
     } >"$BODY"
     ;;
   *)

--- a/src/data-push-holdback.ts
+++ b/src/data-push-holdback.ts
@@ -1,0 +1,167 @@
+export interface VendorKeyedData {
+  path: string;
+  arrayKey: string;
+}
+
+export const VENDOR_KEYED_DATA: readonly VendorKeyedData[] = [
+  { path: "data/index.json", arrayKey: "offers" },
+  { path: "data/deal_changes.json", arrayKey: "changes" },
+  { path: "data/change_refusals.json", arrayKey: "refusals" },
+  { path: "data/verification_state.json", arrayKey: "records" },
+];
+
+export const DERIVED_FROM_THE_VENDOR_DATA: readonly string[] = [
+  "data/quality_budgets.json",
+  "data/page-lastmod.json",
+  "artifacts/free-llm-api-index/README.md",
+];
+
+export const FAILING_TESTS_MARKER = "failing tests:";
+
+export interface VendorRow {
+  vendor?: unknown;
+}
+
+export function vendorKey(name: unknown): string {
+  return typeof name === "string" ? name.trim().toLowerCase() : "";
+}
+
+function rowsOf(doc: unknown, arrayKey: string): VendorRow[] {
+  if (doc === null || typeof doc !== "object") return [];
+  const rows = (doc as Record<string, unknown>)[arrayKey];
+  return Array.isArray(rows) ? (rows as VendorRow[]) : [];
+}
+
+function byVendor(rows: VendorRow[]): Map<string, VendorRow[]> {
+  const out = new Map<string, VendorRow[]>();
+  for (const row of rows) {
+    const key = vendorKey(row.vendor);
+    const list = out.get(key);
+    if (list) list.push(row);
+    else out.set(key, [row]);
+  }
+  return out;
+}
+
+function displayName(rows: VendorRow[] | undefined): string {
+  const named = rows?.find((r) => typeof r.vendor === "string" && r.vendor.trim().length > 0);
+  return named ? (named.vendor as string).trim() : "";
+}
+
+export function vendorsMoved(before: unknown, after: unknown, arrayKey: string): string[] {
+  const was = byVendor(rowsOf(before, arrayKey));
+  const now = byVendor(rowsOf(after, arrayKey));
+  const moved: string[] = [];
+  for (const key of new Set([...was.keys(), ...now.keys()])) {
+    if (key === "") continue;
+    if (JSON.stringify(was.get(key) ?? null) === JSON.stringify(now.get(key) ?? null)) continue;
+    const name = displayName(now.get(key)) || displayName(was.get(key));
+    if (name !== "") moved.push(name);
+  }
+  return moved.sort((a, b) => a.localeCompare(b));
+}
+
+export function withVendorsAsTheyWereBefore(
+  before: unknown,
+  after: unknown,
+  arrayKey: string,
+  held: Iterable<string>,
+): unknown {
+  const heldKeys = new Set([...held].map(vendorKey).filter((k) => k !== ""));
+  if (heldKeys.size === 0) return after;
+  const restored = new Map<string, VendorRow[]>();
+  for (const row of rowsOf(before, arrayKey)) {
+    const key = vendorKey(row.vendor);
+    if (!heldKeys.has(key)) continue;
+    const list = restored.get(key);
+    if (list) list.push(row);
+    else restored.set(key, [row]);
+  }
+  const out: VendorRow[] = [];
+  const placed = new Set<string>();
+  for (const row of rowsOf(after, arrayKey)) {
+    const key = vendorKey(row.vendor);
+    if (!heldKeys.has(key)) {
+      out.push(row);
+      continue;
+    }
+    if (placed.has(key)) continue;
+    placed.add(key);
+    for (const was of restored.get(key) ?? []) out.push(was);
+  }
+  for (const [key, rows] of restored) {
+    if (placed.has(key)) continue;
+    for (const was of rows) out.push(was);
+  }
+  return { ...(after as Record<string, unknown>), [arrayKey]: out };
+}
+
+export function failingSection(log: string): string {
+  const at = log.lastIndexOf(FAILING_TESTS_MARKER);
+  return at === -1 ? "" : log.slice(at);
+}
+
+export function namesTheVendor(text: string, vendor: string): boolean {
+  const name = vendor.trim();
+  if (name === "") return false;
+  const escaped = name.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  return new RegExp(`(?<![\\p{L}\\p{N}])${escaped}(?![\\p{L}\\p{N}])`, "iu").test(text);
+}
+
+export function vendorsNamedInFailure(log: string, candidates: Iterable<string>): string[] {
+  const section = failingSection(log);
+  if (section === "") return [];
+  const named: string[] = [];
+  const seen = new Set<string>();
+  for (const vendor of candidates) {
+    const key = vendorKey(vendor);
+    if (key === "" || seen.has(key)) continue;
+    if (!namesTheVendor(section, vendor)) continue;
+    seen.add(key);
+    named.push(vendor.trim());
+  }
+  return named.sort((a, b) => a.localeCompare(b));
+}
+
+export type HoldbackDecision = "hold-back" | "refuse-the-batch";
+
+export interface HoldbackVerdict {
+  decision: HoldbackDecision;
+  vendors: string[];
+  reason: string;
+}
+
+export function holdbackVerdict(named: string[], moved: string[]): HoldbackVerdict {
+  const movedKeys = new Set(moved.map(vendorKey));
+  const attributable = named.filter((v) => movedKeys.has(vendorKey(v)));
+  if (moved.length === 0) {
+    return {
+      decision: "refuse-the-batch",
+      vendors: [],
+      reason: "this run moved no vendor's data, so the refusal is about something other than a vendor",
+    };
+  }
+  if (attributable.length === 0) {
+    return {
+      decision: "refuse-the-batch",
+      vendors: [],
+      reason: `the failing tests name none of the ${moved.length} vendor(s) this run moved, so there is nothing to attribute the refusal to`,
+    };
+  }
+  if (attributable.length >= moved.length) {
+    return {
+      decision: "refuse-the-batch",
+      vendors: attributable,
+      reason: `every one of the ${moved.length} vendor(s) this run moved is named by a failing test, so holding them back would leave nothing to push`,
+    };
+  }
+  return {
+    decision: "hold-back",
+    vendors: attributable,
+    reason: `${attributable.length} of the ${moved.length} vendor(s) this run moved are named by a failing test: ${attributable.join(", ")}`,
+  };
+}
+
+export function serializeVendorData(doc: unknown): string {
+  return `${JSON.stringify(doc, null, 2)}\n`;
+}

--- a/test/data-push-gate.test.ts
+++ b/test/data-push-gate.test.ts
@@ -10,6 +10,7 @@ import {
   gateVerdict, parseNonBlockingTests, readNonBlockingTests,
 } from "../src/data-push-gate.ts";
 import { qualityBudgetsPath } from "../src/page-reviews.ts";
+import { VENDOR_KEYED_DATA } from "../src/data-push-holdback.ts";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const REPO = join(__dirname, "..");
@@ -132,10 +133,41 @@ describe("#1317 the suite sees every commit that reaches main", () => {
     }
   });
 
-  it("gives the two outcomes different markers, so neither buries the other", () => {
+  it("gives every outcome a marker of its own, so none of them buries another", () => {
     const reporter = readFileSync(join(REPO, "scripts", "report-data-push-outcome.sh"), "utf8");
     const markers = [...reporter.matchAll(/MARKER="([a-z-]+)"/g)].map((m) => m[1]!);
-    assert.deepStrictEqual(markers, ["data-push-refused", "data-push-over-failures"]);
+    assert.deepStrictEqual(markers, ["data-push-refused", "data-push-over-failures", "data-push-vendorholdback"]);
+    for (const marker of markers) {
+      const others = markers.filter((m) => m !== marker);
+      const words = new Set(marker.split("-"));
+      for (const other of others) {
+        assert.ok(
+          !other.split("-").every((word) => words.has(word)),
+          `an open ${marker} issue would answer a search for ${other}, because every word of ${other} is a word of ${marker}`,
+        );
+      }
+    }
+  });
+
+  it("says on an issue when the gate reached main by holding a vendor back, wherever that can happen", () => {
+    for (const file of GATED_WORKFLOWS) {
+      const text = source(file);
+      const committable = gateStepOf(file).body;
+      const carriesVendorRows = VENDOR_KEYED_DATA.some((f) => committable.includes(f.path));
+      assert.strictEqual(
+        /report-data-push-outcome\.sh "[^"]+" held-back-a-vendor/.test(text),
+        carriesVendorRows,
+        carriesVendorRows
+          ? `${file} commits a file a vendor's rows live in and can hold one back without saying so`
+          : `${file} reports a holdback it can never make`,
+      );
+      if (!carriesVendorRows) continue;
+      assert.match(
+        text,
+        /steps\.gate\.outputs\.held_back_vendors != ''/,
+        `${file} reports a holdback in a step that a holdback alone does not reach`,
+      );
+    }
   });
 
   it("routes every scheduled data writer through the gate, each with its own quarantine branch", () => {
@@ -170,14 +202,24 @@ const FAILING_BY_MODE: Record<string, string[]> = {
   excused: ["test/how-current-our-reading-is.test.ts"],
   mixed: ["test/how-current-our-reading-is.test.ts", "test/the-data-this-run-wrote-is-wrong.test.ts"],
   crashed: [],
+  vendor: [],
+  "vendor-one-at-a-time": [],
 };
 
 const GATE_CONFIGURATION = ["GATE_RATCHET_BUDGETS", "GATE_UPDATE_PAGE_LASTMOD", "GATE_REGENERATE_LLM_INDEX"];
 
-const SUITE = `import { appendFileSync, writeFileSync } from "node:fs";
+const SUITE = `import { appendFileSync, readFileSync, writeFileSync } from "node:fs";
 const modes = ${JSON.stringify(FAILING_BY_MODE)};
 const mode = process.env.GATE_FIXTURE_TESTS || "green";
-const failing = modes[mode];
+let failing = modes[mode];
+let blamed = [];
+if (mode.startsWith("vendor")) {
+  const rows = JSON.parse(readFileSync("data/deal_changes.json", "utf8")).changes;
+  blamed = rows.filter((r) => r.reading === "wrong").map((r) => r.vendor);
+  if (mode === "vendor-one-at-a-time") blamed = blamed.slice(0, 1);
+  failing = blamed.length > 0 ? ["test/the-data-this-run-wrote-is-wrong.test.ts"] : [];
+}
+const red = mode === "crashed" || failing.length > 0;
 writeFileSync(process.env.GATE_FAILING_FILES, failing.map((f) => f + "\\n").join(""));
 writeFileSync(
   process.env.GATE_FIXTURE_ENV_REPORT,
@@ -185,11 +227,12 @@ writeFileSync(
 );
 appendFileSync(process.env.GITHUB_OUTPUT, "a_test_spawned_a_script_that_wrote_this=yes\\n");
 console.log("\\u2139 tests 2");
-console.log("\\u2139 pass " + (mode === "green" ? 2 : 1));
-console.log("\\u2139 fail " + (mode === "green" ? 0 : 1));
-if (mode !== "green") {
+console.log("\\u2139 pass " + (red ? 1 : 2));
+console.log("\\u2139 fail " + (red ? 1 : 0));
+if (red) {
   console.log("\\u2716 failing tests:");
   for (const f of failing) console.log("the fixture assertion in " + f);
+  for (const v of blamed) console.log("  the reading this run wrote for " + v + " is wrong");
   if (mode === "crashed") console.log("the suite died before it named a file");
   process.exit(1);
 }
@@ -247,6 +290,28 @@ const PACKAGE = JSON.stringify(
   2,
 );
 
+interface FixtureChange {
+  vendor: string;
+  summary: string;
+  reading?: string;
+}
+
+function changesFile(changes: FixtureChange[]): string {
+  return `${JSON.stringify({ changes }, null, 2)}\n`;
+}
+
+const AS_MAIN_HAS_IT = "the reading main already carries";
+
+const CHANGES_ON_MAIN = changesFile([
+  { vendor: "Steadyvendor", summary: AS_MAIN_HAS_IT },
+  { vendor: "Blamedvendor", summary: AS_MAIN_HAS_IT },
+  { vendor: "Secondblamedvendor", summary: AS_MAIN_HAS_IT },
+]);
+
+function changesOn(origin: string, ref: string): FixtureChange[] {
+  return JSON.parse(git(origin, "show", `${ref}:data/deal_changes.json`)).changes;
+}
+
 let scratch: string;
 
 function git(cwd: string, ...args: string[]): string {
@@ -270,6 +335,7 @@ function fixtureRepo(options: { shallow?: boolean } = {}): { work: string; origi
   writeFileSync(join(work, "ratchet.js"), RATCHET);
   writeFileSync(join(work, "allowlist.json"), ALLOWLIST);
   writeFileSync(join(work, "data", "health.json"), '{"checked":1}\n');
+  writeFileSync(join(work, "data", "deal_changes.json"), CHANGES_ON_MAIN);
   writeFileSync(join(work, "data", "quality_budgets.json"), BUDGETS_BEFORE);
   writeFileSync(join(work, "data", "page-lastmod.json"), '{"version":1,"pages":{}}\n');
   mkdirSync(join(work, "artifacts", "free-llm-api-index"), { recursive: true });
@@ -437,6 +503,119 @@ describe("#1317 the gate, run against a repository", () => {
     const run = runGate(work, "green", "data-quarantine/fixture", "data(auto): fixture");
     assert.strictEqual(run.status, 2);
     assert.match(run.stderr, /usage: gate-data-push\.sh/);
+  });
+});
+
+describe("#1337 one refused reading costs one vendor, not the batch it arrived in", () => {
+  before(() => {
+    scratch = mkdtempSync(join(tmpdir(), "gate-holdback-"));
+  });
+
+  after(() => {
+    if (scratch && existsSync(scratch)) rmSync(scratch, { recursive: true, force: true });
+  });
+
+  it("puts the rest of the run on main and leaves the blamed vendor as main already had it", () => {
+    const { work, origin } = fixtureRepo();
+    writeFileSync(
+      join(work, "data", "deal_changes.json"),
+      changesFile([
+        { vendor: "Steadyvendor", summary: "a reading this run stands behind" },
+        { vendor: "Blamedvendor", summary: "a reading the suite refuses", reading: "wrong" },
+        { vendor: "Secondblamedvendor", summary: "another reading this run stands behind" },
+      ]),
+    );
+
+    const run = runGate(work, "vendor", "data-quarantine/fixture", "data(auto): fixture", "data/deal_changes.json");
+
+    assert.strictEqual(run.status, 0, `the gate refused the whole batch: ${run.stdout}${run.stderr}`);
+    assert.deepStrictEqual(changesOn(origin, "main"), [
+      { vendor: "Steadyvendor", summary: "a reading this run stands behind" },
+      { vendor: "Blamedvendor", summary: AS_MAIN_HAS_IT },
+      { vendor: "Secondblamedvendor", summary: "another reading this run stands behind" },
+    ]);
+    assert.deepStrictEqual(quarantineRefs(origin, "data-quarantine/fixture"), [], "a run that reached main quarantined something too");
+    assert.match(run.outputs, /held_back_vendors=Blamedvendor/);
+    assert.match(run.stdout, /Held back and left for the next run to read again: Blamedvendor/);
+    assert.strictEqual(suiteRuns(run.stdout), 2, "what reached main was not read by the suite after the holdback");
+  });
+
+  it("refuses the batch when every vendor it moved is blamed, so nothing is left to push", () => {
+    const { work, origin } = fixtureRepo();
+    const before = mainSha(origin);
+    writeFileSync(
+      join(work, "data", "deal_changes.json"),
+      changesFile([
+        { vendor: "Steadyvendor", summary: AS_MAIN_HAS_IT },
+        { vendor: "Blamedvendor", summary: "a reading the suite refuses", reading: "wrong" },
+        { vendor: "Secondblamedvendor", summary: AS_MAIN_HAS_IT },
+      ]),
+    );
+
+    const run = runGate(work, "vendor", "data-quarantine/fixture", "data(auto): fixture", "data/deal_changes.json");
+
+    assert.strictEqual(run.status, 1, `the gate pushed a batch with nothing left in it: ${run.stdout}`);
+    assert.strictEqual(mainSha(origin), before, "main moved on a batch that was entirely refused");
+    assert.match(run.stdout, /holding them back would leave nothing to push/);
+    assert.strictEqual(suiteRuns(run.stdout), 1, "the suite was run again on a batch nothing had been taken out of");
+    assert.strictEqual(quarantineRefs(origin, "data-quarantine/fixture").length, 1);
+  });
+
+  it("refuses the batch when the failing test names no vendor this run moved", () => {
+    const { work, origin } = fixtureRepo();
+    const before = mainSha(origin);
+    writeFileSync(
+      join(work, "data", "deal_changes.json"),
+      changesFile([
+        { vendor: "Steadyvendor", summary: "a reading this run stands behind" },
+        { vendor: "Blamedvendor", summary: AS_MAIN_HAS_IT },
+        { vendor: "Secondblamedvendor", summary: AS_MAIN_HAS_IT },
+      ]),
+    );
+
+    const run = runGate(work, "red", "data-quarantine/fixture", "data(auto): fixture", "data/deal_changes.json");
+
+    assert.strictEqual(run.status, 1, `the gate pushed data it could not attribute a refusal to: ${run.stdout}`);
+    assert.strictEqual(mainSha(origin), before);
+    assert.match(run.stdout, /nothing to attribute the refusal to/);
+    assert.strictEqual(suiteRuns(run.stdout), 1, "the suite was run again on a batch nothing had been taken out of");
+  });
+
+  it("holds one set of vendors back and no more, and quarantines the batch as the run wrote it", () => {
+    const { work, origin } = fixtureRepo();
+    const before = mainSha(origin);
+    const asTheRunWroteIt: FixtureChange[] = [
+      { vendor: "Steadyvendor", summary: "a reading this run stands behind" },
+      { vendor: "Blamedvendor", summary: "a reading the suite refuses", reading: "wrong" },
+      { vendor: "Secondblamedvendor", summary: "a second reading the suite refuses", reading: "wrong" },
+    ];
+    writeFileSync(join(work, "data", "deal_changes.json"), changesFile(asTheRunWroteIt));
+
+    const run = runGate(work, "vendor-one-at-a-time", "data-quarantine/fixture", "data(auto): fixture", "data/deal_changes.json");
+
+    assert.strictEqual(run.status, 1, `the gate pushed a batch the suite never passed: ${run.stdout}`);
+    assert.strictEqual(mainSha(origin), before);
+    assert.strictEqual(suiteRuns(run.stdout), 2, "the gate held back more than one set of vendors");
+    assert.match(run.stdout, /the batch stands or falls as one/);
+    const refs = quarantineRefs(origin, "data-quarantine/fixture");
+    assert.strictEqual(refs.length, 1);
+    assert.deepStrictEqual(
+      changesOn(origin, refs[0]!),
+      asTheRunWroteIt,
+      "the quarantine ref carries the reduced batch rather than the one the run wrote",
+    );
+  });
+
+  it("holds nothing back for a run whose committable paths carry no vendor's rows", () => {
+    const { work, origin } = fixtureRepo();
+    writeFileSync(join(work, "data", "health.json"), '{"checked":9}\n');
+
+    const run = runGate(work, "red", "data-quarantine/fixture", "data(auto): fixture", "data/health.json");
+
+    assert.strictEqual(run.status, 1);
+    assert.match(run.stdout, /None of the files a vendor's rows live in is among the paths this run may commit/);
+    assert.strictEqual(suiteRuns(run.stdout), 1);
+    assert.strictEqual(quarantineRefs(origin, "data-quarantine/fixture").length, 1);
   });
 });
 

--- a/test/data-push-holdback.test.ts
+++ b/test/data-push-holdback.test.ts
@@ -1,0 +1,206 @@
+import { describe, it } from "node:test";
+import assert from "node:assert";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import {
+  DERIVED_FROM_THE_VENDOR_DATA,
+  VENDOR_KEYED_DATA,
+  failingSection,
+  holdbackVerdict,
+  namesTheVendor,
+  serializeVendorData,
+  vendorKey,
+  vendorsMoved,
+  vendorsNamedInFailure,
+  withVendorsAsTheyWereBefore,
+} from "../src/data-push-holdback.ts";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const REPO = join(__dirname, "..");
+
+function row(vendor: string, extra: Record<string, unknown> = {}) {
+  return { vendor, ...extra };
+}
+
+function doc(rows: unknown[], arrayKey = "changes", rest: Record<string, unknown> = {}) {
+  return { ...rest, [arrayKey]: rows };
+}
+
+const FAILURE = `ℹ tests 5015
+ℹ pass 5013
+ℹ fail 2
+✖ failing tests:
+test at test/superseded-terms-listings.test.ts:181:5
+✖ publishes no superseded stored terms in a visible listing slot
+  AssertionError: [ '/category/monitoring Hyperping', '/best/free-monitoring Hyperping' ]
+`;
+
+describe("#1337 which vendors a red suite blames", () => {
+  it("reads only the failure report, so a vendor named in a passing test's title is not blamed", () => {
+    const log = `✔ Databases: Firebase is demoted on a recorded withdrawal\n${FAILURE}`;
+    assert.deepStrictEqual(vendorsNamedInFailure(log, ["Firebase", "Hyperping"]), ["Hyperping"]);
+  });
+
+  it("names nobody when the suite failed without printing a failure report", () => {
+    assert.strictEqual(failingSection("ℹ fail 1\nthe suite died\n"), "");
+    assert.deepStrictEqual(vendorsNamedInFailure("ℹ fail 1\nthe suite died\n", ["Hyperping"]), []);
+  });
+
+  it("matches a vendor name on its own boundaries, not as a fragment of a longer word", () => {
+    assert.ok(namesTheVendor("✖ /vendor/modal is wrong", "Modal"));
+    assert.ok(namesTheVendor("✖ Modal's page is wrong", "Modal"));
+    assert.ok(!namesTheVendor("✖ the Modality report is wrong", "Modal"));
+    assert.ok(!namesTheVendor("✖ premodal is wrong", "Modal"));
+  });
+
+  it("matches a vendor name whose own characters mean something to a regular expression", () => {
+    assert.ok(namesTheVendor("✖ C++ Builder is wrong", "C++ Builder"));
+    assert.ok(namesTheVendor("✖ Fly.io is wrong", "Fly.io"));
+    assert.ok(!namesTheVendor("✖ FlyXio is wrong", "Fly.io"));
+  });
+
+  it("returns each blamed vendor once, whatever case the failure printed it in", () => {
+    const log = "✖ failing tests:\nhyperping HYPERPING Hyperping\n";
+    assert.deepStrictEqual(vendorsNamedInFailure(log, ["Hyperping", "hyperping"]), ["Hyperping"]);
+  });
+});
+
+describe("#1337 whether a batch stands or falls as one", () => {
+  it("holds back the named vendors when they are a proper part of what the run moved", () => {
+    const verdict = holdbackVerdict(["Hyperping"], ["Authress", "Hyperping", "RepoForge", "Thunder Client"]);
+    assert.strictEqual(verdict.decision, "hold-back");
+    assert.deepStrictEqual(verdict.vendors, ["Hyperping"]);
+    assert.match(verdict.reason, /1 of the 4/);
+  });
+
+  it("refuses the batch when the failure names no vendor the run moved", () => {
+    const verdict = holdbackVerdict([], ["Authress", "Hyperping"]);
+    assert.strictEqual(verdict.decision, "refuse-the-batch");
+    assert.deepStrictEqual(verdict.vendors, []);
+    assert.match(verdict.reason, /nothing to attribute the refusal to/);
+  });
+
+  it("refuses the batch when every vendor it moved is named, so nothing would be left", () => {
+    const verdict = holdbackVerdict(["Authress", "Hyperping"], ["Authress", "Hyperping"]);
+    assert.strictEqual(verdict.decision, "refuse-the-batch");
+    assert.match(verdict.reason, /nothing to push/);
+  });
+
+  it("refuses the batch when the run moved no vendor at all", () => {
+    assert.strictEqual(holdbackVerdict([], []).decision, "refuse-the-batch");
+  });
+
+  it("blames only vendors this run moved, so a name the failure carries from elsewhere decides nothing", () => {
+    const verdict = holdbackVerdict(["Firebase"], ["Authress", "Hyperping"]);
+    assert.strictEqual(verdict.decision, "refuse-the-batch");
+    assert.deepStrictEqual(verdict.vendors, []);
+  });
+});
+
+describe("#1337 which vendors a run moved", () => {
+  it("names a vendor whose row changed, added or went, and no vendor whose row stood still", () => {
+    const before = doc([row("Steady", { note: "same" }), row("Edited", { note: "was" }), row("Gone", {})]);
+    const after = doc([row("Steady", { note: "same" }), row("Edited", { note: "now" }), row("Arrived", {})]);
+    assert.deepStrictEqual(vendorsMoved(before, after, "changes"), ["Arrived", "Edited", "Gone"]);
+  });
+
+  it("names a vendor whose second row is new, so a per-name join does not hide a duplicate", () => {
+    const before = doc([row("Kong", { date: "2026-08-28" })]);
+    const after = doc([row("Kong", { date: "2026-08-28" }), row("Kong", { date: "2026-09-09" })]);
+    assert.deepStrictEqual(vendorsMoved(before, after, "changes"), ["Kong"]);
+  });
+
+  it("reads an absent or misshapen array as no vendors rather than throwing", () => {
+    assert.deepStrictEqual(vendorsMoved(null, null, "changes"), []);
+    assert.deepStrictEqual(vendorsMoved({}, { changes: "not an array" }, "changes"), []);
+  });
+});
+
+describe("#1337 putting a held vendor back the way main had it", () => {
+  it("restores every row of a held vendor and leaves every other row exactly as the run wrote it", () => {
+    const before = doc([row("Kept", { note: "was" }), row("Held", { note: "was" })]);
+    const after = doc([row("Kept", { note: "now" }), row("Held", { note: "now" })]);
+    assert.deepStrictEqual(withVendorsAsTheyWereBefore(before, after, "changes", ["Held"]), {
+      changes: [row("Kept", { note: "now" }), row("Held", { note: "was" })],
+    });
+  });
+
+  it("drops a row the run added for a held vendor the baseline did not carry", () => {
+    const before = doc([row("Kept", {})]);
+    const after = doc([row("Kept", {}), row("Held", { note: "new" })]);
+    assert.deepStrictEqual(withVendorsAsTheyWereBefore(before, after, "changes", ["Held"]), {
+      changes: [row("Kept", {})],
+    });
+  });
+
+  it("puts back a row the run removed for a held vendor", () => {
+    const before = doc([row("Kept", {}), row("Held", { note: "was" })]);
+    const after = doc([row("Kept", {})]);
+    assert.deepStrictEqual(withVendorsAsTheyWereBefore(before, after, "changes", ["Held"]), {
+      changes: [row("Kept", {}), row("Held", { note: "was" })],
+    });
+  });
+
+  it("restores both of a held vendor's rows at the place the first of them stood", () => {
+    const before = doc([row("Held", { n: 1 }), row("Kept", {}), row("Held", { n: 2 })]);
+    const after = doc([row("Held", { n: 9 }), row("Kept", {}), row("Held", { n: 8 })]);
+    assert.deepStrictEqual(withVendorsAsTheyWereBefore(before, after, "changes", ["Held"]), {
+      changes: [row("Held", { n: 1 }), row("Held", { n: 2 }), row("Kept", {})],
+    });
+  });
+
+  it("matches the held vendor whatever case the failure named it in", () => {
+    const before = doc([row("Hyperping", { note: "was" })]);
+    const after = doc([row("Hyperping", { note: "now" })]);
+    assert.deepStrictEqual(withVendorsAsTheyWereBefore(before, after, "changes", ["hYpErPiNg"]), {
+      changes: [row("Hyperping", { note: "was" })],
+    });
+  });
+
+  it("keeps the run's own value for a field that is not a vendor's row", () => {
+    const before = doc([row("Held", { note: "was" })], "records", { generated_at: "2026-09-09" });
+    const after = doc([row("Held", { note: "now" })], "records", { generated_at: "2026-09-10" });
+    const reduced = withVendorsAsTheyWereBefore(before, after, "records", ["Held"]) as Record<string, unknown>;
+    assert.strictEqual(reduced.generated_at, "2026-09-10");
+    assert.deepStrictEqual(reduced.records, [row("Held", { note: "was" })]);
+  });
+
+  it("returns the run's own data untouched when nothing is held back", () => {
+    const after = doc([row("Kept", {})]);
+    assert.strictEqual(withVendorsAsTheyWereBefore(doc([]), after, "changes", []), after);
+  });
+
+  it("writes the shape the shipped files are written in, so a holdback is not a reformatting", () => {
+    for (const { path, arrayKey } of VENDOR_KEYED_DATA) {
+      const shipped = readFileSync(join(REPO, path), "utf8");
+      const parsed = JSON.parse(shipped) as Record<string, unknown>;
+      assert.ok(Array.isArray(parsed[arrayKey]), `${path} has no ${arrayKey} array for a vendor's rows to live in`);
+      assert.strictEqual(serializeVendorData(parsed), shipped, `${path} is not written the way a holdback would rewrite it`);
+    }
+  });
+
+  it("holding nobody back rewrites none of the shipped files", () => {
+    for (const { path, arrayKey } of VENDOR_KEYED_DATA) {
+      const shipped = readFileSync(join(REPO, path), "utf8");
+      const parsed = JSON.parse(shipped);
+      assert.strictEqual(serializeVendorData(withVendorsAsTheyWereBefore(parsed, parsed, arrayKey, [])), shipped, path);
+    }
+  });
+
+  it("every file a vendor's rows live in carries a vendor on every row", () => {
+    for (const { path, arrayKey } of VENDOR_KEYED_DATA) {
+      const rows = JSON.parse(readFileSync(join(REPO, path), "utf8"))[arrayKey] as { vendor?: unknown }[];
+      assert.ok(rows.length > 0, `${path} is empty, so this rule has no subject`);
+      const nameless = rows.filter((r) => vendorKey(r.vendor) === "").length;
+      assert.strictEqual(nameless, 0, `${path} has ${nameless} row(s) no holdback could attribute to a vendor`);
+    }
+  });
+
+  it("names files that exist, so a rename cannot quietly stop a holdback reaching one", () => {
+    for (const path of [...VENDOR_KEYED_DATA.map((f) => f.path), ...DERIVED_FROM_THE_VENDOR_DATA]) {
+      assert.doesNotThrow(() => readFileSync(join(REPO, path), "utf8"), `${path} is named by the holdback and does not exist`);
+    }
+  });
+});


### PR DESCRIPTION
A scheduled re-verification writes one commit carrying every vendor it read, and when the suite refuses that commit every vendor in it is refused. The 19:30Z run on 2026-09-10 lost 31 verifications and three unrelated change records — Thunder Client, RepoForge, Authress — because of one reading of one page.

## What changed

The gate now asks who the failing tests named.

`src/data-push-holdback.ts` reads the run's data and the same files at the commit the run started from, works out which vendors moved, and intersects that set with the names printed in the suite's own failure report. Where the intersection is a proper, non-empty subset:

- every held vendor's rows are put back exactly as the baseline had them, in every file a vendor's rows live in — `index.json`, `deal_changes.json`, `change_refusals.json`, `verification_state.json`;
- the files derived from that data — the budgets, the page dates, the published index — are reset and derived again from what is left;
- **the suite reads the reduced commit before anything is pushed.**

That last point is the contract, and it is the same one as before: only what the suite has passed reaches `main`. What changed is the price of a refusal.

A holdback happens at most once per run, so a red suite costs two suite runs and no more. Where the failure names nobody the run moved, or names everybody, the batch is quarantined exactly as it always was — and the quarantine ref carries the batch as the run wrote it, not the reduced one.

## The blame is a proper subset of what the run moved, which is what makes it safe

Vendor names are matched on their own boundaries against the suite's failure report only, never against the passing output — a name in a passing test's title (`Databases: Firebase is demoted on a recorded withdrawal`) blames nobody. Candidates are limited to vendors this run actually moved, so a name the failure carries from elsewhere decides nothing.

A false blame costs one vendor's fresh reading and one suite run. It cannot put unread data on `main`, because the reduced commit is read by the suite before it is pushed.

## Measured against the batch that is quarantined now

Replaying `data-quarantine/rolling-reverification-20260910T194658Z-3da83db` through the holdback with the run's real failure text:

```
1 of the 81 vendor(s) this run moved are named by a failing test: Hyperping
```

Hyperping's rows come back byte-identical to `main` in all four files; every one of the other 80 vendors' rows is byte-identical to what the run wrote. That branch is four commits behind and its data predates #1523 and #1527, so it is not being merged here — the next scheduled run produces its own batch and the mechanism is what carries it.

## Scope

Only the re-verification job commits files a vendor's rows live in. The other four gated jobs see no vendor-keyed file among their committable paths and behave exactly as they did; a test asserts that, in both directions.

A holdback is reported on an issue of its own, with its own marker. It is the good outcome of a bad reading, and it will repeat every day that vendor is drawn until either the reading or the rule behind it changes — which is worth saying out loud rather than burying in a run log.

## Tests

- `test/data-push-holdback.test.ts` — 24 tests on the blame, the verdict and the restore, including duplicate vendor rows, a vendor whose name means something to a regular expression, and a check that a holdback of nobody rewrites none of the shipped files byte for byte.
- `test/data-push-gate.test.ts` — five end-to-end runs of the gate against a real repository: the rest of the batch reaches `main` with the blamed vendor as `main` had it; every vendor blamed leaves nothing to push; nobody blamed refuses as before; a second holdback is refused and the ref carries the original batch; a run with no vendor-keyed path holds nothing back.

Refs #1337
