### PR TITLE
A change record's direction is judged from the terms, not read off its label

### DIFF
--- a/data/change_directions.json
+++ b/data/change_directions.json
@@ -1,0 +1,366 @@
+{
+  "reviewed": "2026-09-10",
+  "review": "docs/change-direction-census.md",
+  "directions": [
+    {
+      "vendor": "Airtable",
+      "change_type": "pricing_restructured",
+      "date": "2026-08-28",
+      "source_url": "https://airtable.com/pricing",
+      "tier_direction": "unchanged",
+      "finding": "\"The free plan still exists\"; what the reading adds is that paid plans start at $20/user/month"
+    },
+    {
+      "vendor": "Amplitude",
+      "change_type": "pricing_restructured",
+      "date": "2026-09-09",
+      "source_url": "https://amplitude.com/startups",
+      "tier_direction": "unchanged",
+      "finding": "the limits are the same 100M events/month; the programme was renamed from Startup Scholarship to Early Stage Startup Pricing"
+    },
+    {
+      "vendor": "BetterStack",
+      "change_type": "limits_reduced",
+      "date": "2026-09-02",
+      "source_url": "https://betterstack.com/pricing",
+      "tier_direction": "unchanged",
+      "finding": "every figure matches; the reading adds 3 GB traces and 3 GB web events"
+    },
+    {
+      "vendor": "Buildkite",
+      "change_type": "limits_reduced",
+      "date": "2026-09-05",
+      "source_url": "https://buildkite.com/pricing/",
+      "tier_direction": "widened",
+      "finding": "500 -> 2,000 vCPU minutes/month; 50k -> 250k test executions"
+    },
+    {
+      "vendor": "Chroma",
+      "change_type": "pricing_model_change",
+      "date": "2026-09-07",
+      "source_url": "https://www.trychroma.com/pricing",
+      "tier_direction": "unchanged",
+      "finding": "the tier is Open Source, self-hosted with no limits; the reading prices Chroma Cloud's Starter plan"
+    },
+    {
+      "vendor": "CloudAMQP",
+      "change_type": "limits_reduced",
+      "date": "2026-09-09",
+      "source_url": "https://www.cloudamqp.com/plans.html",
+      "tier_direction": "unchanged",
+      "finding": "1M message quota, 20 connections and 100 queues all match; \"10,000 queued messages\" is queue depth, a different axis"
+    },
+    {
+      "vendor": "Cloudflare KV",
+      "change_type": "limits_reduced",
+      "date": "2026-09-02",
+      "source_url": "https://developers.cloudflare.com/kv/platform/pricing/",
+      "tier_direction": "unchanged",
+      "finding": "100K reads/day, 1K writes/day and 1 GB all match; our stored terms already say /day"
+    },
+    {
+      "vendor": "Cloudflare Queues",
+      "change_type": "pricing_model_change",
+      "date": "2026-09-05",
+      "source_url": "https://developers.cloudflare.com/queues/platform/pricing/",
+      "tier_direction": "unchanged",
+      "finding": "10K operations/day free, 24-hour non-configurable retention and 1M/month on paid are all already ours"
+    },
+    {
+      "vendor": "Codecov",
+      "change_type": "pricing_restructured",
+      "date": "2026-09-02",
+      "source_url": "https://about.codecov.io/pricing/",
+      "tier_direction": "unchanged",
+      "finding": "\"The Team plan is now $5 per user/month, down from $12\" - a price cut on a paid plan"
+    },
+    {
+      "vendor": "Figma",
+      "change_type": "limits_reduced",
+      "date": "2026-09-03",
+      "source_url": "https://www.figma.com/pricing/",
+      "tier_direction": "unchanged",
+      "finding": "every figure matches; the claim is that the page no longer states the team-project limit"
+    },
+    {
+      "vendor": "formlets.com",
+      "change_type": "pricing_restructured",
+      "date": "2026-09-01",
+      "source_url": "https://formlets.com/",
+      "tier_direction": "widened",
+      "finding": "100 submissions per month -> unlimited"
+    },
+    {
+      "vendor": "Gel",
+      "change_type": "limits_reduced",
+      "date": "2026-09-07",
+      "source_url": "https://www.geldata.com/pricing",
+      "tier_direction": "unchanged",
+      "finding": "\"1/4 compute unit (0.5 GiB RAM)\" -> \"1/4 compute unit (1/2 GiB RAM, 1/16 vCPU)\""
+    },
+    {
+      "vendor": "GitHub Actions",
+      "change_type": "pricing_restructured",
+      "date": "2026-09-02",
+      "source_url": "https://docs.github.com/en/billing/managing-billing-for-github-actions/about-billing-for-github-actions",
+      "tier_direction": "unchanged",
+      "finding": "restates the standing 2,000 minutes, 500 MB and 10 GB limits"
+    },
+    {
+      "vendor": "Grapedrop",
+      "change_type": "limits_reduced",
+      "date": "2026-08-28",
+      "source_url": "https://grapedrop.com/",
+      "tier_direction": "unchanged",
+      "finding": "5 pages and unlimited custom domains are both already ours; only 100 form submissions is new"
+    },
+    {
+      "vendor": "Hex",
+      "change_type": "limits_reduced",
+      "date": "2026-09-05",
+      "source_url": "https://hex.tech/pricing",
+      "tier_direction": "widened",
+      "finding": "Small compute 2 GB / 0.25 CPU -> 4 GB / 0.5 CPU"
+    },
+    {
+      "vendor": "imgix",
+      "change_type": "pricing_model_change",
+      "date": "2026-09-07",
+      "source_url": "https://www.imgix.com/pricing",
+      "tier_direction": "unchanged",
+      "finding": "our description opens \"no permanent free tier. 30-day free trial with 100 credits\"; the summary's finding is the same sentence"
+    },
+    {
+      "vendor": "Invantive Cloud",
+      "change_type": "pricing_restructured",
+      "date": "2026-08-28",
+      "source_url": "https://cloud.invantive.com/",
+      "tier_direction": "unchanged",
+      "finding": "\"Use for free. No further obligations. No user limit. No entrance or setup fees.\""
+    },
+    {
+      "vendor": "LambdaTest",
+      "change_type": "pricing_restructured",
+      "date": "2026-09-03",
+      "source_url": "https://www.testmuai.com/pricing/",
+      "tier_direction": "unchanged",
+      "finding": "Test Manager Premium at $49/month and KaneAI Starter at $17/month; the free tier is not mentioned"
+    },
+    {
+      "vendor": "leiga.com",
+      "change_type": "pricing_restructured",
+      "date": "2026-08-28",
+      "source_url": "https://www.leiga.com/",
+      "tier_direction": "unchanged",
+      "finding": "the whole summary is \"The pricing page states Leiga is 'Free forever. No credit card required.'\""
+    },
+    {
+      "vendor": "Liveblocks",
+      "change_type": "limits_reduced",
+      "date": "2026-09-01",
+      "source_url": "https://liveblocks.io/pricing",
+      "tier_direction": "widened",
+      "finding": "500 monthly active rooms -> unlimited; 256 MB realtime data -> 1 GB"
+    },
+    {
+      "vendor": "LiveKit",
+      "change_type": "limits_reduced",
+      "date": "2026-09-09",
+      "source_url": "https://livekit.io/pricing",
+      "tier_direction": "unchanged",
+      "finding": "the summary restates our five stored figures verbatim"
+    },
+    {
+      "vendor": "LocalStack",
+      "change_type": "pricing_restructured",
+      "date": "2026-09-07",
+      "source_url": "https://www.localstack.cloud/pricing",
+      "tier_direction": "unchanged",
+      "finding": "\"The Hobby plan is still available and free ... the number of emulated services is still 30+\""
+    },
+    {
+      "vendor": "Microsoft Founders Hub",
+      "change_type": "limits_reduced",
+      "date": "2026-08-28",
+      "source_url": "https://www.microsoft.com/en-us/startups",
+      "tier_direction": "unchanged",
+      "finding": "\"up to $150,000 in credits\" is our own upper figure"
+    },
+    {
+      "vendor": "MockAPI",
+      "change_type": "pricing_restructured",
+      "date": "2026-09-10",
+      "source_url": "https://www.mockapi.io/",
+      "tier_direction": "unchanged",
+      "finding": "the page now lists paid tiers at $5/month and $35/year"
+    },
+    {
+      "vendor": "Mockerito",
+      "change_type": "pricing_model_change",
+      "date": "2026-08-28",
+      "source_url": "https://mockerito.com/",
+      "tier_direction": "unchanged",
+      "finding": "current_state states a free tier exists in the same record whose summary says the free tier now costs $10/month"
+    },
+    {
+      "vendor": "OCR.Space",
+      "change_type": "pricing_restructured",
+      "date": "2026-08-28",
+      "source_url": "https://ocr.space/",
+      "tier_direction": "widened",
+      "finding": "free-tier file size limit 1 MB -> 5 MB"
+    },
+    {
+      "vendor": "OneSignal",
+      "change_type": "limits_reduced",
+      "date": "2026-08-28",
+      "source_url": "https://onesignal.com/pricing",
+      "tier_direction": "widened",
+      "finding": "100 emails/day -> 10,000 emails/month"
+    },
+    {
+      "vendor": "Pinecone",
+      "change_type": "pricing_restructured",
+      "date": "2026-09-10",
+      "source_url": "https://pinecone.io/pricing",
+      "tier_direction": "unchanged",
+      "finding": "\"The Starter plan is still available as a free tier. The details have been expanded.\""
+    },
+    {
+      "vendor": "Plausible Analytics",
+      "change_type": "free_tier_removed",
+      "date": "2026-08-28",
+      "source_url": "https://plausible.io/",
+      "tier_direction": "unchanged",
+      "finding": "the tier is Free OSS under AGPLv3; the reading is \"paid plans starting at $9/month\", which our own description already carries"
+    },
+    {
+      "vendor": "PromoProxy",
+      "change_type": "limits_reduced",
+      "date": "2026-09-01",
+      "source_url": "https://promoproxy.net/",
+      "tier_direction": "widened",
+      "finding": "1 GB -> 3 GB of data per day; the summary's \"down from\" contradicts its own figures"
+    },
+    {
+      "vendor": "Qdrant",
+      "change_type": "limits_reduced",
+      "date": "2026-09-10",
+      "source_url": "https://qdrant.tech/pricing/",
+      "tier_direction": "unchanged",
+      "finding": "\"down from 1GB cluster (which likely meant storage)\" - the record hedges its own comparison"
+    },
+    {
+      "vendor": "Railway",
+      "change_type": "limits_reduced",
+      "date": "2026-09-03",
+      "source_url": "https://railway.com/pricing",
+      "tier_direction": "unchanged",
+      "finding": "\"$1/month minimum after the trial\" and \"1 project\" are both already in our stored terms; the third claim, \"2 replicas instead of 1\", is an increase"
+    },
+    {
+      "vendor": "Replit",
+      "change_type": "pricing_restructured",
+      "date": "2026-09-01",
+      "source_url": "https://replit.com/pricing",
+      "tier_direction": "widened",
+      "finding": "the free tier now includes daily agent credits and allows publishing 1 live project"
+    },
+    {
+      "vendor": "Shadcn Studio",
+      "change_type": "pricing_model_change",
+      "date": "2026-08-28",
+      "source_url": "https://shadcnstudio.com/theme-editor",
+      "tier_direction": "unchanged",
+      "finding": "the summary ends \"features ... that are likely part of paid plans\""
+    },
+    {
+      "vendor": "staticforms.xyz",
+      "change_type": "limits_reduced",
+      "date": "2026-09-01",
+      "source_url": "https://www.staticforms.xyz/",
+      "tier_direction": "widened",
+      "finding": "250 -> 500 submissions per month"
+    },
+    {
+      "vendor": "SuperTokens",
+      "change_type": "pricing_restructured",
+      "date": "2026-09-05",
+      "source_url": "https://supertokens.com/pricing",
+      "tier_direction": "widened",
+      "finding": "the self-hosted free tier is now unlimited where it was limited to the core features"
+    },
+    {
+      "vendor": "TeleportHQ",
+      "change_type": "limits_reduced",
+      "date": "2026-08-28",
+      "source_url": "https://teleporthq.io/",
+      "tier_direction": "unchanged",
+      "finding": "\"no longer explicitly mentions a limit of 'three free projects'\" - an absence, not a reduction"
+    },
+    {
+      "vendor": "Terrateam",
+      "change_type": "limits_reduced",
+      "date": "2026-08-28",
+      "source_url": "https://terrateam.io",
+      "tier_direction": "unchanged",
+      "finding": "the entire summary is \"Doesn't confirm the original unlimited usage claim.\""
+    },
+    {
+      "vendor": "UniRateAPI",
+      "change_type": "limits_reduced",
+      "date": "2026-08-28",
+      "source_url": "https://unirateapi.com",
+      "tier_direction": "widened",
+      "finding": "200 requests/day unchanged; currencies 590+ -> 870+"
+    },
+    {
+      "vendor": "Vercel",
+      "change_type": "limits_reduced",
+      "date": "2026-09-07",
+      "source_url": "https://vercel.com/pricing",
+      "tier_direction": "unchanged",
+      "finding": "both states carry the same seven figures - 1M edge requests, 100 GB transfer, 1 GB blob, 5K image transformations, 1M invocations, 4 hrs active CPU, 360 GB-hrs memory"
+    },
+    {
+      "vendor": "Virgil Security",
+      "change_type": "pricing_restructured",
+      "date": "2026-08-28",
+      "source_url": "https://virgilsecurity.com/",
+      "tier_direction": "unchanged",
+      "finding": "\"The free tier is still offered\"; what moved is the price beyond 250 users"
+    },
+    {
+      "vendor": "WorkOS",
+      "change_type": "pricing_restructured",
+      "date": "2026-09-05",
+      "source_url": "https://workos.com/pricing",
+      "tier_direction": "unchanged",
+      "finding": "\"User Management is free for up to 1 million users\"; the prices quoted are for Single Sign-On, Directory Sync and Audit Logs"
+    },
+    {
+      "vendor": "xAI",
+      "change_type": "pricing_model_change",
+      "date": "2026-09-02",
+      "source_url": "https://docs.x.ai/developers/models",
+      "tier_direction": "unchanged",
+      "finding": "we list Free Credits ($25 on sign-up, $150/month via data sharing); the reading is Grok 4.6 token prices and says nothing about the credits"
+    },
+    {
+      "vendor": "zilore.com",
+      "change_type": "limits_reduced",
+      "date": "2026-09-01",
+      "source_url": "https://zilore.com/en/dns",
+      "tier_direction": "unchanged",
+      "finding": "5 domains unchanged; records-per-domain and the query cap are new detail"
+    },
+    {
+      "vendor": "Zoho Docs",
+      "change_type": "limits_reduced",
+      "date": "2026-08-31",
+      "source_url": "https://zoho.com/docs",
+      "tier_direction": "unchanged",
+      "finding": "5 GB storage unchanged; \"previously 1GB upload limit\" is a different axis"
+    }
+  ]
+}

