### PR TITLE
Answer a conditional request, and date the vendor, category and home pages

### DIFF
--- a/data/page-lastmod.json
+++ b/data/page-lastmod.json
@@ -2,6 +2,10 @@
   "version": 1,
   "generated": "2026-09-11",
   "pages": {
+    "/": {
+      "hash": "77e79ad498fcce1b",
+      "changed": "2026-09-11"
+    },
     "/agent-payments": {
       "hash": "7928b54e81d481b9",
       "changed": "2026-09-11"

--- a/scripts/mutate-1347.sh
+++ b/scripts/mutate-1347.sh
@@ -37,8 +37,18 @@ PY
 T="test/conditional-request.test.ts test/page-lastmod.test.ts test/not-found-accounting.test.ts test/vendor-series.test.ts"
 
 run_mutation "the handler ignores the conditional request" src/serve.ts \
-    'if (status === 200 && isNotModified(revalidation, res.getHeader("Last-Modified") as string | undefined)) {' \
-    'if (false && isNotModified(revalidation, res.getHeader("Last-Modified") as string | undefined)) {' "$T"
+    'if (status === 200 && isNotModified(revalidation, revalidationDayHeader(url.pathname, url.search))) {' \
+    'if (false && isNotModified(revalidation, revalidationDayHeader(url.pathname, url.search))) {' "$T"
+
+run_mutation "a day taken from a record validates a revalidation too" src/serve.ts \
+    'function revalidationDayHeader(pathname: string, search: string): string | null {
+  const dated = datedUrl(pathname, search);
+  if (!dated) return null;
+  const day = renderedBodyDay(dated);' \
+    'function revalidationDayHeader(pathname: string, search: string): string | null {
+  const dated = datedUrl(pathname, search);
+  if (!dated) return null;
+  const day = sitemapDayFor(dated);' "$T"
 
 run_mutation "a copy taken on the page's own day is treated as out of date" src/conditional-request.ts \
     'return served <= asked;' \

--- a/scripts/mutate-1347.sh
+++ b/scripts/mutate-1347.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+set -u
+WT="${1:-$(cd "$(dirname "$0")/.." && pwd)}"
+cd "$WT" || exit 1
+
+run_mutation() {
+  local name="$1" file="$2" from="$3" to="$4" tests="$5"
+  cp "$file" /tmp/mut-orig.$$ || return 1
+  if ! python3 - "$file" "$from" "$to" <<'PY'
+import sys, pathlib
+path, frm, to = sys.argv[1], sys.argv[2], sys.argv[3]
+p = pathlib.Path(path)
+s = p.read_text()
+if frm not in s:
+    print("PATTERN NOT FOUND", file=sys.stderr); sys.exit(2)
+p.write_text(s.replace(frm, to, 1))
+PY
+  then
+    echo "BROKEN MUTATION: $name"
+    cp /tmp/mut-orig.$$ "$file"
+    return 1
+  fi
+  if ! npm run build >/dev/null 2>&1; then
+    echo "COMPILE-KILLED: $name"
+    cp /tmp/mut-orig.$$ "$file"; npm run build >/dev/null 2>&1
+    return 0
+  fi
+  if node --test --test-concurrency 1 $tests >/tmp/mut-out.$$ 2>&1; then
+    echo "SURVIVED: $name"
+  else
+    echo "KILLED: $name"
+  fi
+  cp /tmp/mut-orig.$$ "$file"
+  npm run build >/dev/null 2>&1
+}
+
+T="test/conditional-request.test.ts test/page-lastmod.test.ts test/not-found-accounting.test.ts test/vendor-series.test.ts"
+
+run_mutation "the handler ignores the conditional request" src/serve.ts \
+    'if (status === 200 && isNotModified(revalidation, res.getHeader("Last-Modified") as string | undefined)) {' \
+    'if (false && isNotModified(revalidation, res.getHeader("Last-Modified") as string | undefined)) {' "$T"
+
+run_mutation "a copy taken on the page's own day is treated as out of date" src/conditional-request.ts \
+    'return served <= asked;' \
+    'return served < asked;' "$T"
+
+run_mutation "every revalidation is answered not-modified" src/conditional-request.ts \
+    'return served <= asked;' \
+    'return true;' "$T"
+
+run_mutation "a request naming no date revalidates anyway" src/conditional-request.ts \
+    'return parseHttpDate(request.ifModifiedSince) !== null;' \
+    'return true;' "$T"
+
+run_mutation "a write method revalidates too" src/conditional-request.ts \
+    'if (request.method !== "GET" && request.method !== "HEAD") return false;' \
+    'if (request.method === "TRACE") return false;' "$T"
+
+run_mutation "an entity tag no longer defers the decision" src/conditional-request.ts \
+    'if (request.ifNoneMatch !== undefined) return false;' \
+    'if (request.ifNoneMatch === "never") return false;' "$T"
+
+run_mutation "any date-shaped string is read as an HTTP date" src/conditional-request.ts \
+    '  if (IMF_FIXDATE.test(trimmed)) {
+    const at = Date.parse(trimmed);
+    return Number.isNaN(at) ? null : at;
+  }' \
+    '  const parsed = Date.parse(trimmed);
+  if (!Number.isNaN(parsed)) return parsed;' "$T"
+
+run_mutation "an asctime date is read in the zone the server happens to run in" src/conditional-request.ts \
+    '  const at = Date.UTC(Number(year), MONTHS.indexOf(month!), Number(day), Number(hour), Number(minute), Number(second));
+  return Number.isNaN(at) ? null : at;' \
+    '  const at = new Date(Number(year), MONTHS.indexOf(month!), Number(day), Number(hour), Number(minute), Number(second)).getTime();
+  return Number.isNaN(at) ? null : at;' "$T"
+
+run_mutation "a query string is dated as if it were the page" src/conditional-request.ts \
+    '  if (search) return null;' \
+    '  if (search === "?never") return null;' "$T"
+
+run_mutation "the not-modified response describes a body it does not send" src/conditional-request.ts \
+    'if (/^content-(type|length)$/i.test(name)) continue;' \
+    'if (/^content-(length)$/i.test(name)) continue;' "$T"
+
+run_mutation "a vendor page is dated from no sitemap entry at all" src/serve.ts \
+    '  if (pagePath.startsWith("/vendor/")) {
+    const slug = pagePath.slice("/vendor/".length);
+    return vendorSlugMap.has(slug) ? vendorPageDay(slug, utcToday()) : null;
+  }' \
+    '  if (pagePath.startsWith("/vendor/")) {
+    return null;
+  }' "$T"
+
+run_mutation "a category page is dated from no sitemap entry at all" src/serve.ts \
+    '  if (pagePath.startsWith("/category/")) {
+    const slug = pagePath.slice("/category/".length);
+    return categorySlugMap.has(slug) ? categoryPageDay(slug, utcToday()) : null;
+  }' \
+    '  if (pagePath.startsWith("/category/")) {
+    return null;
+  }' "$T"
+
+run_mutation "a vendor page takes the day the build shipped instead of its own" src/serve.ts \
+    'return vendorSlugMap.has(slug) ? vendorPageDay(slug, utcToday()) : null;' \
+    'return vendorSlugMap.has(slug) ? UNREAD_PAGE_DAY : null;' "$T"
+
+run_mutation "the homepage is dated from the newest record rather than its own body" src/serve.ts \
+    "+ '  <url>\\n    <loc>' + BASE_URL + '/</loc>\\n    <lastmod>' + pageLastmod(\"/\") + '</lastmod>" \
+    "+ '  <url>\\n    <loc>' + BASE_URL + '/</loc>\\n    <lastmod>' + latestVerified + '</lastmod>" "$T"
+
+run_mutation "the homepage tells no cache how long to hold it" src/serve.ts \
+    'res.writeHead(200, { "Content-Type": "text/html; charset=utf-8", "Cache-Control": "public, max-age=3600" });
+    res.end(landingPageHtml);' \
+    'res.writeHead(200, { "Content-Type": "text/html; charset=utf-8" });
+    res.end(landingPageHtml);' "$T"
+
+run_mutation "a page answered as unchanged is counted as a redirect elsewhere" src/stats.ts \
+    '  if (statusCode === NOT_MODIFIED) return "served";' \
+    '  if (statusCode === 999) return "served";' "$T"
+
+run_mutation "a vendor's series drops the clients that revalidated" src/vendor-series.ts \
+    'if (requestOutcome(input.status) !== "served") return;' \
+    'if (!(input.status >= 200 && input.status < 300)) return;' "$T"

