### PR TITLE
Link the AI and LLM free-tier index from the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,9 +5,11 @@
 
 An MCP server that aggregates free tiers, startup credits, and developer tool deals — so your AI agent (or you) can find the best infrastructure offers without leaving the workflow.
 
-AgentDeals indexes real, verified pricing data from 1,500+ developer infrastructure vendors across 54 categories. Available on [npm](https://www.npmjs.com/package/agentdeals) for local use or as a hosted remote server. Connect any MCP-compatible client and search deals by keyword, category, or eligibility.
+AgentDeals indexes real, verified pricing data from 1,500+ developer infrastructure vendors across 60 categories. Available on [npm](https://www.npmjs.com/package/agentdeals) for local use or as a hosted remote server. Connect any MCP-compatible client and search deals by keyword, category, or eligibility.
 
 **Live:** [agentdeals.dev](https://agentdeals.dev)
+
+**Free tiers for AI and LLM APIs:** [a dated, sourced list of 31 vendors](artifacts/free-llm-api-index/README.md), regenerated from the catalogue whenever a record moves. Every row carries the date we last read that vendor's own page and the URL we read it on, and the rows whose terms changed carry the terms they replaced.
 
 ## Install
 


### PR DESCRIPTION
`artifacts/free-llm-api-index/README.md` has been generated and committed on `main` since 2026-09-09, regenerated on every push, and nothing in the repository points at it. It is a public, dated, sourced list of 31 vendors and it is reachable today only by someone who already knows the path.

This is not the publication https://github.com/robhunter/agentdeals/issues/1497 asks for — that needs the standalone repository, which is blocked on repository variables I cannot set. It is the part that needs nobody's permission.

Also corrects the opening paragraph's category count: 60, not 54, after the consumer-app removal in #1410 took the catalogue from 65 categories to 60.