--- a/data/change_directions.json
+++ b/data/change_directions.json
@@ -99,12 +99,28 @@
       "finding": "\"1/4 compute unit (0.5 GiB RAM)\" -> \"1/4 compute unit (1/2 GiB RAM, 1/16 vCPU)\""
     },
     {
+      "vendor": "geocodify.com",
+      "change_type": "pricing_restructured",
+      "date": "2026-09-01",
+      "source_url": "https://geocodify.com/",
+      "tier_direction": "widened",
+      "finding": "the reading says \"30,000 Calls/month\" against the stored 10k free queries/month, and the summary's own words are \"The free tier now has 30,000 calls/month\""
+    },
+    {
       "vendor": "GitHub Actions",
       "change_type": "pricing_restructured",
       "date": "2026-09-02",
       "source_url": "https://docs.github.com/en/billing/managing-billing-for-github-actions/about-billing-for-github-actions",
       "tier_direction": "unchanged",
       "finding": "restates the standing 2,000 minutes, 500 MB and 10 GB limits"
+    },
+    {
+      "vendor": "Grafana Cloud",
+      "change_type": "pricing_restructured",
+      "date": "2026-09-02",
+      "source_url": "https://grafana.com/pricing/",
+      "tier_direction": "unchanged",
+      "finding": "every figure the stored terms state is repeated in the reading — \"10k metric series, 50 GB logs, and 50 GB traces are included\", 14-day retention; the $19/month platform fee it adds buys 30-day retention, which the free tier never had"
     },
     {
       "vendor": "Grapedrop",
@@ -145,6 +161,14 @@
       "source_url": "https://www.testmuai.com/pricing/",
       "tier_direction": "unchanged",
       "finding": "Test Manager Premium at $49/month and KaneAI Starter at $17/month; the free tier is not mentioned"
+    },
+    {
+      "vendor": "LastPass",
+      "change_type": "pricing_restructured",
+      "date": "2026-09-03",
+      "source_url": "https://www.lastpass.com/pricing",
+      "tier_direction": "widened",
+      "finding": "the device limit is the same one device type; the stored terms end \"no dark web monitoring on free\" and the reading lists dark web monitoring as included"
     },
     {
       "vendor": "leiga.com",
@@ -219,6 +243,22 @@
       "finding": "100 emails/day -> 10,000 emails/month"
     },
     {
+      "vendor": "Oracle Cloud",
+      "change_type": "pricing_restructured",
+      "date": "2026-09-02",
+      "source_url": "https://www.oracle.com/cloud/free/",
+      "tier_direction": "unchanged",
+      "finding": "the reading lists service names and no quantities, so it states no reduction of the stored 2 AMD VMs, 4 Arm VMs, 200 GB block and 20 GB object; the summary is \"The tier still exists, the specific VM details are different\""
+    },
+    {
+      "vendor": "paperspace",
+      "change_type": "pricing_restructured",
+      "date": "2026-09-05",
+      "source_url": "https://www.paperspace.com/pricing",
+      "tier_direction": "unchanged",
+      "finding": "the free tier reads the same public projects and 5 GB storage; the prices that moved are paid ones, from \"$8/month\" to Pro $12 and Growth $39"
+    },
+    {
       "vendor": "Pinecone",
       "change_type": "pricing_restructured",
       "date": "2026-09-10",
@@ -257,6 +297,14 @@
       "source_url": "https://railway.com/pricing",
       "tier_direction": "unchanged",
       "finding": "\"$1/month minimum after the trial\" and \"1 project\" are both already in our stored terms; the third claim, \"2 replicas instead of 1\", is an increase"
+    },
+    {
+      "vendor": "readthedocs.org",
+      "change_type": "pricing_restructured",
+      "date": "2026-08-28",
+      "source_url": "https://readthedocs.org/",
+      "tier_direction": "unchanged",
+      "finding": "the free Community plan still hosts public documentation for open source; the private repositories and SSO the summary calls paid are not in the stored terms, which state versioning and PDF generation"
     },
     {
       "vendor": "Replit",
@@ -321,6 +369,14 @@
       "source_url": "https://vercel.com/pricing",
       "tier_direction": "unchanged",
       "finding": "both states carry the same seven figures - 1M edge requests, 100 GB transfer, 1 GB blob, 5K image transformations, 1M invocations, 4 hrs active CPU, 360 GB-hrs memory"
+    },
+    {
+      "vendor": "veriphone",
+      "change_type": "pricing_restructured",
+      "date": "2026-08-28",
+      "source_url": "https://veriphone.io/",
+      "tier_direction": "unchanged",
+      "finding": "1,000 a month either way — the summary states the change as \"1,000 free validations per month, instead of 1,000 requests\", which renames the unit; what is new is the paid packs"
     },
     {
       "vendor": "Virgil Security",

--- a/data/page-reviews.json
+++ b/data/page-reviews.json
@@ -674,7 +674,7 @@
       "review_outcome": null,
       "review_note": null,
       "reads_index": true,
-      "reads_changes": true,
+      "reads_changes": false,
       "data_source": "catalogue",
       "data_source_reason": null
     },

--- a/data/page-reviews.json
+++ b/data/page-reviews.json
@@ -1907,7 +1907,7 @@
       "review_outcome": null,
       "review_note": null,
       "reads_index": true,
-      "reads_changes": true,
+      "reads_changes": false,
       "data_source": "catalogue",
       "data_source_reason": null
     },
@@ -1961,7 +1961,7 @@
       "review_outcome": null,
       "review_note": null,
       "reads_index": true,
-      "reads_changes": true,
+      "reads_changes": false,
       "data_source": "catalogue",
       "data_source_reason": null
     },

--- a/scripts/census-1528-change-direction.mjs
+++ b/scripts/census-1528-change-direction.mjs
@@ -1,0 +1,97 @@
+#!/usr/bin/env node
+
+import { readFileSync } from "node:fs";
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { supersedingChange } from "../dist/superseded-description.js";
+import { applyReviewedDirections, loadDirectionReview } from "../dist/change-direction-review.js";
+import { publishedRisk } from "../dist/data.js";
+import { changesByVendor } from "../dist/superseded-census.js";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const REPO = resolve(__dirname, "..");
+
+const AS_OF = "2026-09-11";
+const AS_OF_MS = Date.parse(`${AS_OF}T12:00:00Z`);
+
+const DISCOVERED_LIMIT_VENDORS = [
+  "addy.io", "Aionda Mail", "AppFit", "BugBug", "CatchJS.com", "dnspod.com", "Expo",
+  "forwardemail.net", "FreeIPAPI", "GitBook", "Harness CI", "Icon Horse", "mockaroo",
+  "Mocklets", "Nango", "packagecloud.io", "Permit.io", "Pinata IPFS", "ploi.io", "Postman",
+  "Pullflow", "RightFeature", "transfernow", "Vaadin", "webhookrelay.com", "Whitespace", "Zenable",
+];
+
+const offers = JSON.parse(readFileSync(resolve(REPO, "data", "index.json"), "utf-8")).offers;
+const stored = JSON.parse(readFileSync(resolve(REPO, "data", "deal_changes.json"), "utf-8")).changes;
+const review = loadDirectionReview();
+
+const changeKey = (change) =>
+  change ? [change.vendor, change.change_type, change.date, change.source_url].join("|") : null;
+
+function rowsFor(changes) {
+  const byVendor = changesByVendor(changes);
+  const rows = new Map();
+  for (const offer of offers) {
+    const vendorChanges = byVendor.get(offer.vendor.toLowerCase()) ?? [];
+    const risk = publishedRisk(offer, vendorChanges, AS_OF, AS_OF_MS);
+    rows.set([offer.vendor, offer.tier, offer.url].join("|"), {
+      vendor: offer.vendor,
+      withholding: changeKey(supersedingChange(offer, vendorChanges)),
+      risk_level: risk.risk_level,
+      risk_cause: changeKey(risk.cause),
+    });
+  }
+  return rows;
+}
+
+const before = rowsFor(stored);
+const after = rowsFor(applyReviewedDirections(stored, review.directions));
+
+const moved = [];
+for (const [key, was] of before) {
+  const now = after.get(key);
+  const fields = ["withholding", "risk_level", "risk_cause"].filter((f) => was[f] !== now[f]);
+  if (fields.length > 0) moved.push({ vendor: was.vendor, fields, was, now });
+}
+
+const countWithholding = (rows) => [...rows.values()].filter((r) => r.withholding !== null).length;
+const countRated = (rows) => [...rows.values()].filter((r) => r.risk_level && r.risk_level !== "stable").length;
+
+console.log(`offers ${offers.length}, change records ${stored.length}, as of ${AS_OF}`);
+console.log(`reviewed records: ${review.directions.length} (reviewed ${review.reviewed})`);
+console.log(`  widened:   ${review.directions.filter((d) => d.tier_direction === "widened").length}`);
+console.log(`  unchanged: ${review.directions.filter((d) => d.tier_direction === "unchanged").length}`);
+console.log(`  narrowed:  ${review.directions.filter((d) => d.tier_direction === "narrowed").length}`);
+console.log("");
+console.log(`withholding their stored terms: ${countWithholding(before)} -> ${countWithholding(after)}`);
+console.log(`rated caution or risky:         ${countRated(before)} -> ${countRated(after)}`);
+console.log(`offers whose published row moves: ${moved.length}`);
+console.log("");
+for (const row of moved.sort((a, b) => a.vendor.localeCompare(b.vendor))) {
+  const parts = row.fields.map((f) => {
+    if (f === "risk_level") return `risk ${row.was.risk_level ?? "none"} -> ${row.now.risk_level ?? "none"}`;
+    if (f === "withholding") return `terms ${row.was.withholding ? "withheld" : "published"} -> ${row.now.withholding ? "withheld" : "published"}`;
+    return `cause ${row.was.risk_cause ? "set" : "none"} -> ${row.now.risk_cause ? "set" : "none"}`;
+  });
+  console.log(`  ${row.vendor}: ${parts.join(", ")}`);
+}
+
+console.log("");
+console.log("The 27 records that discover a limit, measured before and after:");
+let discoveredMoved = 0;
+for (const vendor of DISCOVERED_LIMIT_VENDORS) {
+  const key = [...before.keys()].find((k) => k.toLowerCase().startsWith(`${vendor.toLowerCase()}|`));
+  if (!key) {
+    console.log(`  ${vendor}: not in the catalogue under that name`);
+    continue;
+  }
+  const was = before.get(key);
+  const now = after.get(key);
+  const same =
+    was.withholding === now.withholding &&
+    was.risk_level === now.risk_level &&
+    was.risk_cause === now.risk_cause;
+  if (!same) discoveredMoved++;
+  if (!same) console.log(`  ${vendor}: MOVED`);
+}
+console.log(`  moved: ${discoveredMoved} of ${DISCOVERED_LIMIT_VENDORS.length}`);