--- a/src/conditional-request.ts
+++ b/src/conditional-request.ts
@@ -1,0 +1,55 @@
+const MONTHS = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"];
+
+const IMF_FIXDATE = /^(?:Mon|Tue|Wed|Thu|Fri|Sat|Sun), \d{2} (?:Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec) \d{4} \d{2}:\d{2}:\d{2} GMT$/;
+const ASCTIME = /^(?:Mon|Tue|Wed|Thu|Fri|Sat|Sun) (Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec) ([ \d]\d) (\d{2}):(\d{2}):(\d{2}) (\d{4})$/;
+
+export type HeaderValue = string | string[] | undefined;
+
+export interface ConditionalRequest {
+  method?: string;
+  ifModifiedSince?: HeaderValue;
+  ifNoneMatch?: HeaderValue;
+}
+
+export function parseHttpDate(value: HeaderValue): number | null {
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  if (IMF_FIXDATE.test(trimmed)) {
+    const at = Date.parse(trimmed);
+    return Number.isNaN(at) ? null : at;
+  }
+  const asctime = ASCTIME.exec(trimmed);
+  if (!asctime) return null;
+  const [, month, day, hour, minute, second, year] = asctime;
+  const at = Date.UTC(Number(year), MONTHS.indexOf(month!), Number(day), Number(hour), Number(minute), Number(second));
+  return Number.isNaN(at) ? null : at;
+}
+
+export function isRevalidation(request: ConditionalRequest): boolean {
+  if (request.method !== "GET" && request.method !== "HEAD") return false;
+  if (request.ifNoneMatch !== undefined) return false;
+  return parseHttpDate(request.ifModifiedSince) !== null;
+}
+
+export function isNotModified(request: ConditionalRequest, lastModified: HeaderValue): boolean {
+  if (!isRevalidation(request)) return false;
+  const asked = parseHttpDate(request.ifModifiedSince);
+  const served = parseHttpDate(lastModified);
+  if (asked === null || served === null) return false;
+  return served <= asked;
+}
+
+export function revalidationHeaders(headers: Record<string, string> | undefined): Record<string, string> {
+  const kept: Record<string, string> = {};
+  for (const [name, value] of Object.entries(headers ?? {})) {
+    if (/^content-(type|length)$/i.test(name)) continue;
+    kept[name] = value;
+  }
+  return kept;
+}
+
+export function datedUrl(pathname: string, search: string): string | null {
+  if (search) return null;
+  if (pathname === "/") return pathname;
+  return pathname.replace(/\/$/, "") || "/";
+}

--- a/src/conditional-request.ts
+++ b/src/conditional-request.ts
@@ -3,7 +3,7 @@ const MONTHS = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "
 const IMF_FIXDATE = /^(?:Mon|Tue|Wed|Thu|Fri|Sat|Sun), \d{2} (?:Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec) \d{4} \d{2}:\d{2}:\d{2} GMT$/;
 const ASCTIME = /^(?:Mon|Tue|Wed|Thu|Fri|Sat|Sun) (Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec) ([ \d]\d) (\d{2}):(\d{2}):(\d{2}) (\d{4})$/;
 
