### PR TITLE
Judge the Thunder Client record's direction from its own two states

### DIFF
--- a/data/change_directions.json
+++ b/data/change_directions.json
@@ -1,5 +1,5 @@
 {
-  "reviewed": "2026-09-10",
+  "reviewed": "2026-09-11",
   "review": "docs/change-direction-census.md",
   "directions": [
     {
@@ -353,6 +353,14 @@
       "source_url": "https://terrateam.io",
       "tier_direction": "unchanged",
       "finding": "the entire summary is \"Doesn't confirm the original unlimited usage claim.\""
+    },
+    {
+      "vendor": "Thunder Client",
+      "change_type": "limits_reduced",
+      "date": "2026-09-10",
+      "source_url": "https://www.thunderclient.com/pricing",
+      "tier_direction": "widened",
+      "finding": "our terms say \"1 local collection run per month\"; the reading says the free plan \"now includes unlimited collection runs\" and that the 1/month limit \"is removed\""
     },
     {
       "vendor": "UniRateAPI",


### PR DESCRIPTION
`/vendor/thunder-client` reads *"requires caution because of one specific recorded change, discovered 2026-09-10: The free plan now includes unlimited collection runs, and previously 1 local collection run per month is removed"* and withholds the stored terms underneath it.

This is the #1528 defect on a record #1532 cannot reach. It was written 2026-09-10 — after the review file was built from the census, before the fix merged — so the one-time backfill does not hold it and the detector only judges records it writes itself.

Our stored terms say `1 local collection run per month`. The reading says that limit is removed. `widened`.

Data only. `node --test test/change-*.test.ts test/superseded-*.test.ts` — 701 of 701.

Netlify and Authress are the same window and I am **not** claiming them here: each reading restates the figure it covers and is silent on other stored claims, which is the class where withholding is right and the caution is not. Raised separately.