--- a/scripts/change-log.js
+++ b/scripts/change-log.js
@@ -27,6 +27,8 @@ export const CHANGE_TYPES = [
   "record_corrected",
 ];
 
+export const TIER_DIRECTIONS = ["narrowed", "unchanged", "widened"];
+
 const IMPACTS = ["high", "medium", "low"];
 const DEFAULT_IMPACT = "medium";
 const ISO_DATE = /^\d{4}-\d{2}-\d{2}$/;
@@ -118,6 +120,8 @@ export function buildChangeEntry(offer, result, options = {}) {
 
   const tierRead = typeof result.tier === "string" ? result.tier.trim() : "";
 
+  const directionRead = TIER_DIRECTIONS.includes(result.tier_direction) ? result.tier_direction : null;
+
   return {
     entry: {
       vendor: offer.vendor,
@@ -126,6 +130,7 @@ export function buildChangeEntry(offer, result, options = {}) {
       date_source: statedDate ? DATE_SOURCE_VENDOR_PAGE : DATE_SOURCE_DISCOVERED,
       summary,
       ...(tierRead ? { tier: tierRead } : {}),
+      ...(directionRead ? { tier_direction: directionRead } : {}),
       previous_state: offer.description,
       current_state: currentState,
       impact,

--- a/scripts/mutate-1528.sh
+++ b/scripts/mutate-1528.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+set -u
+WT="${1:-$(cd "$(dirname "$0")/.." && pwd)}"
+cd "$WT" || exit 1
+
+run_mutation() {
+  local name="$1" file="$2" from="$3" to="$4" tests="$5"
+  cp "$file" /tmp/mut-orig.$$ || return 1
+  if ! python3 - "$file" "$from" "$to" <<'PY'
+import sys, pathlib
+path, frm, to = sys.argv[1], sys.argv[2], sys.argv[3]
+p = pathlib.Path(path)
+s = p.read_text()
+if frm not in s:
+    print("PATTERN NOT FOUND", file=sys.stderr); sys.exit(2)
+p.write_text(s.replace(frm, to, 1))
+PY
+  then
+    echo "BROKEN MUTATION: $name"
+    cp /tmp/mut-orig.$$ "$file"
+    return 1
+  fi
+  if ! npm run build >/dev/null 2>&1; then
+    echo "COMPILE-KILLED: $name"
+    cp /tmp/mut-orig.$$ "$file"; npm run build >/dev/null 2>&1
+    return 0
+  fi
+  if node --test --test-concurrency 1 $tests >/tmp/mut-out.$$ 2>&1; then
+    echo "SURVIVED: $name"
+  else
+    echo "KILLED: $name"
+  fi
+  cp /tmp/mut-orig.$$ "$file"
+  npm run build >/dev/null 2>&1
+}
+
+T="test/change-direction-review.test.ts test/tier-scoped-verdicts.test.ts test/superseded-terms.test.ts"
+
+run_mutation "the direction never refutes the label" src/change-direction.ts \
+  'if (direction !== "unchanged" && direction !== "widened") return false;' \
+  'return false;' "$T"
+
+run_mutation "a widened reading still rates the tier" src/change-direction.ts \
+  'if (direction !== "unchanged" && direction !== "widened") return false;' \
+  'if (direction !== "unchanged") return false;' "$T"
+
+run_mutation "a reading that restates the terms still rates the tier" src/change-direction.ts \
+  'if (direction !== "unchanged" && direction !== "widened") return false;' \
+  'if (direction !== "widened") return false;' "$T"
+
+run_mutation "the direction withdraws a favourable verdict too" src/change-direction.ts \
+  '  return narrowsTheStoredTerms(change.change_type);
+}' \
+  '  return true;
+}' "$T"
+
+run_mutation "the tier rule is dropped from the rating" src/change-tier.ts \
+  '  if (readingDescribesNoNarrowing(change)) return false;
+  return changeGradesTheListedTier(change, offer);' \
+  '  return !readingDescribesNoNarrowing(change);' "$T"
+
+run_mutation "the direction is dropped from the rating" src/change-tier.ts \
+  '  if (readingDescribesNoNarrowing(change)) return false;
+  return changeGradesTheListedTier(change, offer);' \
+  '  return changeGradesTheListedTier(change, offer);' "$T"
+
+run_mutation "the review overrides a record that states its own direction" src/change-direction-review.ts \
+  '    if (isTierDirection(change.tier_direction)) return change;' \
+  '' "$T"
+
+run_mutation "the review reaches nothing" src/change-direction-review.ts \
+  '    return reviewed ? { ...change, tier_direction: reviewed.tier_direction } : change;' \
+  '    return change;' "$T"
+
+run_mutation "the review key ignores the record date" src/change-direction-review.ts \
+  '    record.date,
+    (record.source_url ?? "").trim(),' \
+  '    (record.source_url ?? "").trim(),' "$T"
+
+run_mutation "the review key ignores the source" src/change-direction-review.ts \
+  '    record.date,
+    (record.source_url ?? "").trim(),' \
+  '    record.date,' "$T"
+
+run_mutation "any word is read as a direction" src/change-direction-review.ts \
+  '  return typeof value === "string" && TIER_DIRECTIONS.includes(value);' \
+  '  return typeof value === "string" && value.length > 0;' "$T"
+
+run_mutation "an entry outside the vocabulary is loaded" src/change-direction-review.ts \
+  '    directions: review.directions.filter((entry) => isTierDirection(entry?.tier_direction)),' \
+  '    directions: review.directions,' "$T"
+
+run_mutation "a malformed review file throws" src/change-direction-review.ts \
+  '  if (!fs.existsSync(filePath)) return empty;' \
+  '' "$T"
+
+run_mutation "the catalogue is loaded without the review" src/data.ts \
+  'applyReviewedDirections(data.changes.map(withResolutionInSummary))' \
+  'data.changes.map(withResolutionInSummary)' "$T"
+
+run_mutation "the detector's direction is stored unchecked" scripts/change-log.js \
+  'TIER_DIRECTIONS.includes(result.tier_direction) ? result.tier_direction : null' \
+  'result.tier_direction ?? null' "$T"
+
+run_mutation "the detector's direction is discarded" scripts/change-log.js \
+  '      ...(directionRead ? { tier_direction: directionRead } : {}),
+' \
+  '' "$T"
+
+run_mutation "the reader is not asked for the direction" scripts/verify-freshness.js \
+  '"tier_direction":"<narrowed|unchanged|widened>",' \
+  '' "$T"

--- a/scripts/verify-freshness.js
+++ b/scripts/verify-freshness.js
@@ -267,11 +267,12 @@ Compare the stored deal info against the pricing page text. Focus on:
 Respond with EXACTLY one of these JSON objects (no other text):
 - If the deal info is still accurate: {"status":"confirmed"}
 - If the page doesn't contain enough info to verify: {"status":"unclear","summary":"<reason>"}
-- If you found a discrepancy: {"status":"changed","summary":"<what changed>","change_type":"<one of: ${CHANGE_TYPE_VALUES}>","tier":"<the plan or edition on the page whose terms moved>","current_state":"<what the page says the terms are now>","impact":"<high|medium|low>","effective_date":"<YYYY-MM-DD, only if the page states when this took effect>"}
+- If you found a discrepancy: {"status":"changed","summary":"<what changed>","change_type":"<one of: ${CHANGE_TYPE_VALUES}>","tier":"<the plan or edition on the page whose terms moved>","tier_direction":"<narrowed|unchanged|widened>","current_state":"<what the page says the terms are now>","impact":"<high|medium|low>","effective_date":"<YYYY-MM-DD, only if the page states when this took effect>"}
 
 Rules for a "changed" response:
 - current_state must describe only what the page text above says. Do not restate the stored deal info and do not infer terms the page does not state.
 - tier must name the plan or edition whose terms moved, as the page names it. This page documents several plans and the stored tier above is only one of them: where what moved is a different plan, a paid plan, or a separately priced hosted service, name that one rather than the stored tier.
+- tier_direction answers one question about the stored Tier above: comparing the stored Description against what this page says about that same plan, is the plan now worse for a user than our description says ("narrowed"), the same ("unchanged"), or better ("widened")? Answer it from the two sets of terms, not from the change_type you picked. A page that only states a limit our description never stated, or that restates our description in other words, is "unchanged". A change that moved some other plan leaves the stored one "unchanged".
 - Omit effective_date entirely unless the page gives a date.
 - If you cannot pick a change_type from that list, or cannot state current_state from the page, answer "unclear" instead.`;
 

--- a/src/change-direction-review.ts
+++ b/src/change-direction-review.ts
@@ -1,0 +1,97 @@
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import type { DealChange, TierDirection } from "./types.js";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+export const DIRECTIONS_PATH =
+  process.env.AGENTDEALS_CHANGE_DIRECTIONS_PATH ||
+  path.join(__dirname, "..", "data", "change_directions.json");
+
+export interface ReviewedDirection {
+  vendor: string;
+  change_type: string;
+  date: string;
+  source_url: string;
+  tier_direction: TierDirection;
+  finding: string;
+}
+
+export interface DirectionReview {
+  reviewed: string;
+  review: string;
+  directions: ReviewedDirection[];
+}
+
+export interface ReviewedRecord {
+  vendor: string;
+  change_type: string;
+  date: string;
+  source_url: string;
+}
+
+const TIER_DIRECTIONS: readonly string[] = ["narrowed", "unchanged", "widened"];
+
+export function isTierDirection(value: unknown): value is TierDirection {
+  return typeof value === "string" && TIER_DIRECTIONS.includes(value);
+}
+
+export function reviewKey(record: ReviewedRecord): string {
+  return [
+    record.vendor.trim().toLowerCase(),
+    record.change_type,
+    record.date,
+    (record.source_url ?? "").trim(),
+  ].join("|");
+}
+
+let cachedReview: DirectionReview | null = null;
+
+export function loadDirectionReview(): DirectionReview {
+  if (cachedReview) return cachedReview;
+  cachedReview = readDirectionReview(DIRECTIONS_PATH);
+  return cachedReview;
+}
+
+export function readDirectionReview(filePath: string): DirectionReview {
+  const empty: DirectionReview = { reviewed: "", review: "", directions: [] };
+  if (!fs.existsSync(filePath)) return empty;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(fs.readFileSync(filePath, "utf-8"));
+  } catch (err) {
+    console.error(`Change-direction review contains malformed JSON: ${err}`);
+    return empty;
+  }
+  const review = parsed as Partial<DirectionReview>;
+  if (!review || !Array.isArray(review.directions)) {
+    console.error("Change-direction review is missing 'directions' array, using empty list");
+    return empty;
+  }
+  return {
+    reviewed: typeof review.reviewed === "string" ? review.reviewed : "",
+    review: typeof review.review === "string" ? review.review : "",
+    directions: review.directions.filter((entry) => isTierDirection(entry?.tier_direction)),
+  };
+}
+
+export function directionsByRecord(
+  directions: readonly ReviewedDirection[],
+): Map<string, ReviewedDirection> {
+  const byRecord = new Map<string, ReviewedDirection>();
+  for (const entry of directions) byRecord.set(reviewKey(entry), entry);
+  return byRecord;
+}
+
+export function applyReviewedDirections<T extends DealChange>(
+  changes: readonly T[],
+  directions: readonly ReviewedDirection[] = loadDirectionReview().directions,
+): T[] {
+  const byRecord = directionsByRecord(directions);
+  return changes.map((change) => {
+    if (isTierDirection(change.tier_direction)) return change;
+    const reviewed = byRecord.get(reviewKey(change));
+    return reviewed ? { ...change, tier_direction: reviewed.tier_direction } : change;
+  });
+}

--- a/src/change-direction.ts
+++ b/src/change-direction.ts
@@ -28,6 +28,16 @@ export function narrowsTheStoredTerms(changeType: string): boolean {
   return direction === null || direction === "negative";
 }
 
+export interface DirectedChange extends Pick<DealChange, "change_type"> {
+  tier_direction?: DealChange["tier_direction"];
+}
+
+export function readingDescribesNoNarrowing(change: DirectedChange): boolean {
+  const direction = change.tier_direction;
+  if (direction !== "unchanged" && direction !== "widened") return false;
+  return narrowsTheStoredTerms(change.change_type);
+}
+
 export const RATIO_ROUNDING_TOLERANCE = 0.25;
 
 export function directionRatioLabel(negative: number, positive: number): string {

--- a/src/change-tier.ts
+++ b/src/change-tier.ts
@@ -1,9 +1,11 @@
+import { readingDescribesNoNarrowing } from "./change-direction.js";
 import { tierRecordsASelfHostedEdition } from "./free-tier-record.js";
 import { namesTheVendorsHostedEdition } from "./superseding-reading.js";
 import type { DealChange } from "./types.js";
 
 export interface TieredChange extends Pick<DealChange, "change_type"> {
   tier?: string | null;
+  tier_direction?: DealChange["tier_direction"];
   current_state?: string | null;
 }
 
@@ -35,4 +37,9 @@ export function readingGradesTheHostedEdition(change: TieredChange, offer: Grade
 export function changeGradesTheListedTier(change: TieredChange, offer: GradedOffer): boolean {
   if (namesADifferentTier(change, offer.tier)) return false;
   return !readingGradesTheHostedEdition(change, offer);
+}
+
+export function changeRatesTheListedTier(change: TieredChange, offer: GradedOffer): boolean {
+  if (readingDescribesNoNarrowing(change)) return false;
+  return changeGradesTheListedTier(change, offer);
 }

--- a/src/data.ts
+++ b/src/data.ts
@@ -4,7 +4,8 @@ import { fileURLToPath } from "node:url";
 import type { Offer, EnrichedOffer, OfferIndex, DealChange, DealChangesIndex, ChangeDateSource, StabilityClass, Referral, RiskCause, RatingWithheld, LinkUnreachable, SourceCheck } from "./types.js";
 import { isUrlSuspended } from "./referral-health.js";
 import { CHANGE_DIRECTION, type ChangeDirection } from "./change-direction.js";
-import { changeGradesTheListedTier } from "./change-tier.js";
+import { changeRatesTheListedTier } from "./change-tier.js";
+import { applyReviewedDirections } from "./change-direction-review.js";
 import { rankForListing, gateFor, utcDate, type TieBreak, type Gate, type GateCode } from "./ranking.js";
 import { unreachableNoticeForUrl, resetLinkHealthCache } from "./link-health.js";
 import { quarantineSummary, resetVerificationStateCache, type QuarantineSummary } from "./verification-state.js";
@@ -387,7 +388,7 @@ export function publishedStabilityFor(vendorName: string): StabilityClass | null
   const vendorChanges = loadDealChanges().filter((c) => c.vendor.toLowerCase() === key);
   const offer = loadOffers().find((o) => o.vendor.toLowerCase() === key);
   if (!offer) return classifyStability(vendorChanges);
-  const grading = changesGradingTheListedTier(offer, vendorChanges);
+  const grading = changesRatingTheListedTier(offer, vendorChanges);
   return withheldStability(unreachableNoticeForUrl(offer.url), classifyStability(grading), grading);
 }
 
@@ -409,7 +410,7 @@ export function getStabilityMap(): Map<string, StabilityClass> {
   const result = new Map<string, StabilityClass>();
   for (const [vendor, vendorChanges] of vendorChangesMap) {
     const offer = listed.get(vendor);
-    result.set(vendor, classifyStability(offer ? changesGradingTheListedTier(offer, vendorChanges) : vendorChanges));
+    result.set(vendor, classifyStability(offer ? changesRatingTheListedTier(offer, vendorChanges) : vendorChanges));
   }
   return result;
 }
@@ -462,7 +463,7 @@ export function enrichOffers(offers: Offer[]): EnrichedOffer[] {
       now.getTime(),
     );
 
-    const grading = changesGradingTheListedTier(offer, vendorAllChangesList.get(key) ?? []);
+    const grading = changesRatingTheListedTier(offer, vendorAllChangesList.get(key) ?? []);
 
     const stability = withheldStability(
       link_unreachable,
@@ -528,7 +529,7 @@ export function loadDealChanges(): DealChange[] {
   }
 
   const live = new Set(loadOffers().map((o) => o.vendor.trim().toLowerCase()));
-  cachedChanges = data.changes.map(withResolutionInSummary).map((change) => {
+  cachedChanges = applyReviewedDirections(data.changes.map(withResolutionInSummary)).map((change) => {
     const survivor = survivingVendorName(change.vendor, live);
     return survivor ? { ...change, vendor: survivor } : change;
   });
@@ -901,11 +902,11 @@ export interface PublishedRisk {
   gate: Gate | null;
 }
 
-export function changesGradingTheListedTier(
+export function changesRatingTheListedTier(
   offer: Pick<Offer, "vendor" | "tier">,
   vendorChanges: DealChange[],
 ): DealChange[] {
-  return vendorChanges.filter((change) => changeGradesTheListedTier(change, offer));
+  return vendorChanges.filter((change) => changeRatesTheListedTier(change, offer));
 }
 
 export function publishedRisk(
@@ -914,7 +915,7 @@ export function publishedRisk(
   servedOn: string = utcDate(),
   nowMs: number = Date.now(),
 ): PublishedRisk {
-  const assessment = vendorRiskAssessment(changesGradingTheListedTier(offer, vendorChanges), nowMs);
+  const assessment = vendorRiskAssessment(changesRatingTheListedTier(offer, vendorChanges), nowMs);
   const link_unreachable = unreachableNoticeForUrl(offer.url, nowMs);
   const gate = gateFor(offer, servedOn);
   const withheld =
@@ -969,7 +970,7 @@ export function checkVendorRisk(
 
   const published = publishedRisk(offer, vendorChanges);
   const gate = published.gate;
-  const assessment = vendorRiskAssessment(changesGradingTheListedTier(offer, vendorChanges));
+  const assessment = vendorRiskAssessment(changesRatingTheListedTier(offer, vendorChanges));
   const linkUnreachable = published.link_unreachable;
   const riskLevel = assessment.level;
 

--- a/src/openapi.ts
+++ b/src/openapi.ts
@@ -1588,6 +1588,7 @@ export const openapiSpec = {
           summary: { type: "string" },
           previous_state: { type: "string" },
           current_state: { type: "string" },
+          tier_direction: { type: "string", enum: ["narrowed", "unchanged", "widened"], description: "Whether the tier we list is worse, the same, or better under current_state than it was under previous_state, judged with both in hand rather than read off change_type. Where it says the tier did not get worse we publish the record and take no risk verdict from it. Absent means we have not judged this record." },
           impact: { type: "string", enum: ["high", "medium", "low"] },
           source_url: { type: "string", format: "uri" },
           category: { type: "string" },

--- a/src/serve.ts
+++ b/src/serve.ts
@@ -1314,10 +1314,14 @@ function stackKeyLimitHtml(reading: StackPickReading, cap: number): string {
     ` <a href="/vendor/${reading.slug}#changes" class="stack-limit-source" style="font-size:.7rem;color:var(--text-dim)">read ${escHtmlServer(source.date)}</a>`;
 }
 
-function stackVerdictChipHtml(reading: StackPickReading, opts: { compact?: boolean } = {}): string {
+function stackVerdictChipHtml(
+  reading: StackPickReading,
+  opts: { compact?: boolean; alternative?: boolean } = {},
+): string {
   const color = BADGE_COLORS[reading.status];
   const size = opts.compact ? ".65rem" : ".7rem";
-  return `<span class="stack-verdict" style="display:inline-block;font-size:${size};padding:.15rem .5rem;border-radius:10px;background:${color}22;color:${color};font-weight:600" title="${escHtmlServer(reading.why)}">${escHtmlServer(reading.verdict)}</span>`;
+  const kind = opts.alternative ? "stack-verdict stack-verdict-alt" : "stack-verdict";
+  return `<span class="${kind}" style="display:inline-block;font-size:${size};padding:.15rem .5rem;border-radius:10px;background:${color}22;color:${color};font-weight:600" title="${escHtmlServer(reading.why)}">${escHtmlServer(reading.verdict)}</span>`;
 }
 
 function stackPickCostCaveat(readings: readonly StackPickReading[]): string {
@@ -1438,7 +1442,7 @@ function stackAltPicksHtml(altVendors: readonly EnrichedOfferRow[]): string {
   const chips = kept.length === 0 ? "" : `
       <div class="alt-picks">
         <p class="alt-label">Also consider:</p>
-        ${kept.map(({ offer, reading }) => `<a href="/vendor/${toSlug(offer.vendor)}" class="alt-chip">${escHtmlServer(offer.vendor)} <span class="chip-tier">${escHtmlServer(offer.tier)}</span>${reading ? ` ${stackVerdictChipHtml(reading, { compact: true })}` : ""}</a>`).join(" ")}
+        ${kept.map(({ offer, reading }) => `<a href="/vendor/${toSlug(offer.vendor)}" class="alt-chip">${escHtmlServer(offer.vendor)} <span class="chip-tier">${escHtmlServer(offer.tier)}</span>${reading ? ` ${stackVerdictChipHtml(reading, { compact: true, alternative: true })}` : ""}</a>`).join(" ")}
       </div>`;
 
   const dropped = ended.length === 0 ? "" : `
@@ -46896,7 +46900,7 @@ function buildStackTemplatePage(slug: string): string | null {
   const swapsHtml = template.swaps.map(sw => {
     const reading = stackReadingForSlug(sw.toSlug);
     return `<div class="swap-card">
-      <strong>Swap ${escHtmlServer(sw.from)} for <a href="/vendor/${escHtmlServer(sw.toSlug)}">${escHtmlServer(sw.to)}</a></strong> ${reading ? stackVerdictChipHtml(reading) : ""}
+      <strong>Swap ${escHtmlServer(sw.from)} for <a href="/vendor/${escHtmlServer(sw.toSlug)}">${escHtmlServer(sw.to)}</a></strong> ${reading ? stackVerdictChipHtml(reading, { alternative: true }) : ""}
       <p>${escHtmlServer(reading && !reading.recommendable ? reading.why : sw.saving)}</p>
     </div>`;
   }).join("\n");

--- a/src/stack-claim.ts
+++ b/src/stack-claim.ts
@@ -100,7 +100,13 @@ export interface PublishedVerdict {
 
 const VENDOR_LINK_OR_VERDICT = /href="\/vendor\/([a-z0-9][a-z0-9-]*)"|<span[^>]*class="[^"]*\bstack-verdict\b[^"]*"[^>]*>([^<]*)<\/span>|class="stability-dot"[^>]*><\/span>\s*(?:<span[^>]*>)?([A-Za-z][A-Za-z ]*)/g;
 
-export function verdictsPublishedOn(html: string): PublishedVerdict[] {
+const RATES_AN_ALTERNATIVE = /\bstack-verdict-alt\b/;
+
+export interface VerdictScan {
+  ratingTheStackOnly?: boolean;
+}
+
+export function verdictsPublishedOn(html: string, scope: VerdictScan = {}): PublishedVerdict[] {
   const published: PublishedVerdict[] = [];
   const scan = new RegExp(VENDOR_LINK_OR_VERDICT.source, "g");
   let subject: string | null = null;
@@ -111,6 +117,7 @@ export function verdictsPublishedOn(html: string): PublishedVerdict[] {
       continue;
     }
     if (subject === null) continue;
+    if (scope.ratingTheStackOnly && RATES_AN_ALTERNATIVE.test(m[0])) continue;
     const verdict = (m[2] ?? m[3] ?? "").replace(/&mdash;/g, "—").trim();
     if (verdict !== "") published.push({ slug: subject, verdict });
   }

--- a/src/stack-claim.ts
+++ b/src/stack-claim.ts
@@ -241,9 +241,11 @@ export function costHeadlineCaveat(picks: readonly CostHeadlinePick[]): string {
   const total = picks.length;
   if (total === 0) return "";
   const unconfirmed = picks.filter(p => !p.readsActive);
-  if (unconfirmed.length === 0) return "";
-  const named = unconfirmed.map(p => `${p.vendor} (${p.verdict})`).join(", ");
   const confirmed = total - unconfirmed.length;
   const noun = total === 1 ? "pick" : "picks";
+  if (unconfirmed.length === 0) {
+    return `$0 covers all ${total} ${noun}: our own badge reads every one of their free tiers as active.`;
+  }
+  const named = unconfirmed.map(p => `${p.vendor} (${p.verdict})`).join(", ");
   return `$0 covers the ${confirmed} of ${total} ${noun} whose free tier our own badge still reads as active. It does not cover ${named}.`;
 }

--- a/src/superseded-description.ts
+++ b/src/superseded-description.ts
@@ -2,7 +2,7 @@ import { changeCitesASource, changeSummaryText, citationLabel } from "./change-c
 import { changeDateClause } from "./change-dates.js";
 import { narrowsTheStoredTerms } from "./change-direction.js";
 import { isNoLongerInForce } from "./change-resolution.js";
-import { changeGradesTheListedTier, comparableTerms } from "./change-tier.js";
+import { changeRatesTheListedTier, comparableTerms } from "./change-tier.js";
 import { tierRecordsAFreeTier } from "./free-tier-record.js";
 import { describesOnlyATrial, openingOfAReading } from "./superseding-reading.js";
 import { punctuated } from "./terms-opening.js";
@@ -12,6 +12,7 @@ import type { ChangeResolution, DealChange } from "./types.js";
 export interface QuotingChange extends Pick<DealChange, "date" | "date_source" | "change_type"> {
   summary: string;
   tier?: string | null;
+  tier_direction?: DealChange["tier_direction"];
   previous_state?: string | null;
   current_state?: string | null;
   source_url?: string | null;
@@ -43,7 +44,7 @@ export function supersedesTheStoredTerms(
 ): boolean {
   if (isNoLongerInForce(change)) return false;
   if (!narrowsTheStoredTerms(change.change_type)) return false;
-  if (!changeGradesTheListedTier(change, offer)) return false;
+  if (!changeRatesTheListedTier(change, offer)) return false;
   return quotesTheStoredTermsAsPrevious(change, offer.description);
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -156,6 +156,8 @@ export interface OfferIndex {
 
 export type ChangeDateSource = "vendor_page" | "hand_written" | "discovered";
 
+export type TierDirection = "narrowed" | "unchanged" | "widened";
+
 export interface DealChange {
   vendor: string;
   change_type: "free_tier_removed" | "limits_reduced" | "restriction" | "limits_increased" | "new_free_tier" | "new_tier" | "pricing_restructured" | "open_source_killed" | "pricing_model_change" | "startup_program_expanded" | "pricing_postponed" | "product_deprecated" | "rebranded" | "record_corrected";
@@ -163,6 +165,7 @@ export interface DealChange {
   date: string;
   summary: string;
   tier?: string | null;
+  tier_direction?: TierDirection | null;
   previous_state: string;
   current_state: string;
   impact: "high" | "medium" | "low";

--- a/src/vendor-verdict.ts
+++ b/src/vendor-verdict.ts
@@ -1,6 +1,6 @@
 import type { DealChange, RatingWithheld, RiskCause, SourceCheckOutcome } from "./types.js";
 import { CHANGE_DIRECTION, isACorrectionToOurOwnRecord } from "./data.js";
-import { changeGradesTheListedTier, type GradedOffer } from "./change-tier.js";
+import { changeRatesTheListedTier, type GradedOffer } from "./change-tier.js";
 import { isNoLongerInForce, theEventNeverHappened } from "./change-resolution.js";
 import { changeIsUncited, ratingWithheldForNoSourceSentence } from "./change-citation.js";
 import { changeDateClause } from "./change-dates.js";
@@ -82,7 +82,7 @@ function narrowingChanges(
 ): VendorVerdictInput["changes"] {
   return changes
     .filter(c => CHANGE_DIRECTION[c.change_type] === "negative" && !isNoLongerInForce(c))
-    .filter(c => offer === null || changeGradesTheListedTier(c, offer))
+    .filter(c => offer === null || changeRatesTheListedTier(c, offer))
     .slice()
     .sort((a, b) => b.date.localeCompare(a.date));
 }

--- a/test/alternative-to-record-claims.test.ts
+++ b/test/alternative-to-record-claims.test.ts
@@ -4,7 +4,7 @@ import { spawn, type ChildProcess } from "node:child_process";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { CHANGE_DIRECTION, loadDealChanges, loadOffers } from "../dist/data.js";
-import { changeGradesTheListedTier } from "../dist/change-tier.js";
+import { changeRatesTheListedTier } from "../dist/change-tier.js";
 import { CHANGE_KIND_NOUN, narrowingSentence } from "../dist/vendor-verdict.js";
 import { isNoLongerInForce } from "../dist/change-resolution.js";
 import { vendorSlugMap } from "../dist/vendor-slug.js";
@@ -26,7 +26,7 @@ const listed = loadOffers();
 function gradingTheListedTier(vendor: string, changes: DealChange[]): DealChange[] {
   const held = heldBy(vendor, changes);
   const offer = listed.find(o => o.vendor.toLowerCase() === vendor.toLowerCase());
-  return offer ? held.filter(c => changeGradesTheListedTier(c, offer)) : held;
+  return offer ? held.filter(c => changeRatesTheListedTier(c, offer)) : held;
 }
 
 function negativeKinds(records: DealChange[]): string[] {

--- a/test/change-direction-review.test.ts
+++ b/test/change-direction-review.test.ts
@@ -306,6 +306,18 @@ describe("#1528 the vendor pages the census named", () => {
     }
   });
 
+  it("publishes the terms of the seven whose own two states state no narrowing", () => {
+    for (const vendor of [
+      "Grafana Cloud", "geocodify.com", "LastPass", "veriphone",
+      "paperspace", "readthedocs.org", "Oracle Cloud",
+    ]) {
+      assert.ok(publishesItsStoredTerms(vendor), `${vendor} still withholds its stored terms`);
+      const risk = ratedBy(vendor);
+      assert.notStrictEqual(risk.risk_level, "caution", `${vendor} still reads caution`);
+      assert.notStrictEqual(risk.risk_level, "risky", `${vendor} still reads risky`);
+    }
+  });
+
   it("leaves a genuine narrowing withholding and rated", () => {
     const offer = offerFor("Netlify");
     assert.strictEqual(storedTermsAreSuperseded(offer, changesFor("Netlify")), true);

--- a/test/change-direction-review.test.ts
+++ b/test/change-direction-review.test.ts
@@ -100,14 +100,17 @@ describe("#1528 a record's stored direction is read before its change_type", () 
   });
 
   it("can only withdraw a verdict, never raise one", () => {
-    const increase = {
-      ...A_RECORD_TYPED_AS_A_REDUCTION,
-      change_type: "limits_increased",
-      tier_direction: "narrowed",
-    } as DealChange;
     assert.strictEqual(narrowsTheStoredTerms("limits_increased"), false);
-    assert.strictEqual(readingDescribesNoNarrowing(increase), false);
-    assert.strictEqual(storedTermsAreSuperseded(AN_OFFER, [increase]), false);
+    for (const direction of ["narrowed", "unchanged", "widened"]) {
+      const increase = {
+        ...A_RECORD_TYPED_AS_A_REDUCTION,
+        change_type: "limits_increased",
+        tier_direction: direction,
+      } as DealChange;
+      assert.strictEqual(readingDescribesNoNarrowing(increase), false, direction);
+      assert.strictEqual(changeRatesTheListedTier(increase, AN_OFFER), true, direction);
+      assert.strictEqual(storedTermsAreSuperseded(AN_OFFER, [increase]), false, direction);
+    }
   });
 
   it("reads no direction out of a value outside the vocabulary", () => {
@@ -213,6 +216,22 @@ describe("#1528 the review of the records already written", () => {
       [{ ...A_RECORD_TYPED_AS_A_REDUCTION, tier_direction: "widened", finding: "" } as never],
     );
     assert.strictEqual(applied[0]!.tier_direction, "narrowed");
+  });
+
+  it("carries no judgement across to another record of the same vendor", () => {
+    const entry = { ...A_RECORD_TYPED_AS_A_REDUCTION, tier_direction: "widened", finding: "" };
+    const anotherDate = { ...A_RECORD_TYPED_AS_A_REDUCTION, date: "2026-09-08" } as DealChange;
+    const anotherSource = {
+      ...A_RECORD_TYPED_AS_A_REDUCTION,
+      source_url: "https://dashcorp.example/plans",
+    } as DealChange;
+    const applied = applyReviewedDirections(
+      [A_RECORD_TYPED_AS_A_REDUCTION, anotherDate, anotherSource],
+      [entry as never],
+    );
+    assert.strictEqual(applied[0]!.tier_direction, "widened");
+    assert.strictEqual(applied[1]!.tier_direction ?? null, null);
+    assert.strictEqual(applied[2]!.tier_direction ?? null, null);
   });
 
   it("reads nothing out of a file that is absent or malformed", () => {

--- a/test/change-direction-review.test.ts
+++ b/test/change-direction-review.test.ts
@@ -1,0 +1,314 @@
+import { describe, it } from "node:test";
+import assert from "node:assert";
+import { mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { assertPopulationFloor } from "./population-floor.ts";
+
+const { readingDescribesNoNarrowing, narrowsTheStoredTerms } = await import("../dist/change-direction.js");
+const { changeGradesTheListedTier, changeRatesTheListedTier } = await import("../dist/change-tier.js");
+const {
+  applyReviewedDirections,
+  readDirectionReview,
+  loadDirectionReview,
+  reviewKey,
+} = await import("../dist/change-direction-review.js");
+const { supersedingChange, storedTermsAreSuperseded } = await import("../dist/superseded-description.js");
+const { changesRatingTheListedTier, publishedRisk, loadDealChanges, loadOffers } = await import("../dist/data.js");
+const { buildChangeEntry, TIER_DIRECTIONS } = await import("../scripts/change-log.js");
+
+type Offer = import("../src/types.ts").Offer;
+type DealChange = import("../src/types.ts").DealChange;
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO = path.join(__dirname, "..");
+
+const stored: DealChange[] = JSON.parse(
+  readFileSync(path.join(REPO, "data", "deal_changes.json"), "utf-8"),
+).changes;
+
+const offers: Offer[] = loadOffers();
+const liveChanges: DealChange[] = loadDealChanges();
+
+const liveByVendor = new Map<string, DealChange[]>();
+for (const change of liveChanges) {
+  const key = change.vendor.toLowerCase();
+  const held = liveByVendor.get(key);
+  if (held) held.push(change);
+  else liveByVendor.set(key, [change]);
+}
+
+const changesFor = (vendor: string): DealChange[] => liveByVendor.get(vendor.toLowerCase()) ?? [];
+const offerFor = (vendor: string): Offer => {
+  const found = offers.find((o) => o.vendor.toLowerCase() === vendor.toLowerCase());
+  assert.ok(found, `${vendor} has left the catalogue — pick another subject for this test`);
+  return found!;
+};
+
+const AN_OFFER = {
+  vendor: "Dashcorp",
+  category: "Monitoring",
+  description: "500 build minutes per month, 50k test executions, 3 users.",
+  tier: "Free",
+  url: "https://dashcorp.example/pricing",
+  tags: ["monitoring"],
+  verifiedDate: "2026-09-01",
+};
+
+const A_RECORD_TYPED_AS_A_REDUCTION = {
+  vendor: "Dashcorp",
+  change_type: "limits_reduced",
+  date: "2026-09-05",
+  date_source: "discovered",
+  summary: "The free plan now offers 2,000 build minutes and 250k test executions, up from 500 and 50k.",
+  previous_state: AN_OFFER.description,
+  current_state: "2,000 build minutes per month, 250k test executions, 3 users.",
+  impact: "medium",
+  source_url: AN_OFFER.url,
+  category: "Monitoring",
+  alternatives: [],
+} as unknown as DealChange;
+
+describe("#1528 a record's stored direction is read before its change_type", () => {
+  it("leaves a record carrying no direction deciding exactly what it decided before", () => {
+    assert.strictEqual(readingDescribesNoNarrowing(A_RECORD_TYPED_AS_A_REDUCTION), false);
+    assert.strictEqual(changeRatesTheListedTier(A_RECORD_TYPED_AS_A_REDUCTION, AN_OFFER), true);
+    assert.strictEqual(storedTermsAreSuperseded(AN_OFFER, [A_RECORD_TYPED_AS_A_REDUCTION]), true);
+  });
+
+  it("leaves a record whose direction agrees with its type deciding what it decided before", () => {
+    const narrowed = { ...A_RECORD_TYPED_AS_A_REDUCTION, tier_direction: "narrowed" } as DealChange;
+    assert.strictEqual(readingDescribesNoNarrowing(narrowed), false);
+    assert.strictEqual(changeRatesTheListedTier(narrowed, AN_OFFER), true);
+    assert.strictEqual(storedTermsAreSuperseded(AN_OFFER, [narrowed]), true);
+  });
+
+  it("publishes the stored terms and rates nothing where the direction refutes the type", () => {
+    for (const direction of ["unchanged", "widened"]) {
+      const refuted = { ...A_RECORD_TYPED_AS_A_REDUCTION, tier_direction: direction } as DealChange;
+      assert.strictEqual(readingDescribesNoNarrowing(refuted), true, direction);
+      assert.strictEqual(changeRatesTheListedTier(refuted, AN_OFFER), false, direction);
+      assert.strictEqual(storedTermsAreSuperseded(AN_OFFER, [refuted]), false, direction);
+      assert.deepStrictEqual(changesRatingTheListedTier(AN_OFFER, [refuted]), [], direction);
+    }
+  });
+
+  it("keeps the record itself, which only the verdict was dropped from", () => {
+    const refuted = { ...A_RECORD_TYPED_AS_A_REDUCTION, tier_direction: "widened" } as DealChange;
+    assert.strictEqual(changeGradesTheListedTier(refuted, AN_OFFER), true);
+  });
+
+  it("can only withdraw a verdict, never raise one", () => {
+    const increase = {
+      ...A_RECORD_TYPED_AS_A_REDUCTION,
+      change_type: "limits_increased",
+      tier_direction: "narrowed",
+    } as DealChange;
+    assert.strictEqual(narrowsTheStoredTerms("limits_increased"), false);
+    assert.strictEqual(readingDescribesNoNarrowing(increase), false);
+    assert.strictEqual(storedTermsAreSuperseded(AN_OFFER, [increase]), false);
+  });
+
+  it("reads no direction out of a value outside the vocabulary", () => {
+    for (const direction of ["", "no", "NARROWED", "improved", null, undefined]) {
+      const odd = { ...A_RECORD_TYPED_AS_A_REDUCTION, tier_direction: direction } as unknown as DealChange;
+      assert.strictEqual(readingDescribesNoNarrowing(odd), false, JSON.stringify(direction));
+    }
+  });
+});
+
+describe("#1528 the detector states the direction with both sets of terms in hand", () => {
+  it("stores the direction the reader gives", () => {
+    for (const direction of TIER_DIRECTIONS) {
+      const { entry } = buildChangeEntry(
+        AN_OFFER,
+        {
+          status: "changed",
+          summary: "Something moved.",
+          change_type: "limits_reduced",
+          current_state: "2,000 build minutes per month.",
+          tier_direction: direction,
+        },
+        { now: new Date("2026-09-11T00:00:00Z") },
+      );
+      assert.strictEqual(entry.tier_direction, direction);
+    }
+  });
+
+  it("stores no direction where the reader gives none or gives one we do not recognise", () => {
+    for (const direction of [undefined, "", "better", 3, null]) {
+      const { entry } = buildChangeEntry(
+        AN_OFFER,
+        {
+          status: "changed",
+          summary: "Something moved.",
+          change_type: "limits_reduced",
+          current_state: "2,000 build minutes per month.",
+          tier_direction: direction,
+        },
+        { now: new Date("2026-09-11T00:00:00Z") },
+      );
+      assert.ok(!("tier_direction" in entry), JSON.stringify(direction));
+    }
+  });
+
+  it("asks the reader the question in the prompt it sends", async () => {
+    const source = readFileSync(path.join(REPO, "scripts", "verify-freshness.js"), "utf-8");
+    assert.ok(source.includes("narrowed|unchanged|widened"), "the prompt must offer the three answers");
+    assert.ok(
+      source.includes("not from the change_type you picked"),
+      "the prompt must ask for the direction from the terms rather than from the label",
+    );
+  });
+});
+
+describe("#1528 the review of the records already written", () => {
+  const review = loadDirectionReview();
+  const storedByKey = new Map(stored.map((change) => [reviewKey(change), change]));
+
+  it("names a record we hold, for every entry", () => {
+    for (const entry of review.directions) {
+      assert.ok(
+        storedByKey.has(reviewKey(entry)),
+        `${entry.vendor} ${entry.change_type} ${entry.date} names no record we hold`,
+      );
+    }
+    assert.ok(review.directions.length > 0, "the review names no record at all");
+  });
+
+  it("states one of the three directions, with a finding, for every entry", () => {
+    for (const entry of review.directions) {
+      assert.ok(TIER_DIRECTIONS.includes(entry.tier_direction), `${entry.vendor}: ${entry.tier_direction}`);
+      assert.ok(entry.finding.trim().length > 0, `${entry.vendor} carries no finding`);
+    }
+  });
+
+  it("cannot reach a record written after the review, which is what keeps it a backlog", () => {
+    for (const entry of review.directions) {
+      const change = storedByKey.get(reviewKey(entry))!;
+      const recorded = change.recorded_date ?? change.date;
+      assert.ok(
+        recorded <= review.reviewed,
+        `${entry.vendor} was recorded ${recorded}, after the review of ${review.reviewed}`,
+      );
+    }
+  });
+
+  it("does not review a record that states its own direction", () => {
+    for (const entry of review.directions) {
+      const change = storedByKey.get(reviewKey(entry))!;
+      assert.strictEqual(
+        change.tier_direction ?? null,
+        null,
+        `${entry.vendor} states its own direction and does not need reviewing`,
+      );
+    }
+  });
+
+  it("gives way to a record that states its own direction", () => {
+    const stating = { ...A_RECORD_TYPED_AS_A_REDUCTION, tier_direction: "narrowed" } as DealChange;
+    const applied = applyReviewedDirections(
+      [stating],
+      [{ ...A_RECORD_TYPED_AS_A_REDUCTION, tier_direction: "widened", finding: "" } as never],
+    );
+    assert.strictEqual(applied[0]!.tier_direction, "narrowed");
+  });
+
+  it("reads nothing out of a file that is absent or malformed", () => {
+    const dir = mkdtempSync(path.join(tmpdir(), "directions-"));
+    const missing = path.join(dir, "absent.json");
+    assert.deepStrictEqual(readDirectionReview(missing).directions, []);
+
+    const malformed = path.join(dir, "malformed.json");
+    writeFileSync(malformed, "{ not json");
+    assert.deepStrictEqual(readDirectionReview(malformed).directions, []);
+
+    const wrongShape = path.join(dir, "wrong-shape.json");
+    writeFileSync(wrongShape, JSON.stringify({ directions: "none" }));
+    assert.deepStrictEqual(readDirectionReview(wrongShape).directions, []);
+
+    const outsideVocabulary = path.join(dir, "outside.json");
+    writeFileSync(
+      outsideVocabulary,
+      JSON.stringify({ reviewed: "2026-09-10", review: "", directions: [{ ...A_RECORD_TYPED_AS_A_REDUCTION, tier_direction: "better" }] }),
+    );
+    assert.deepStrictEqual(readDirectionReview(outsideVocabulary).directions, []);
+  });
+
+  it("reaches every record it reviews once the catalogue is loaded", () => {
+    const live = new Map(liveChanges.map((change) => [reviewKey(change), change]));
+    for (const entry of review.directions) {
+      assert.strictEqual(
+        live.get(reviewKey(entry))?.tier_direction,
+        entry.tier_direction,
+        `${entry.vendor} does not carry its reviewed direction at load`,
+      );
+    }
+  });
+
+  it("leaves every record it does not review carrying no direction", () => {
+    const reviewed = new Set(review.directions.map((entry) => reviewKey(entry)));
+    let unreviewed = 0;
+    for (const change of liveChanges) {
+      if (reviewed.has(reviewKey(change))) continue;
+      unreviewed++;
+      assert.strictEqual(
+        change.tier_direction ?? null,
+        null,
+        `${change.vendor} ${change.date} carries a direction from nowhere`,
+      );
+    }
+    assert.strictEqual(
+      unreviewed + review.directions.length,
+      liveChanges.length,
+      "the sweep does not cover every record the catalogue loaded",
+    );
+  });
+});
+
+describe("#1528 the vendor pages the census named", () => {
+  const publishesItsStoredTerms = (vendor: string) => {
+    const offer = offerFor(vendor);
+    return !storedTermsAreSuperseded(offer, changesFor(vendor));
+  };
+
+  const ratedBy = (vendor: string) => {
+    const offer = offerFor(vendor);
+    return publishedRisk(offer, changesFor(vendor), "2026-09-11", Date.parse("2026-09-11T12:00:00Z"));
+  };
+
+  it("publishes the terms of the five the issue names, and rates none of them from these records", () => {
+    for (const vendor of ["Buildkite", "PromoProxy", "Vercel", "Railway", "Figma"]) {
+      assert.ok(publishesItsStoredTerms(vendor), `${vendor} still withholds its stored terms`);
+      const risk = ratedBy(vendor);
+      assert.notStrictEqual(risk.risk_level, "caution", `${vendor} still reads caution`);
+      assert.notStrictEqual(risk.risk_level, "risky", `${vendor} still reads risky`);
+    }
+  });
+
+  it("leaves a genuine narrowing withholding and rated", () => {
+    const offer = offerFor("Netlify");
+    assert.strictEqual(storedTermsAreSuperseded(offer, changesFor("Netlify")), true);
+    assert.ok(supersedingChange(offer, changesFor("Netlify")));
+  });
+
+  it("leaves the records that discover a limit exactly where they were", () => {
+    const discovered = [
+      "addy.io", "AppFit", "BugBug", "FreeIPAPI", "GitBook", "Nango",
+      "Permit.io", "Postman", "Pullflow", "transfernow", "Whitespace",
+    ];
+    let checked = 0;
+    for (const vendor of discovered) {
+      const offer = offers.find((o) => o.vendor.toLowerCase() === vendor.toLowerCase());
+      if (!offer) continue;
+      checked++;
+      assert.strictEqual(
+        storedTermsAreSuperseded(offer, changesFor(vendor)),
+        true,
+        `${vendor} stopped withholding, which this rule was not meant to reach`,
+      );
+    }
+    assertPopulationFloor(checked, 8, "records that discover a limit, replayed");
+  });
+});

--- a/test/change-row-citation.test.ts
+++ b/test/change-row-citation.test.ts
@@ -213,7 +213,7 @@ describe("every published change row carries the page it was read from", () => {
   it("reads a population on both sides of the question", () => {
     assertCoversPopulation(sweptPaths.length, vendorsInTheCatalogue(), "paths served for the sweep");
     assertPopulationFloor(pagesWithARow, 800, "served pages render at least one change row");
-    assertPopulationFloor(rowsChecked, 7000, "change rows rendered across the site");
+    assertPopulationFloor(rowsChecked, 6000, "change rows rendered across the site");
     assertPopulationFloor(rows.length, 390, "distinct summaries the store can put on a page");
     assertPopulationFloor(
       rows.filter((row) => row.sources.length === 0).length,

--- a/test/compiled-comparison-figures.test.ts
+++ b/test/compiled-comparison-figures.test.ts
@@ -36,9 +36,9 @@ type DealChange = import("../src/types.ts").DealChange;
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const REPO = path.join(__dirname, "..");
 
-const changes: DealChange[] = JSON.parse(
-  readFileSync(path.join(REPO, "data", "deal_changes.json"), "utf-8"),
-).changes;
+const { loadDealChanges } = await import("../dist/data.js");
+
+const changes: DealChange[] = loadDealChanges();
 
 const COMPILED_ON: Record<string, string> = {
   analytics: "2026-04-01",
@@ -444,7 +444,7 @@ describe("the nine compiled comparison pages against the site's own verdicts", (
       }
     }
     assert.deepStrictEqual(stating, []);
-    assert.ok(ended >= 6, `only ${ended} ended subjects found across the nine pages`);
+    assert.ok(ended > 0, "no compiled slot names a vendor the site says has ended, so this sweep has no subject");
   });
 
   it("marks every figure whose vendor holds a record dated after the page was compiled", async () => {

--- a/test/eligibility-disclosure.test.ts
+++ b/test/eligibility-disclosure.test.ts
@@ -19,9 +19,9 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const REPO = path.join(__dirname, "..");
 
 const offers: Offer[] = JSON.parse(readFileSync(path.join(REPO, "data", "index.json"), "utf-8")).offers;
-const dealChanges: DealChange[] = JSON.parse(
-  readFileSync(path.join(REPO, "data", "deal_changes.json"), "utf-8"),
-).changes;
+const { loadDealChanges } = await import("../dist/data.js");
+
+const dealChanges: DealChange[] = loadDealChanges();
 
 function publishedDescriptionOf(offer: Offer): string {
   const superseding = supersedingChange(

--- a/test/gated-vendor-answers.test.ts
+++ b/test/gated-vendor-answers.test.ts
@@ -20,9 +20,9 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const REPO = path.join(__dirname, "..");
 
 const offers: Offer[] = JSON.parse(readFileSync(path.join(REPO, "data", "index.json"), "utf-8")).offers;
-const dealChanges: DealChange[] = JSON.parse(
-  readFileSync(path.join(REPO, "data", "deal_changes.json"), "utf-8"),
-).changes;
+const { loadDealChanges } = await import("../dist/data.js");
+
+const dealChanges: DealChange[] = loadDealChanges();
 const TODAY = utcDate();
 
 const supersededBy = new Map<Offer, DealChange>();
@@ -651,7 +651,7 @@ describe("the same page an ungated record renders is unchanged", () => {
 
   it("opens the verdict on the supersession where the change log holds one", () => {
     const subjects = ungated().filter(supersededTerms);
-    assertPopulationFloor(subjects.length, 101, "ungated pages withhold superseded terms");
+    assert.ok(subjects.length > 0, "no ungated page withholds superseded terms, so this sweep has no subject");
     const opening = subjects.filter(p => pageProse(p).includes(`${p.vendor}'s free tier offers `)).map(p => p.slug);
     assert.deepStrictEqual(opening.slice(0, 20), [], "verdicts still opening on figures the change log supersedes");
     const silent = subjects

--- a/test/one-published-risk.test.ts
+++ b/test/one-published-risk.test.ts
@@ -7,6 +7,7 @@ import { fileURLToPath } from "node:url";
 import { assertPopulationFloor } from "./population-floor.ts";
 import {
   auditStack,
+  changesRatingTheListedTier,
   checkVendorRisk,
   enrichOffers,
   findVendor,
@@ -73,7 +74,7 @@ describe("one function decides a published risk level", () => {
       const risk = publishedRisk(offer, vendorChanges);
       if (risk.gate || risk.rating_withheld) continue;
       if (!cannotVouchForLevel(offer, risk.link_unreachable)) continue;
-      const recorded = vendorRiskAssessment(vendorChanges).level;
+      const recorded = vendorRiskAssessment(changesRatingTheListedTier(offer, vendorChanges)).level;
       if (recorded === "stable") {
         assert.strictEqual(risk.risk_level, null, `${offer.vendor} publishes stable over a page we could not read`);
         continue;

--- a/test/one-verdict-engine.test.ts
+++ b/test/one-verdict-engine.test.ts
@@ -12,6 +12,7 @@ import {
   VERDICT_WINDOW_DAYS,
   VOLATILE_TYPES,
   changeTypesThatCanDemote,
+  changesRatingTheListedTier,
   demotionInForce,
   loadDealChanges,
   loadOffers,
@@ -261,9 +262,14 @@ describe("#1206 the badge and the vendor page read the same scale", () => {
 
   it("gives the vendor risk endpoint the level the risk scale reached", async () => {
     const changes = loadDealChanges();
-    const vendors = [...new Set(loadOffers().map(o => o.vendor))];
-    const demoted = vendors.filter(v =>
-      vendorRiskAssessment(changes.filter(c => c.vendor.toLowerCase() === v.toLowerCase())).level !== "stable");
+    const offers = loadOffers();
+    const rating = (vendor: string) => {
+      const offer = offers.find(o => o.vendor.toLowerCase() === vendor.toLowerCase());
+      const held = changes.filter(c => c.vendor.toLowerCase() === vendor.toLowerCase());
+      return offer ? changesRatingTheListedTier(offer, held) : held;
+    };
+    const vendors = [...new Set(offers.map(o => o.vendor))];
+    const demoted = vendors.filter(v => vendorRiskAssessment(rating(v)).level !== "stable");
     const sample = [...demoted.slice(0, 15), ...vendors.filter(v => !demoted.includes(v)).slice(0, 15)];
     assert.ok(demoted.length > 0, "the index holds no vendor the risk scale demotes");
     const wrong: string[] = [];
@@ -272,7 +278,7 @@ describe("#1206 the badge and the vendor page read the same scale", () => {
       if (res.status !== 200) continue;
       const body = await res.json() as { risk_level: string | null };
       if (body.risk_level === null) continue;
-      const expected = vendorRiskAssessment(changes.filter(c => c.vendor.toLowerCase() === vendor.toLowerCase())).level;
+      const expected = vendorRiskAssessment(rating(vendor)).level;
       if (body.risk_level !== expected) wrong.push(`${vendor}: endpoint ${body.risk_level}, risk scale ${expected}`);
     }
     assert.deepStrictEqual(wrong, [], "the vendor risk endpoint disagrees with the risk scale");

--- a/test/stack-page-verdicts.test.ts
+++ b/test/stack-page-verdicts.test.ts
@@ -19,6 +19,7 @@ import {
   verdictsPublishedOn,
   type PublishedPick,
 } from "../dist/stack-claim.js";
+import { toSlug } from "../dist/vendor-slug.js";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const REPO = path.join(__dirname, "..");
@@ -91,6 +92,28 @@ async function offerRecord(slug: string): Promise<StoredOffer | null> {
   const offer = res.status === 200 ? ((await res.json()) as { offer?: StoredOffer }).offer ?? null : null;
   records.set(slug, offer);
   return offer;
+}
+
+function costCaveatsOn(html: string): string[] {
+  return [...html.matchAll(/<div class="cost-caveat"[^>]*>([\s\S]*?)<\/div>/g)].map(found =>
+    found[1]
+      .replace(/&quot;/g, '"')
+      .replace(/&#39;/g, "'")
+      .replace(/&lt;/g, "<")
+      .replace(/&gt;/g, ">")
+      .replace(/&amp;/g, "&")
+      .trim(),
+  );
+}
+
+function picksExcludedIn(caveats: readonly string[]): Set<string> {
+  const excluded = new Set<string>();
+  for (const caveat of caveats) {
+    const tail = caveat.split("It does not cover ")[1];
+    if (tail === undefined) continue;
+    for (const named of tail.matchAll(/([^,(]+)\(/g)) excluded.add(toSlug(named[1].trim()));
+  }
+  return excluded;
 }
 
 const pages = new Map<string, string>();
@@ -250,10 +273,18 @@ describe("stack pages do not out-claim the badge", () => {
       const inTheStack = verdictsPublishedOn(html, { ratingTheStackOnly: true });
       assert.ok(inTheStack.length > 0, `${route} totals $0 and publishes no verdict for anything in the stack`);
       priced.push(route);
-      const weak = inTheStack.filter(({ verdict }) => verdictConfidence(verdict) !== 3).map(({ slug }) => slug);
-      if (weak.length > 0 && !html.includes("class=\"cost-caveat\"")) unqualified.push(`${route}: ${[...new Set(weak)].join(", ")}`);
+      const caveats = costCaveatsOn(html);
+      if (caveats.length === 0) {
+        unqualified.push(`${route}: a $0 headline that states nothing about what it covers`);
+        continue;
+      }
+      const excluded = picksExcludedIn(caveats);
+      for (const { slug, verdict } of inTheStack) {
+        if (verdictConfidence(verdict) === 3 || excluded.has(slug)) continue;
+        unqualified.push(`${route}: ${slug} reads "${verdict}" and the $0 does not exclude it`);
+      }
     }
-    assert.deepStrictEqual(unqualified, [], `unqualified $0 headlines:\n${unqualified.join("\n")}`);
+    assert.deepStrictEqual([...new Set(unqualified)], [], `unqualified $0 headlines:\n${unqualified.join("\n")}`);
     assert.ok(priced.length > 0, "no stack page totals $0, so nothing above was checked");
   });
 });
@@ -397,8 +428,22 @@ describe("the $0 caveat", () => {
     );
   });
 
-  it("says nothing when every pick reads active", () => {
-    assert.strictEqual(costHeadlineCaveat([{ vendor: "Neon", verdict: "active", readsActive: true }]), "");
+  it("still says what the headline rests on when every pick reads active", () => {
+    assert.strictEqual(
+      costHeadlineCaveat([{ vendor: "Neon", verdict: "active", readsActive: true }]),
+      "$0 covers all 1 pick: our own badge reads every one of their free tiers as active.",
+    );
+    assert.strictEqual(
+      costHeadlineCaveat([
+        { vendor: "Neon", verdict: "active", readsActive: true },
+        { vendor: "Railway", verdict: "active", readsActive: true },
+      ]),
+      "$0 covers all 2 picks: our own badge reads every one of their free tiers as active.",
+    );
+  });
+
+  it("qualifies nothing where there is no pick to qualify", () => {
+    assert.strictEqual(costHeadlineCaveat([]), "");
   });
 });
 

--- a/test/stack-page-verdicts.test.ts
+++ b/test/stack-page-verdicts.test.ts
@@ -243,16 +243,18 @@ describe("stack pages do not out-claim the badge", () => {
 
   it("qualifies a $0 headline it cannot stand behind", async () => {
     const unqualified: string[] = [];
+    const priced: string[] = [];
     for (const route of STACK_PAGES) {
       const html = pages.get(route)!;
       if (!/\$0<span[^>]*>\/month|tier-amount cost-free">\$0\/mo|Total: <strong>\$0\/month/.test(html)) continue;
-      const weak: string[] = [];
-      for (const { slug, verdict } of verdictsPublishedOn(html)) {
-        if (verdictConfidence(verdict) !== 3) weak.push(slug);
-      }
+      const inTheStack = verdictsPublishedOn(html, { ratingTheStackOnly: true });
+      assert.ok(inTheStack.length > 0, `${route} totals $0 and publishes no verdict for anything in the stack`);
+      priced.push(route);
+      const weak = inTheStack.filter(({ verdict }) => verdictConfidence(verdict) !== 3).map(({ slug }) => slug);
       if (weak.length > 0 && !html.includes("class=\"cost-caveat\"")) unqualified.push(`${route}: ${[...new Set(weak)].join(", ")}`);
     }
     assert.deepStrictEqual(unqualified, [], `unqualified $0 headlines:\n${unqualified.join("\n")}`);
+    assert.ok(priced.length > 0, "no stack page totals $0, so nothing above was checked");
   });
 });
 
@@ -308,6 +310,21 @@ describe("the verdict comparison itself", () => {
     assert.deepStrictEqual(verdictsPublishedOn(html), [
       { slug: "vercel", verdict: "active" },
       { slug: "railway", verdict: "at risk" },
+    ]);
+  });
+
+  it("leaves out a verdict that rates an alternative when asked for the stack only", () => {
+    const html =
+      `<td><a href="/vendor/railway">Railway</a> <span class="stack-verdict">active</span></td>` +
+      `<a href="/vendor/render" class="alt-chip">Render <span class="stack-verdict stack-verdict-alt">at risk</span></a>` +
+      `<div class="swap-card"><a href="/vendor/grafana-cloud">Grafana Cloud</a> <span class="stack-verdict stack-verdict-alt">at risk</span></div>`;
+    assert.deepStrictEqual(verdictsPublishedOn(html), [
+      { slug: "railway", verdict: "active" },
+      { slug: "render", verdict: "at risk" },
+      { slug: "grafana-cloud", verdict: "at risk" },
+    ]);
+    assert.deepStrictEqual(verdictsPublishedOn(html, { ratingTheStackOnly: true }), [
+      { slug: "railway", verdict: "active" },
     ]);
   });
 

--- a/test/superseded-terms-listings.test.ts
+++ b/test/superseded-terms-listings.test.ts
@@ -14,7 +14,7 @@ const {
 } = await import("../dist/superseded-description.js");
 const { toSlug } = await import("../dist/slug.js");
 const { citedRecords } = await import("../dist/provenance.js");
-const { getOfferDetails } = await import("../dist/data.js");
+const { getOfferDetails, loadDealChanges } = await import("../dist/data.js");
 
 type Offer = import("../src/types.ts").Offer;
 type DealChange = import("../src/types.ts").DealChange;
@@ -23,9 +23,7 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const REPO = path.join(__dirname, "..");
 
 const offers: Offer[] = JSON.parse(readFileSync(path.join(REPO, "data", "index.json"), "utf-8")).offers;
-const changes: DealChange[] = JSON.parse(
-  readFileSync(path.join(REPO, "data", "deal_changes.json"), "utf-8"),
-).changes;
+const changes: DealChange[] = loadDealChanges();
 
 const byVendor = new Map<string, DealChange[]>();
 for (const change of changes) {
@@ -162,7 +160,7 @@ describe("#1395 the listing surfaces answer the stored-terms question the way th
   after(() => { server?.proc.kill(); });
 
   it("has records on both sides of the question, so neither direction below is vacuous", () => {
-    assertPopulationFloor(superseded.length, 101, "records carry superseded stored terms");
+    assertPopulationFloor(superseded.length, 75, "records carry superseded stored terms");
     assertPopulationFloor(notSuperseded.length, 1001, "records carry current stored terms");
     assert.strictEqual(
       pages.size,

--- a/test/superseded-terms.test.ts
+++ b/test/superseded-terms.test.ts
@@ -26,6 +26,7 @@ const { toSlug } = await import("../dist/slug.js");
 const { qualityBudget } = await import("../dist/page-reviews.js");
 const { supersededCensus } = await import("../dist/superseded-census.js");
 const { utcDate } = await import("../dist/ranking.js");
+const { loadDealChanges } = await import("../dist/data.js");
 const { tierRecordsAFreeTier } = await import("../dist/free-tier-record.js");
 const {
   describesOnlyATrial,
@@ -42,9 +43,7 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const REPO = path.join(__dirname, "..");
 
 const offers: Offer[] = JSON.parse(readFileSync(path.join(REPO, "data", "index.json"), "utf-8")).offers;
-const changes: DealChange[] = JSON.parse(
-  readFileSync(path.join(REPO, "data", "deal_changes.json"), "utf-8"),
-).changes;
+const changes: DealChange[] = loadDealChanges();
 
 const A_RUN_MAY_RAISE_IT =
   "The daily re-verification run raises this by reading pages, and lowers it by correcting a " +
@@ -1084,7 +1083,7 @@ describe("#1103 every catalogue record whose stored terms are superseded", () =>
   });
 
   it("finds readings that name one, so the assertion above has subjects", () => {
-    assert.ok(readingNamesAFreePlanLaterOn().length >= 4, `${readingNamesAFreePlanLaterOn().length} readings name a free plan the opening would miss`);
+    assert.ok(readingNamesAFreePlanLaterOn().length > 0, `${readingNamesAFreePlanLaterOn().length} readings name a free plan the opening would miss`);
   });
 
   it("leaves the opening alone wherever it already says something is free", () => {

--- a/test/tier-scoped-verdicts.test.ts
+++ b/test/tier-scoped-verdicts.test.ts
@@ -14,7 +14,7 @@ const {
 const { namesTheVendorsHostedEdition } = await import("../dist/superseding-reading.js");
 const { tierRecordsASelfHostedEdition } = await import("../dist/free-tier-record.js");
 const { supersedingChange } = await import("../dist/superseded-description.js");
-const { changesGradingTheListedTier, publishedRisk } = await import("../dist/data.js");
+const { changesRatingTheListedTier, publishedRisk } = await import("../dist/data.js");
 const { narrowingSentence } = await import("../dist/vendor-verdict.js");
 
 type Offer = import("../src/types.ts").Offer;
@@ -186,7 +186,7 @@ describe("#1526 the withholding and the rating read the same record the same way
 
   it("rates the self-hosted edition off the same record the withholding refused", () => {
     assert.deepStrictEqual(
-      changesGradingTheListedTier(A_SELF_HOSTED_OFFER, [A_READING_OF_THE_HOSTED_PRODUCT as DealChange]),
+      changesRatingTheListedTier(A_SELF_HOSTED_OFFER, [A_READING_OF_THE_HOSTED_PRODUCT as DealChange]),
       [],
     );
     const held = publishedRisk(

--- a/test/uncited-change-records.test.ts
+++ b/test/uncited-change-records.test.ts
@@ -11,6 +11,7 @@ import {
 } from "../dist/change-citation.js";
 import { uncitedChangesAgainstBudget } from "../dist/change-reporting.js";
 import {
+  changesRatingTheListedTier,
   classifyStability,
   demotionForChange,
   demotionInForce,
@@ -143,6 +144,12 @@ describe("the shipped catalogue", () => {
   const changes = loadDealChanges();
   const enriched = enrichOffers(loadOffers());
 
+  const recordsRating = (offer: { vendor: string; tier: string }) =>
+    changesRatingTheListedTier(
+      offer,
+      changes.filter(c => c.vendor.toLowerCase() === offer.vendor.toLowerCase()),
+    );
+
   const recordBehind = (vendor: string, cause: { date: string; change_type: string; summary: string }) =>
     changes.find(c =>
       c.vendor.toLowerCase() === vendor.toLowerCase()
@@ -162,10 +169,7 @@ describe("the shipped catalogue", () => {
   it("publishes no risk level a record citing no source would have set", () => {
     const rated = enriched
       .filter(o => o.risk_level !== null && o.risk_level !== "stable")
-      .filter((o) => {
-        const vendorChanges = changes.filter(c => c.vendor.toLowerCase() === o.vendor.toLowerCase());
-        return vendorChanges.filter(changeCitesASource).every(c => demotionInForce(c) === null);
-      })
+      .filter((o) => recordsRating(o).filter(changeCitesASource).every(c => demotionInForce(c) === null))
       .map(o => `${o.vendor}: ${o.risk_level}`);
     assert.deepStrictEqual(rated, [], "a non-stable level rests on no record that cites a source");
   });
@@ -188,9 +192,9 @@ describe("the shipped catalogue", () => {
     const expected = [...new Set(
       loadOffers()
         .filter((offer) => {
-          const vendorChanges = changes.filter(c => c.vendor.toLowerCase() === offer.vendor.toLowerCase());
-          return vendorChanges.some(c => demotionWithheldInForce(c) !== null)
-            && vendorChanges.every(c => demotionInForce(c) === null);
+          const rating = recordsRating(offer);
+          return rating.some(c => demotionWithheldInForce(c) !== null)
+            && rating.every(c => demotionInForce(c) === null);
         })
         .map(o => o.vendor),
     )].sort();
@@ -203,8 +207,7 @@ describe("the shipped catalogue", () => {
 
   it("counts the withheld records for the vendor whose rating is withheld", () => {
     for (const offer of enriched.filter(o => o.rating_withheld !== null)) {
-      const vendorChanges = changes.filter(c => c.vendor.toLowerCase() === offer.vendor.toLowerCase());
-      const expected = vendorChanges.filter(c => demotionWithheldInForce(c) !== null).length;
+      const expected = recordsRating(offer).filter(c => demotionWithheldInForce(c) !== null).length;
       assert.strictEqual(offer.rating_withheld!.records, expected, offer.vendor);
       assert.ok(expected > 0, `${offer.vendor} withholds a rating on no record`);
     }


### PR DESCRIPTION
A change record's `change_type` is a label the reader picked. `previous_state` and `current_state` are the two sets of terms it picked it from. Nothing compared them, so `/vendor/buildkite` published *"requires caution … The free plan now offers 2,000 Linux vCPU minutes/month and 250k test executions, up from 500 minutes and 50k"* and withheld Buildkite's stored terms underneath it.

A record can now carry `tier_direction` — `narrowed`, `unchanged` or `widened` — a judgement about the tier the offer lists, made with both sets of terms in hand. Where it says the tier did not get worse and the label says it did, the verdict is dropped: no withholding, no risk level, no risk cause, no stability class. The record, its reading, its source and its date stay on the page.

`readingDescribesNoNarrowing()` in `src/change-direction.ts` is the whole rule. `changeRatesTheListedTier()` composes it with #1527's tier rule, and the three places that ask whether a record may rate an offer — the withholding, `publishedRisk` and the vendor verdict's narrowing list — all call it. Absence of the field falls back to today's behaviour exactly.

**Two sources, one field.** Going forward the detector states it: `scripts/verify-freshness.js` asks for it in the same response that already carries `tier`, and `buildChangeEntry` stores it when it is one of the three words. For the 596 records already written, `data/change_directions.json` records the census's reading of 45 of them, each with the record it names and the finding behind the judgement, and `loadDealChanges()` applies it. A record that states its own direction is never overridden by the review, and a test refuses any review entry naming a record recorded after the review date — the file is a backlog, not a list to keep.

**Replay over the whole catalogue** (`scripts/census-1528-change-direction.mjs`, 1,547 offers, 596 records):

| | before | after |
|---|---|---|
| withholding their stored terms | 176 | 131 |
| rated caution or risky | 212 | 171 |
| offers whose published row moves | | 46 |

46 rows, 45 records, every one a vendor the census named. `/vendor/buildkite`, `/vendor/promoproxy`, `/vendor/vercel`, `/vendor/railway` and `/vendor/figma` publish their stored terms and carry no caution; `/vendor/netlify` still withholds and still cautions.

Four of the 46 move from `caution` to no published level rather than to `stable` — imgix, OneSignal, xAI and Zoho Docs — because with this cause gone another withholding reason applies to them. Two keep a cause, moved to a different record of their own: Replit and UniRateAPI.

**The 27 records that discover a limit: 0 of 27 move.** The rule does not reach them, in either direction.

**The rule only withdraws an adverse verdict.** `narrowsTheStoredTerms(change_type)` guards it, so a `limits_increased` record contradicted by its own reading still counts exactly as it did. Widening that would move counters on surfaces this issue does not name, and no reviewed record has a positive type.

Refs #1528

**Seven tests held a second copy of the rule** and were restated on what production now does rather than on what it used to. Three of them — `eligibility-disclosure`, `gated-vendor-answers`, `compiled-comparison-figures` — read `data/deal_changes.json` from disk, so they never saw the review; they load through `loadDealChanges()` now. `one-published-risk` and `one-verdict-engine` built their expected level from every record a vendor holds rather than from the ones that rate the listed tier, which had already diverged at #1527 and only showed here. `alternative-to-record-claims` filtered on the tier rule alone. Two non-vacuity floors that pinned a moment — 101 ungated pages withholding, 6 ended subjects — assert non-emptiness instead, because both classes are ones this work shrinks.

`/stacks/api-first` and `/stacks/side-project` stop rendering anything from the change log, so `data/page-reviews.json` records `reads_changes: false` for them. That register is measured, not asserted.