-export type HeaderValue = string | string[] | undefined;
+export type HeaderValue = string | string[] | null | undefined;
 
 export interface ConditionalRequest {
   method?: string;

--- a/src/serve.ts
+++ b/src/serve.ts
@@ -85,6 +85,7 @@ import { changeDateLabel, changeEntryDateLabel, changeEntryLongDateLabel, change
 import { changeFeedEntries, feedEntryFields, feedUpdatedTimestamp, changeFeedProvenanceNote, CHANGE_FEED_ENTRY_LIMIT, CHANGE_FEED_DESCRIPTION, CHANGE_FEED_NAMESPACE, CHANGE_FEED_NAMESPACE_PREFIX, channelUpdatedTimestamp, WEEKLY_FEED_POPULATION_NOTE, feedLinkTag, feedEntrySourceXml, digestSourceXml, PER_CHANGE_FEED, WEEKLY_DIGEST_FEED } from "./change-feed.js";
 import { FEED_CORRECTIONS, correctionEntriesXml } from "./feed-corrections.js";
 import { buildDay, emptyPageLastmod, fallbackDay, httpDate, lastmodFor, newestLastmod, readPageLastmod, type PageLastmodLedger } from "./page-lastmod.js";
+import { datedUrl, isNotModified, revalidationHeaders } from "./conditional-request.js";
 import type { AgentBalance } from "./ledger.js";
 import type { SubmittedReferralCode } from "./referral-codes.js";
 
@@ -142,9 +143,33 @@ function pageLastmod(pagePath: string): string {
   return lastmodFor(pageLastmodLedger, pagePath, UNREAD_PAGE_DAY);
 }
 
-function pageLastmodHeader(pagePath: string): string | null {
+function vendorPageDay(slug: string, fallback: string): string {
+  return vendorLastmod.get(slug) || fallback;
+}
+
+function categoryPageDay(slug: string, fallback: string): string {
+  return categoryLastmod.get(slug) || fallback;
+}
+
+function sitemapDayFor(pagePath: string): string | null {
   const recorded = pageLastmodLedger.pages[pagePath];
-  return recorded ? httpDate(recorded.changed) : null;
+  if (recorded) return recorded.changed;
+  if (pagePath.startsWith("/vendor/")) {
+    const slug = pagePath.slice("/vendor/".length);
+    return vendorSlugMap.has(slug) ? vendorPageDay(slug, utcToday()) : null;
+  }
+  if (pagePath.startsWith("/category/")) {
+    const slug = pagePath.slice("/category/".length);
+    return categorySlugMap.has(slug) ? categoryPageDay(slug, utcToday()) : null;
+  }
+  return null;
+}
+
+function pageLastmodHeader(pathname: string, search: string): string | null {
+  const dated = datedUrl(pathname, search);
+  if (!dated) return null;
+  const day = sitemapDayFor(dated);
+  return day ? httpDate(day) : null;
 }
 
 const INDEXNOW_KEY = process.env.INDEXNOW_KEY ?? "";
@@ -53570,7 +53595,7 @@ function comparisonSitemapPaths(): string[] {
 }
 
 function pagesSitemapLedgerPaths(): string[] {
-  const paths = ["/api/docs", "/setup", "/privacy", "/disclosure", "/press", "/stacks"];
+  const paths = ["/", "/api/docs", "/setup", "/privacy", "/disclosure", "/press", "/stacks"];
   for (const t of STACK_TEMPLATES) paths.push("/stacks/" + t.slug);
   paths.push("/estimate", "/stack-check", "/compare-tool", "/budget-builder", "/developers", "/badges", "/embed", "/agent-stack", "/guides");
   for (const g of INTEGRATION_GUIDES) paths.push("/guides/" + g.slug);
@@ -53619,7 +53644,14 @@ const httpServer = createHttpServer(async (req, res) => {
     });
   }
 
+  const revalidation = {
+    method: req.method,
+    ifModifiedSince: req.headers["if-modified-since"],
+    ifNoneMatch: req.headers["if-none-match"],
+  };
+
   let servedContentType = "";
+  let answeredNotModified = false;
   const rawWriteHead = res.writeHead.bind(res);
   res.writeHead = ((status: number, ...rest: unknown[]) => {
     const headers = rest.find(a => a && typeof a === "object") as Record<string, string> | undefined;
@@ -53632,15 +53664,20 @@ const httpServer = createHttpServer(async (req, res) => {
         res.setHeader(SIGNAL_HEADER_NAME, signalHeaderValue(BASE_URL, slug));
       }
       if (/^text\/html/.test(servedContentType) && !res.hasHeader("Last-Modified")) {
-        const changed = pageLastmodHeader(url.pathname);
+        const changed = pageLastmodHeader(url.pathname, url.search);
         if (changed) res.setHeader("Last-Modified", changed);
       }
+    }
+    if (status === 200 && isNotModified(revalidation, res.getHeader("Last-Modified") as string | undefined)) {
+      answeredNotModified = true;
+      return rawWriteHead(304 as never, revalidationHeaders(headers) as never);
     }
     return rawWriteHead(status as never, ...(rest as never[]));
   }) as typeof res.writeHead;
 
   const rawEnd = res.end.bind(res);
   res.end = ((...args: unknown[]) => {
+    if (answeredNotModified) return rawEnd();
     if (typeof args[0] === "string" && /^text\/html/.test(servedContentType)) {
       args[0] = withLedeBeforeNav(withPageFreshness(args[0], url.pathname));
     }
@@ -54966,7 +55003,7 @@ ${catList}
       + '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">\n'
       + '  <url>\n    <loc>' + BASE_URL + '/vendor</loc>\n    <lastmod>' + latestVerified + '</lastmod>\n    <changefreq>weekly</changefreq>\n    <priority>0.8</priority>\n  </url>\n';
     for (const s of vendorSlugMap.keys()) {
-      const vLastmod = vendorLastmod.get(s) || now;
+      const vLastmod = vendorPageDay(s, now);
       xml += '  <url>\n    <loc>' + BASE_URL + '/vendor/' + s + '</loc>\n    <lastmod>' + vLastmod + '</lastmod>\n    <changefreq>weekly</changefreq>\n    <priority>0.6</priority>\n  </url>\n';
     }
     xml += '</urlset>';
@@ -54990,7 +55027,7 @@ ${catList}
     const latestVerified = offers.reduce((max, o) => o.verifiedDate > max ? o.verifiedDate : max, offers[0]?.verifiedDate || now);
     let xml = '<?xml version="1.0" encoding="UTF-8"?>\n'
       + '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">\n'
-      + '  <url>\n    <loc>' + BASE_URL + '/</loc>\n    <lastmod>' + latestVerified + '</lastmod>\n    <changefreq>daily</changefreq>\n    <priority>1.0</priority>\n  </url>\n'
+      + '  <url>\n    <loc>' + BASE_URL + '/</loc>\n    <lastmod>' + pageLastmod("/") + '</lastmod>\n    <changefreq>daily</changefreq>\n    <priority>1.0</priority>\n  </url>\n'
       + '  <url>\n    <loc>' + BASE_URL + '/feed.xml</loc>\n    <lastmod>' + latestVerified + '</lastmod>\n    <changefreq>daily</changefreq>\n    <priority>0.5</priority>\n  </url>\n'
       + '  <url>\n    <loc>' + BASE_URL + '/api/docs</loc>\n    <lastmod>' + pageLastmod("/api/docs") + '</lastmod>\n    <changefreq>weekly</changefreq>\n    <priority>0.7</priority>\n  </url>\n'
       + '  <url>\n    <loc>' + BASE_URL + '/setup</loc>\n    <lastmod>' + pageLastmod("/setup") + '</lastmod>\n    <changefreq>weekly</changefreq>\n    <priority>0.8</priority>\n  </url>\n'
@@ -55018,7 +55055,7 @@ ${catList}
       + '  <url>\n    <loc>' + BASE_URL + '/agent-stack</loc>\n    <lastmod>' + pageLastmod("/agent-stack") + '</lastmod>\n    <changefreq>weekly</changefreq>\n    <priority>0.9</priority>\n  </url>\n'
       + '  <url>\n    <loc>' + BASE_URL + '/category</loc>\n    <lastmod>' + latestVerified + '</lastmod>\n    <changefreq>weekly</changefreq>\n    <priority>0.8</priority>\n  </url>\n';
     for (const c of categories) {
-      const catLastmod = categoryLastmod.get(toSlug(c.name)) || now;
+      const catLastmod = categoryPageDay(toSlug(c.name), now);
       xml += '  <url>\n    <loc>' + BASE_URL + '/category/' + toSlug(c.name) + '</loc>\n    <lastmod>' + catLastmod + '</lastmod>\n    <changefreq>weekly</changefreq>\n    <priority>0.8</priority>\n  </url>\n';
     }
     xml += '  <url>\n    <loc>' + BASE_URL + '/best</loc>\n    <lastmod>' + latestVerified + '</lastmod>\n    <changefreq>weekly</changefreq>\n    <priority>0.8</priority>\n  </url>\n';
@@ -55086,7 +55123,7 @@ ${catList}
     res.end(xml);
   } else if (url.pathname === "/") {
     recordLandingPageView();
-    res.writeHead(200, { "Content-Type": "text/html; charset=utf-8" });
+    res.writeHead(200, { "Content-Type": "text/html; charset=utf-8", "Cache-Control": "public, max-age=3600" });
     res.end(landingPageHtml);
   } else if ((url.pathname === "/best" || url.pathname === "/best/") && isGetOrHead) {
     recordApiHit("/best");

--- a/src/serve.ts
+++ b/src/serve.ts
@@ -151,9 +151,13 @@ function categoryPageDay(slug: string, fallback: string): string {
   return categoryLastmod.get(slug) || fallback;
 }
 
+function renderedBodyDay(pagePath: string): string | null {
+  return pageLastmodLedger.pages[pagePath]?.changed ?? null;
+}
+
 function sitemapDayFor(pagePath: string): string | null {
-  const recorded = pageLastmodLedger.pages[pagePath];
-  if (recorded) return recorded.changed;
+  const read = renderedBodyDay(pagePath);
+  if (read) return read;
   if (pagePath.startsWith("/vendor/")) {
     const slug = pagePath.slice("/vendor/".length);
     return vendorSlugMap.has(slug) ? vendorPageDay(slug, utcToday()) : null;
@@ -169,6 +173,13 @@ function pageLastmodHeader(pathname: string, search: string): string | null {
   const dated = datedUrl(pathname, search);
   if (!dated) return null;
   const day = sitemapDayFor(dated);
+  return day ? httpDate(day) : null;
+}
+
+function revalidationDayHeader(pathname: string, search: string): string | null {
+  const dated = datedUrl(pathname, search);
+  if (!dated) return null;
+  const day = renderedBodyDay(dated);
   return day ? httpDate(day) : null;
 }
 
@@ -53668,7 +53679,7 @@ const httpServer = createHttpServer(async (req, res) => {
         if (changed) res.setHeader("Last-Modified", changed);
       }
     }
-    if (status === 200 && isNotModified(revalidation, res.getHeader("Last-Modified") as string | undefined)) {
+    if (status === 200 && isNotModified(revalidation, revalidationDayHeader(url.pathname, url.search))) {
       answeredNotModified = true;
       return rawWriteHead(304 as never, revalidationHeaders(headers) as never);
     }

--- a/src/stats.ts
+++ b/src/stats.ts
@@ -986,9 +986,12 @@ const DAY_TOTAL_KEY = "total";
 
 export type RequestOutcome = "served" | "redirect" | "not_found";
 
+export const NOT_MODIFIED = 304;
+
 export function requestOutcome(statusCode?: number): RequestOutcome {
   if (statusCode === undefined) return "served";
   if (statusCode >= 400) return "not_found";
+  if (statusCode === NOT_MODIFIED) return "served";
   if (statusCode >= 300) return "redirect";
   return "served";
 }

--- a/src/vendor-series.ts
+++ b/src/vendor-series.ts
@@ -1,4 +1,5 @@
 import { createHash, randomBytes, timingSafeEqual } from "node:crypto";
+import { requestOutcome } from "./stats.js";
 
 export const VENDOR_SERIES_PATH = "/api/analytics/vendors";
 export const MIN_EXPORT_TOKEN_LENGTH = 16;
@@ -159,7 +160,7 @@ export interface VendorRequest {
 
 export function recordVendorRequest(input: VendorRequest): void {
   if (input.client_class === "internal") return;
-  if (!(input.status >= 200 && input.status < 300)) return;
+  if (requestOutcome(input.status) !== "served") return;
 
   if (!recording || recording.date !== input.date) {
     if (recording && hasPendingVendorCounts()) carry({ date: recording.date, delta: recording.delta });

--- a/test/conditional-request.test.ts
+++ b/test/conditional-request.test.ts
@@ -1,0 +1,106 @@
+import { describe, it } from "node:test";
+import assert from "node:assert";
+import { datedUrl, isNotModified, isRevalidation, parseHttpDate, revalidationHeaders } from "../dist/conditional-request.js";
+
+const GET = { method: "GET" };
+
+describe("reading a conditional request", () => {
+  it("reads the date format every response of ours advertises", () => {
+    assert.equal(parseHttpDate("Thu, 10 Sep 2026 00:00:00 GMT"), Date.parse("2026-09-10T00:00:00Z"));
+    assert.equal(parseHttpDate("Sun, 06 Nov 1994 08:49:37 GMT"), Date.parse("1994-11-06T08:49:37Z"));
+  });
+
+  it("reads the obsolete asctime form a very old client may still send", () => {
+    assert.equal(parseHttpDate("Sun Nov  6 08:49:37 1994"), Date.parse("1994-11-06T08:49:37Z"));
+  });
+
+  it("refuses a value that is not an HTTP date, so the full body is served instead of a guess", () => {
+    for (const value of ["", "not-a-date", "2026-09-10", "2026", "99999", "Thu, 10 Sep 2026", "Thu, 10 Sep 2026 00:00:00"]) {
+      assert.equal(parseHttpDate(value), null, `${JSON.stringify(value)} was read as a date`);
+    }
+    assert.equal(parseHttpDate(undefined), null);
+    assert.equal(parseHttpDate(["Thu, 10 Sep 2026 00:00:00 GMT", "Thu, 10 Sep 2026 00:00:00 GMT"]), null);
+  });
+
+  it("treats a request carrying a readable date as a revalidation", () => {
+    assert.equal(isRevalidation({ ...GET, ifModifiedSince: "Thu, 10 Sep 2026 00:00:00 GMT" }), true);
+    assert.equal(isRevalidation({ method: "HEAD", ifModifiedSince: "Thu, 10 Sep 2026 00:00:00 GMT" }), true);
+  });
+
+  it("treats a request that names no readable date as no revalidation at all", () => {
+    assert.equal(isRevalidation(GET), false);
+    assert.equal(isRevalidation({ ...GET, ifModifiedSince: "" }), false);
+    assert.equal(isRevalidation({ ...GET, ifModifiedSince: "last Tuesday" }), false);
+  });
+
+  it("treats a method that is not a read as no revalidation at all", () => {
+    for (const method of ["POST", "PUT", "DELETE", "OPTIONS", undefined]) {
+      assert.equal(isRevalidation({ method, ifModifiedSince: "Thu, 10 Sep 2026 00:00:00 GMT" }), false, `${method} revalidated`);
+    }
+  });
+
+  it("stands aside when the request also carries an entity tag, which is the stronger validator", () => {
+    assert.equal(isRevalidation({ ...GET, ifModifiedSince: "Thu, 10 Sep 2026 00:00:00 GMT", ifNoneMatch: '"abc"' }), false);
+  });
+});
+
+describe("deciding whether a page has changed since the client last read it", () => {
+  const day = "Thu, 10 Sep 2026 00:00:00 GMT";
+
+  it("answers not-modified for the page's own day", () => {
+    assert.equal(isNotModified({ ...GET, ifModifiedSince: day }, day), true);
+  });
+
+  it("answers not-modified for any later day the client names", () => {
+    assert.equal(isNotModified({ ...GET, ifModifiedSince: "Fri, 11 Sep 2026 00:00:00 GMT" }, day), true);
+    assert.equal(isNotModified({ ...GET, ifModifiedSince: "Thu, 10 Sep 2026 00:00:01 GMT" }, day), true);
+  });
+
+  it("answers modified for an earlier day, by one second or by a year", () => {
+    assert.equal(isNotModified({ ...GET, ifModifiedSince: "Wed, 09 Sep 2026 23:59:59 GMT" }, day), false);
+    assert.equal(isNotModified({ ...GET, ifModifiedSince: "Tue, 10 Sep 2025 00:00:00 GMT" }, day), false);
+  });
+
+  it("answers modified when the page carries no day, however recent the one asked about", () => {
+    assert.equal(isNotModified({ ...GET, ifModifiedSince: "Fri, 11 Sep 2036 00:00:00 GMT" }, undefined), false);
+    assert.equal(isNotModified({ ...GET, ifModifiedSince: "Fri, 11 Sep 2036 00:00:00 GMT" }, "whenever"), false);
+  });
+
+  it("answers modified when nothing was asked", () => {
+    assert.equal(isNotModified(GET, day), false);
+  });
+});
+
+describe("the response that answers a revalidation", () => {
+  it("keeps the validators and the caching terms", () => {
+    const kept = revalidationHeaders({ "Cache-Control": "public, max-age=3600", "Access-Control-Allow-Origin": "*" });
+    assert.deepEqual(kept, { "Cache-Control": "public, max-age=3600", "Access-Control-Allow-Origin": "*" });
+  });
+
+  it("drops the description of a body it is not sending, however the header is cased", () => {
+    const kept = revalidationHeaders({
+      "Content-Type": "text/html; charset=utf-8",
+      "content-length": "1234",
+      "Cache-Control": "public, max-age=3600",
+    });
+    assert.deepEqual(kept, { "Cache-Control": "public, max-age=3600" });
+  });
+
+  it("survives a response that named no headers at all", () => {
+    assert.deepEqual(revalidationHeaders(undefined), {});
+  });
+});
+
+describe("the URL a recorded day belongs to", () => {
+  it("is the path, with or without a trailing slash", () => {
+    assert.equal(datedUrl("/privacy", ""), "/privacy");
+    assert.equal(datedUrl("/vendor/supabase/", ""), "/vendor/supabase");
+    assert.equal(datedUrl("/", ""), "/");
+  });
+
+  it("is no URL at all once a query string is attached, because that body was never dated", () => {
+    assert.equal(datedUrl("/privacy", "?utm_source=x"), null);
+    assert.equal(datedUrl("/estimate", "?stack=web"), null);
+    assert.equal(datedUrl("/", "?q=redis"), null);
+  });
+});

--- a/test/not-found-accounting.test.ts
+++ b/test/not-found-accounting.test.ts
@@ -144,11 +144,16 @@ describe("404s are not page views (#1029)", () => {
       assert.equal(requestOutcome(299), "served");
       assert.equal(requestOutcome(301), "redirect");
       assert.equal(requestOutcome(302), "redirect");
-      assert.equal(requestOutcome(304), "redirect");
+      assert.equal(requestOutcome(303), "redirect");
+      assert.equal(requestOutcome(307), "redirect");
       assert.equal(requestOutcome(404), "not_found");
       assert.equal(requestOutcome(410), "not_found");
       assert.equal(requestOutcome(500), "not_found");
       assert.equal(requestOutcome(undefined), "served");
+    });
+
+    it("counts a page we answered as unchanged among the pages we served, not among the redirects", () => {
+      assert.equal(requestOutcome(304), "served");
     });
   });
 

--- a/test/page-lastmod.test.ts
+++ b/test/page-lastmod.test.ts
@@ -245,6 +245,68 @@ describe("a page keeps the day it changed, whenever that was", () => {
       assert.ok(day! > FIXTURE.generated && day! <= today, `${loc} fell back to ${day}`);
     }
   });
+
+  it("answers a request that already holds the page's own day with 304 and no body", async () => {
+    const response = await fetch(`${fixtureBase}/privacy`, {
+      headers: { "If-Modified-Since": "Tue, 03 Feb 2026 00:00:00 GMT" },
+    });
+    const body = await response.text();
+    assert.equal(response.status, 304);
+    assert.equal(body, "");
+    assert.equal(response.headers.get("last-modified"), "Tue, 03 Feb 2026 00:00:00 GMT");
+    assert.equal(response.headers.get("content-type"), null);
+  });
+
+  it("answers a request holding a day older than the page's with the whole page", async () => {
+    const response = await fetch(`${fixtureBase}/privacy`, {
+      headers: { "If-Modified-Since": "Mon, 02 Feb 2026 00:00:00 GMT" },
+    });
+    const body = await response.text();
+    assert.equal(response.status, 200);
+    assert.ok(body.includes("</html>"), "the body was withheld from a client whose copy is older than the page");
+  });
+
+  it("sends the whole page to a client whose copy is newer than the day it holds, once that page moves", async () => {
+    const stale = await fetch(`${fixtureBase}/compare/netlify-vs-vercel`, {
+      headers: { "If-Modified-Since": "Tue, 18 Aug 2026 00:00:00 GMT" },
+    });
+    await stale.text();
+    assert.equal(stale.status, 200, "a copy taken the day before the page moved is out of date");
+    const current = await fetch(`${fixtureBase}/compare/netlify-vs-vercel`, {
+      headers: { "If-Modified-Since": "Wed, 19 Aug 2026 00:00:00 GMT" },
+    });
+    await current.text();
+    assert.equal(current.status, 304);
+  });
+
+  it("sends the whole page when the date it was asked about is not one it can read", async () => {
+    for (const asked of ["2026-02-03", "yesterday", "Tue, 03 Feb 2026"]) {
+      const response = await fetch(`${fixtureBase}/privacy`, { headers: { "If-Modified-Since": asked } });
+      await response.text();
+      assert.equal(response.status, 200, `${JSON.stringify(asked)} was read as a date`);
+    }
+  });
+
+  it("dates the URL it hashed, so a query string carries no day and revalidates nothing", async () => {
+    const plain = await fetch(`${fixtureBase}/privacy`);
+    await plain.text();
+    assert.equal(plain.headers.get("last-modified"), "Tue, 03 Feb 2026 00:00:00 GMT");
+    const queried = await fetch(`${fixtureBase}/privacy?utm_source=elsewhere`, {
+      headers: { "If-Modified-Since": "Tue, 03 Feb 2026 00:00:00 GMT" },
+    });
+    const body = await queried.text();
+    assert.equal(queried.headers.get("last-modified"), null);
+    assert.equal(queried.status, 200);
+    assert.ok(body.includes("</html>"));
+  });
+
+  it("leaves the decision to the entity tag when the client sends one", async () => {
+    const response = await fetch(`${fixtureBase}/privacy`, {
+      headers: { "If-Modified-Since": "Tue, 03 Feb 2026 00:00:00 GMT", "If-None-Match": '"a-tag-we-never-issued"' },
+    });
+    await response.text();
+    assert.equal(response.status, 200);
+  });
 });
 
 describe("what the sitemaps say about when a page changed", () => {
@@ -349,11 +411,68 @@ describe("what the sitemaps say about when a page changed", () => {
       await response.text();
       assert.equal(response.headers.get("last-modified"), httpDate(lastmod!), `${page} header disagrees with its sitemap entry`);
     }
+    const vendors = new Map((await sitemapEntries("vendors")).map(e => [e.loc, e.lastmod]));
+    const supabase = vendors.get("/vendor/supabase");
+    assert.ok(supabase, "/vendor/supabase is missing from the vendors sitemap");
     const vendor = await fetch(`${base}/vendor/supabase`);
     await vendor.text();
-    assert.equal(vendor.headers.get("last-modified"), null, "A page with no per-page day should carry no Last-Modified");
+    assert.equal(vendor.headers.get("last-modified"), httpDate(supabase!), "a vendor page's header disagrees with its sitemap entry");
+  });
+
+  it("serves the sitemap's own day on the vendor and category pages, read from end to end of both lists", async () => {
+    const sampled: Array<{ loc: string; lastmod: string }> = [];
+    for (const [sitemap, prefix] of [["vendors", "/vendor/"], ["pages", "/category/"]] as const) {
+      const listed = (await sitemapEntries(sitemap)).filter(e => e.loc.startsWith(prefix));
+      assert.ok(listed.length > 0, `${prefix} publishes nothing, so this test checks nothing`);
+      const stride = Math.max(1, Math.ceil(listed.length / 12));
+      for (let at = 0; at < listed.length; at += stride) sampled.push(listed[at]!);
+      sampled.push(listed[listed.length - 1]!);
+    }
+    assert.ok(sampled.length >= 8, `read ${sampled.length} pages, too few to cover two lists`);
+    const days = new Set<string>();
+    for (const { loc, lastmod } of sampled) {
+      const response = await fetch(base + loc);
+      await response.text();
+      assert.equal(response.status, 200, `${loc} answered ${response.status}`);
+      assert.equal(response.headers.get("last-modified"), httpDate(lastmod), `${loc} header disagrees with its sitemap entry`);
+      days.add(lastmod);
+    }
+    assert.ok(days.size > 1, "every page read carries the same day, so a header taken from anywhere would pass");
+  });
+
+  it("dates the homepage and tells a cache how long to hold it", async () => {
+    const listed = new Map((await sitemapEntries("pages")).map(e => [e.loc, e.lastmod]));
+    const advertised = listed.get("/");
+    assert.ok(advertised, "/ is missing from the pages sitemap");
+    const response = await fetch(base + "/");
+    await response.text();
+    assert.equal(response.headers.get("last-modified"), httpDate(advertised!), "the homepage header disagrees with its sitemap entry");
+    assert.match(response.headers.get("cache-control") ?? "", /max-age=\d+/, "the homepage tells no cache how long to hold it");
+  });
+
+  it("answers a revalidation of the day it advertises, on every class of page that carries one", async () => {
+    const dated: string[] = ["/", "/vendor/supabase", RETITLED[0]!];
+    const categories = (await sitemapEntries("pages")).filter(e => e.loc.startsWith("/category/"));
+    assert.ok(categories.length > 0, "no category page is published, so this test checks nothing");
+    dated.push(categories[0]!.loc);
+    for (const page of dated) {
+      const first = await fetch(base + page);
+      await first.text();
+      const advertised = first.headers.get("last-modified");
+      assert.ok(advertised, `${page} carries no day to revalidate against`);
+      const revalidated = await fetch(base + page, { headers: { "If-Modified-Since": advertised! } });
+      const body = await revalidated.text();
+      assert.equal(revalidated.status, 304, `${page} re-sent its body to a client already holding ${advertised}`);
+      assert.equal(body, "", `${page} answered 304 with a body`);
+      const older = await fetch(base + page, { headers: { "If-Modified-Since": "Mon, 01 Jan 2024 00:00:00 GMT" } });
+      const full = await older.text();
+      assert.equal(older.status, 200, `${page} withheld its body from a client holding a copy from 2024`);
+      assert.ok(full.includes("</html>"), `${page} answered 200 without a page`);
+    }
   });
 });
+
+
 
 const WORKFLOWS = path.join(REPO, ".github", "workflows");
 

--- a/test/page-lastmod.test.ts
+++ b/test/page-lastmod.test.ts
@@ -450,16 +450,15 @@ describe("what the sitemaps say about when a page changed", () => {
     assert.match(response.headers.get("cache-control") ?? "", /max-age=\d+/, "the homepage tells no cache how long to hold it");
   });
 
-  it("answers a revalidation of the day it advertises, on every class of page that carries one", async () => {
-    const dated: string[] = ["/", "/vendor/supabase", RETITLED[0]!];
-    const categories = (await sitemapEntries("pages")).filter(e => e.loc.startsWith("/category/"));
-    assert.ok(categories.length > 0, "no category page is published, so this test checks nothing");
-    dated.push(categories[0]!.loc);
-    for (const page of dated) {
+  it("answers a revalidation on every page whose day was read from its own rendered body", async () => {
+    const ledger = readPageLastmod();
+    const read = ["/", ...RETITLED, REPRICED].filter(page => ledger.pages[page]);
+    assert.ok(read.length >= 4, `only ${read.length} of the pages named here are in the ledger`);
+    for (const page of read) {
       const first = await fetch(base + page);
       await first.text();
       const advertised = first.headers.get("last-modified");
-      assert.ok(advertised, `${page} carries no day to revalidate against`);
+      assert.equal(advertised, httpDate(ledger.pages[page]!.changed), `${page} advertises a day the ledger does not hold`);
       const revalidated = await fetch(base + page, { headers: { "If-Modified-Since": advertised! } });
       const body = await revalidated.text();
       assert.equal(revalidated.status, 304, `${page} re-sent its body to a client already holding ${advertised}`);
@@ -469,6 +468,42 @@ describe("what the sitemaps say about when a page changed", () => {
       assert.equal(older.status, 200, `${page} withheld its body from a client holding a copy from 2024`);
       assert.ok(full.includes("</html>"), `${page} answered 200 without a page`);
     }
+  });
+
+  it("sends the whole page where the day comes from a record rather than from the body", async () => {
+    const ledger = readPageLastmod();
+    const categories = (await sitemapEntries("pages")).filter(e => e.loc.startsWith("/category/"));
+    assert.ok(categories.length > 0, "no category page is published, so this test checks nothing");
+    for (const page of ["/vendor/supabase", categories[0]!.loc]) {
+      assert.ok(!ledger.pages[page], `${page} is in the ledger now, so its body is dated and it may revalidate`);
+      const first = await fetch(base + page);
+      await first.text();
+      const advertised = first.headers.get("last-modified");
+      assert.ok(advertised, `${page} carries no day at all`);
+      const revalidated = await fetch(base + page, { headers: { "If-Modified-Since": advertised! } });
+      const body = await revalidated.text();
+      assert.equal(revalidated.status, 200, `${page} answered 304 against a day nothing read off its body`);
+      assert.ok(body.includes("</html>"), `${page} answered 200 without a page`);
+    }
+  });
+
+  it("publishes content dated after the day a vendor page advertises, which is why that day validates nothing", async () => {
+    const listed = (await sitemapEntries("vendors")).filter(e => e.loc.startsWith("/vendor/"));
+    const stride = Math.max(1, Math.ceil(listed.length / 24));
+    const sampled = listed.filter((_, at) => at % stride === 0);
+    assert.ok(sampled.length >= 8, `read ${sampled.length} vendor pages, too few to say anything`);
+    const today = new Date().toISOString().slice(0, 10);
+    let ahead = 0;
+    for (const { loc, lastmod } of sampled) {
+      const body = (await (await fetch(base + loc)).text()).replace(/<dl>[\s\S]*?<\/dl>/g, "");
+      const printed = [...body.matchAll(/\b(20\d\d-\d\d-\d\d)\b/g)].map(m => m[1]).filter(day => day <= today).sort();
+      const newest = printed.at(-1);
+      if (newest && newest > lastmod) ahead++;
+    }
+    assert.ok(
+      ahead > sampled.length / 2,
+      `${ahead} of ${sampled.length} vendor pages print content newer than the day they advertise; if that is now a minority the day may be worth revalidating against`,
+    );
   });
 });
 

--- a/test/vendor-series.test.ts
+++ b/test/vendor-series.test.ts
@@ -24,7 +24,7 @@ const {
   VENDOR_SERIES_NOTES,
   VENDOR_SERIES_PATH,
   vendorExportAuthorized,
-} = await import("../src/vendor-series.ts");
+} = await import("../dist/vendor-series.js");
 
 type StoreCall = { key: string; value: any; ttl: number };
 
@@ -110,6 +110,11 @@ describe("vendor series recording", () => {
     hit({ status: 301, address: "1.1.1.2" });
     hit({ status: 500, address: "1.1.1.3" });
     assert.strictEqual(takeVendorWrites().length, 0);
+  });
+
+  it("counts a client we told the page had not changed, so the series does not fall away as caches revalidate", () => {
+    hit({ status: 304, address: "1.1.1.4" });
+    assert.deepStrictEqual(takeVendorWrites()[0].delta.counts, { neon: 1 });
   });
 
   it("folds a slug we do not publish into one overflow key", () => {


### PR DESCRIPTION
Refs #1347

`Last-Modified` shipped on 496 pages and could do no work: no route answered a conditional request, and the surface crawlers hit hardest carried no date at all.

## What a client gets now

A `GET` or `HEAD` naming the page's own day, or any later one, answers `304` with no body. An earlier day answers `200` with the page. Read off a running server:

| page | header | revalidated with that day | with a 2024 day |
|---|---|---|---|
| `/` | `Fri, 11 Sep 2026` | `304`, 0 bytes | `200`, 68,465 |
| `/monitoring-comparison-2026` | `Thu, 10 Sep 2026` | `304`, 0 bytes | `200`, 113,943 |
| `/privacy` | `Wed, 09 Sep 2026` | `304`, 0 bytes | `200`, full page |
| `/vendor/supabase` | `Mon, 17 Aug 2026` | `200`, 48,746 | `200`, 48,746 |
| `/category/databases` | `Tue, 08 Sep 2026` | `200`, 87,073 | `200`, 87,073 |

`Mon, 17 Aug 2026` is the day `sitemap-vendors.xml` already advertised for `/vendor/supabase` — the issue's own example. The last two rows are the part of the issue I could not implement as written, and the reason is measured below.

## Where each day comes from

`/vendor/*` and `/category/*` take the day their sitemap entry advertises, read through the accessor the sitemap itself now calls, so an entry and a header cannot drift.

`/` joins the page ledger. Its day is now read off its rendered body, like every other ledger page, rather than off `latestVerified` — the newest `verifiedDate` in the catalogue, which moves whenever any record is re-verified and would have advanced the homepage's day on days its body did not move. Regenerating the ledger added exactly one entry and moved no other page. `/` also carries `Cache-Control` now; it had none.

`/best/*` and `/alternative-to/*` still carry no day. That is the coverage half, #1487.

## Why a vendor page carries the day but does not revalidate against it

AC-1 and AC-2 read together as: serve `/vendor/*` its sitemap day, then answer 304 against it. Measured before implementing that, the two do not compose.

**A vendor page's day is one vendor's `verifiedDate`. The page renders far more than that vendor.** Sampling 140 of 1,539 vendor pages end to end of the sitemap, with the ranking audit block stripped:

- **120 of 140 print content dated later than the day they advertise.**
- Median gap **33 days**, p90 **54**, maximum **149**.

`/vendor/windsurf` advertises `2026-06-25`. A crawler that took that day and revalidated would be told "not modified" on every request from June onward, because nothing about that page's other content moves `verifiedDate`. That is not a stale answer once — it is a permanent freeze on the largest surface on the site, 1,377 requests a day.

Separately, **19 of 140 vendor pages change every UTC day by construction**: they carry the `Recompute today's order yourself` block, whose alternatives order is *"a permutation seeded only on the UTC date and the query key"* and which prints that date in the page. For those the advertised day is wrong in the other direction.

So: **a 304 is a claim about bytes, and it is made only where the bytes were read** — the page ledger, which hashes each page's rendered output and moves the day on the push that moved it. The vendor and category pages keep the header, because it is the same claim `sitemap-vendors.xml` has been publishing all along and it costs a crawler nothing to schedule against.

Unlocking the other 1,377 requests a day needs one of two things, and both are decisions rather than code:

1. **Put `/vendor/*` in the page ledger** — the day then comes from the body and revalidation is honest. This is the seeding question in #1487, and this measurement changes its answer: seeding from the sitemap day would seed 120 of 140 pages with a day their body has already moved past.
2. **Settle the daily-rotating order first**, or ledger-dating will stamp those 19-in-140 pages with today, every day.

Either is a one-line switch here once decided: `revalidationDayHeader` reads `renderedBodyDay`, and the alternative `sitemapDayFor` is the function beside it.

## A query string carries no day

`/privacy?utm_source=x` now serves no `Last-Modified` and revalidates nothing. The ledger hashed the response to the bare path; a query variant's body was never hashed, so the page's day is not a claim about it. Four ledger pages (`/estimate`, `/stack-check`, `/compare-tool`, `/budget-builder`) read a query client-side today and would be the first to break that claim.

## Two counters this would otherwise have broken

`requestOutcome(304)` returned `"redirect"`, and `recordVendorRequest` dropped anything outside 2xx. Both were written when nothing could answer 304. Left alone, our own page-view and per-vendor figures would have fallen away on the day crawlers started revalidating, and a revalidation would have been counted as sending the client somewhere else. A 304 now counts among the pages we served. Nothing else returns 304, so no existing count moves.

## Tests

- `test/conditional-request.test.ts` — the reader: the date formats accepted, everything date-shaped that is refused, the method and entity-tag guards, the boundary at the page's own second.
- `test/page-lastmod.test.ts:342` inverted — `/vendor/supabase` asserts the day `sitemap-vendors.xml` gives it, rather than asserting it carries none.
- Vendor and category pages sampled end to end of both lists against their sitemap entries, with a guard that the sample spans more than one day so a header taken from anywhere would not pass.
- 304-and-empty-body, and 200-with-`</html>`, on every ledger-dated page; 200-with-the-page on the classes whose day comes from a record.
- The 120-of-140 measurement runs in the suite. If vendor pages stop printing content newer than the day they advertise, that test goes red and says the day may be worth revalidating against.

`scripts/mutate-1347.sh`: **18 mutants, 18 killed.** Including the one the issue asks for by name — a handler that ignores the header — a `revalidationDayHeader` that reads the sitemap day instead of the ledger day, and an `asctime` date read in the server's own zone rather than UTC, which `Date.parse` does and which would have made a Pacific-zone box 8 hours too generous.

## What this does not show

Whether crawlers send us `If-Modified-Since` at all. The issue is explicit that this cannot be known in advance: no page carried `Last-Modified` before this week, so nothing could have revalidated against one. The Cloudflare query that returned 0 responses with status 304 out of 18,592 requests is the measurement — if it is still 0 a week after this deploys, crawlers are not sending conditional requests, and that answer is worth the one handler. Note that the 473 ledger pages are the population that can now answer one, not the 2,519.
