### PR TITLE
Answer a conditional request on any page, by tagging the bytes it sent

### DIFF
--- a/scripts/mutate-1347-etag.mjs
+++ b/scripts/mutate-1347-etag.mjs
@@ -1,0 +1,122 @@
+import { readFileSync, writeFileSync } from "node:fs";
+import { execFileSync } from "node:child_process";
+
+const SUITE = ["test/conditional-request.test.ts", "test/page-lastmod.test.ts"];
+const VALIDATOR = "src/conditional-request.ts";
+const SERVER = "src/serve.ts";
+
+const MUTANTS = [
+  ["the-tag-fingerprints-the-route-rather-than-the-body", VALIDATOR,
+    "  return `\"${createHash(\"sha256\").update(body).digest(\"hex\").slice(0, 16)}\"`;",
+    "  return `\"${createHash(\"sha256\").update(body.slice(0, 64)).digest(\"hex\").slice(0, 16)}\"`;"],
+
+  ["the-tag-is-a-constant", VALIDATOR,
+    "  return `\"${createHash(\"sha256\").update(body).digest(\"hex\").slice(0, 16)}\"`;",
+    "  return `\"0123456789abcdef\"`;"],
+
+  ["the-tag-is-served-unquoted", VALIDATOR,
+    "  return `\"${createHash(\"sha256\").update(body).digest(\"hex\").slice(0, 16)}\"`;",
+    "  return createHash(\"sha256\").update(body).digest(\"hex\").slice(0, 16);"],
+
+  ["a-weakened-tag-is-compared-verbatim", VALIDATOR,
+    "  return tag.startsWith(\"W/\") ? tag.slice(2) : tag;",
+    "  return tag;"],
+
+  ["only-the-first-tag-a-client-offers-is-read", VALIDATOR,
+    "  return value.split(\",\").map(tag => tag.trim()).filter(tag => tag.length > 0);",
+    "  return [value.trim()].filter(tag => tag.length > 0);"],
+
+  ["a-header-sent-twice-is-read-as-a-tag", VALIDATOR,
+    "  if (typeof value !== \"string\") return [];",
+    "  if (Array.isArray(value)) return value;\n  if (typeof value !== \"string\") return [];"],
+
+  ["a-write-revalidates", VALIDATOR,
+    "  if (request.method !== \"GET\" && request.method !== \"HEAD\") return false;\n  if (!served) return false;",
+    "  if (!served) return false;"],
+
+  ["a-page-with-no-tag-answers-not-modified", VALIDATOR,
+    "  if (!served) return false;\n  const asked = parseEntityTags(request.ifNoneMatch);",
+    "  if (!served) return true;\n  const asked = parseEntityTags(request.ifNoneMatch);"],
+
+  ["a-client-asking-nothing-answers-not-modified", VALIDATOR,
+    "  if (asked.length === 0) return false;",
+    "  if (asked.length === 0) return true;"],
+
+  ["the-wildcard-is-read-as-an-ordinary-tag", VALIDATOR,
+    "  if (asked.includes(\"*\")) return true;\n",
+    ""],
+
+  ["any-tag-a-client-offers-matches", VALIDATOR,
+    "  return asked.some(tag => withoutWeakness(tag) === withoutWeakness(served));",
+    "  return asked.length > 0;"],
+
+  ["only-a-tag-offered-first-matches", VALIDATOR,
+    "  return asked.some(tag => withoutWeakness(tag) === withoutWeakness(served));",
+    "  return withoutWeakness(asked[0]!) === withoutWeakness(served);"],
+
+  ["no-page-is-tagged", SERVER,
+    "    if (status === 200 && !headOfServedBody && /^text\\/html/.test(servedContentType)) {",
+    "    if (false && status === 200 && !headOfServedBody && /^text\\/html/.test(servedContentType)) {"],
+
+  ["every-response-is-tagged-including-the-ones-that-are-not-pages", SERVER,
+    "    if (status === 200 && !headOfServedBody && /^text\\/html/.test(servedContentType)) {",
+    "    if (status === 200 && !headOfServedBody) {"],
+
+  ["the-tag-is-taken-before-the-page-is-finished", SERVER,
+    "    if (typeof args[0] === \"string\" && /^text\\/html/.test(servedContentType)) {\n      args[0] = withLedeBeforeNav(withPageFreshness(args[0], url.pathname));\n    }\n    if (headOfServedBody) {\n      const head = headOfServedBody;\n      headOfServedBody = null;\n      const tag = typeof args[0] === \"string\" ? entityTag(args[0]) : null;",
+    "    const beforeTheTransform = args[0];\n    if (typeof args[0] === \"string\" && /^text\\/html/.test(servedContentType)) {\n      args[0] = withLedeBeforeNav(withPageFreshness(args[0], url.pathname));\n    }\n    if (headOfServedBody) {\n      const head = headOfServedBody;\n      headOfServedBody = null;\n      const tag = typeof beforeTheTransform === \"string\" ? entityTag(beforeTheTransform) : null;"],
+
+  ["the-tag-is-never-compared-so-nothing-revalidates", SERVER,
+    "      if (tag && matchesEntityTag(revalidation, tag)) {",
+    "      if (false && tag && matchesEntityTag(revalidation, tag)) {"],
+
+  ["the-tag-is-never-sent-so-nothing-can-hold-it", SERVER,
+    "      if (tag) res.setHeader(\"ETag\", tag);",
+    "      if (tag) res.removeHeader(\"ETag\");"],
+
+  ["the-revalidation-drops-the-validator-the-client-must-keep", SERVER,
+    "        rawWriteHead(304 as never, { ...revalidationHeaders(head.headers), ETag: tag } as never);",
+    "        rawWriteHead(304 as never, revalidationHeaders(head.headers) as never);"],
+
+  ["the-revalidation-is-answered-with-an-empty-200", SERVER,
+    "        rawWriteHead(304 as never, { ...revalidationHeaders(head.headers), ETag: tag } as never);",
+    "        rawWriteHead(200 as never, { ...revalidationHeaders(head.headers), ETag: tag } as never);"],
+
+  ["a-day-a-page-never-read-off-its-body-revalidates-it", SERVER,
+    "    if (status === 200 && isNotModified(revalidation, revalidationDayHeader(url.pathname, url.search))) {",
+    "    if (status === 200 && isNotModified(revalidation, pageLastmodHeader(url.pathname, url.search))) {"],
+];
+
+function run(cmd, args) {
+  try {
+    execFileSync(cmd, args, { stdio: "pipe", encoding: "utf-8" });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+const survivors = [];
+const uncompiled = [];
+const skipped = [];
+for (const [name, file, from, to] of MUTANTS) {
+  const original = readFileSync(file, "utf-8");
+  if (!original.includes(from)) {
+    console.log(`SKIP  ${name} — the line it mutates is not in ${file}`);
+    skipped.push(name);
+    continue;
+  }
+  writeFileSync(file, original.replace(from, to));
+  const built = run("npm", ["run", "build"]);
+  const green = built && run("node", ["--test", "--test-concurrency", "1", ...SUITE]);
+  writeFileSync(file, original);
+  if (!built) uncompiled.push(name);
+  console.log(`${green ? "SURVIVED" : built ? "killed  " : "DID NOT COMPILE"}  ${name}`);
+  if (green) survivors.push(name);
+}
+run("npm", ["run", "build"]);
+const killed = MUTANTS.length - survivors.length - uncompiled.length - skipped.length;
+console.log(`\n${killed}/${MUTANTS.length} killed`);
+if (survivors.length > 0) console.log("survivors:", survivors.join(", "));
+if (uncompiled.length > 0) console.log("did not compile:", uncompiled.join(", "));
+if (skipped.length > 0) console.log("skipped — target string moved, so these scored nothing:", skipped.join(", "));

--- a/src/conditional-request.ts
+++ b/src/conditional-request.ts
@@ -1,3 +1,5 @@
+import { createHash } from "node:crypto";
+
 const MONTHS = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"];
 
 const IMF_FIXDATE = /^(?:Mon|Tue|Wed|Thu|Fri|Sat|Sun), \d{2} (?:Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec) \d{4} \d{2}:\d{2}:\d{2} GMT$/;
@@ -29,6 +31,28 @@ export function isRevalidation(request: ConditionalRequest): boolean {
   if (request.method !== "GET" && request.method !== "HEAD") return false;
   if (request.ifNoneMatch !== undefined) return false;
   return parseHttpDate(request.ifModifiedSince) !== null;
+}
+
+export function entityTag(body: string): string {
+  return `"${createHash("sha256").update(body).digest("hex").slice(0, 16)}"`;
+}
+
+function withoutWeakness(tag: string): string {
+  return tag.startsWith("W/") ? tag.slice(2) : tag;
+}
+
+export function parseEntityTags(value: HeaderValue): string[] {
+  if (typeof value !== "string") return [];
+  return value.split(",").map(tag => tag.trim()).filter(tag => tag.length > 0);
+}
+
+export function matchesEntityTag(request: ConditionalRequest, served: string | null): boolean {
+  if (request.method !== "GET" && request.method !== "HEAD") return false;
+  if (!served) return false;
+  const asked = parseEntityTags(request.ifNoneMatch);
+  if (asked.length === 0) return false;
+  if (asked.includes("*")) return true;
+  return asked.some(tag => withoutWeakness(tag) === withoutWeakness(served));
 }
 
 export function isNotModified(request: ConditionalRequest, lastModified: HeaderValue): boolean {

--- a/src/serve.ts
+++ b/src/serve.ts
@@ -85,7 +85,7 @@ import { changeDateLabel, changeEntryDateLabel, changeEntryLongDateLabel, change
 import { changeFeedEntries, feedEntryFields, feedUpdatedTimestamp, changeFeedProvenanceNote, CHANGE_FEED_ENTRY_LIMIT, CHANGE_FEED_DESCRIPTION, CHANGE_FEED_NAMESPACE, CHANGE_FEED_NAMESPACE_PREFIX, channelUpdatedTimestamp, WEEKLY_FEED_POPULATION_NOTE, feedLinkTag, feedEntrySourceXml, digestSourceXml, PER_CHANGE_FEED, WEEKLY_DIGEST_FEED } from "./change-feed.js";
 import { FEED_CORRECTIONS, correctionEntriesXml } from "./feed-corrections.js";
 import { buildDay, emptyPageLastmod, fallbackDay, httpDate, lastmodFor, newestLastmod, readPageLastmod, type PageLastmodLedger } from "./page-lastmod.js";
-import { datedUrl, isNotModified, revalidationHeaders } from "./conditional-request.js";
+import { datedUrl, entityTag, isNotModified, matchesEntityTag, revalidationHeaders } from "./conditional-request.js";
 import type { AgentBalance } from "./ledger.js";
 import type { SubmittedReferralCode } from "./referral-codes.js";
 
@@ -53663,6 +53663,7 @@ const httpServer = createHttpServer(async (req, res) => {
 
   let servedContentType = "";
   let answeredNotModified = false;
+  let headOfServedBody: { status: number; rest: unknown[]; headers?: Record<string, string> } | null = null;
   const rawWriteHead = res.writeHead.bind(res);
   res.writeHead = ((status: number, ...rest: unknown[]) => {
     const headers = rest.find(a => a && typeof a === "object") as Record<string, string> | undefined;
@@ -53683,6 +53684,10 @@ const httpServer = createHttpServer(async (req, res) => {
       answeredNotModified = true;
       return rawWriteHead(304 as never, revalidationHeaders(headers) as never);
     }
+    if (status === 200 && !headOfServedBody && /^text\/html/.test(servedContentType)) {
+      headOfServedBody = { status, rest, headers };
+      return res;
+    }
     return rawWriteHead(status as never, ...(rest as never[]));
   }) as typeof res.writeHead;
 
@@ -53691,6 +53696,18 @@ const httpServer = createHttpServer(async (req, res) => {
     if (answeredNotModified) return rawEnd();
     if (typeof args[0] === "string" && /^text\/html/.test(servedContentType)) {
       args[0] = withLedeBeforeNav(withPageFreshness(args[0], url.pathname));
+    }
+    if (headOfServedBody) {
+      const head = headOfServedBody;
+      headOfServedBody = null;
+      const tag = typeof args[0] === "string" ? entityTag(args[0]) : null;
+      if (tag && matchesEntityTag(revalidation, tag)) {
+        answeredNotModified = true;
+        rawWriteHead(304 as never, { ...revalidationHeaders(head.headers), ETag: tag } as never);
+        return rawEnd();
+      }
+      if (tag) res.setHeader("ETag", tag);
+      rawWriteHead(head.status as never, ...(head.rest as never[]));
     }
     return rawEnd(...(args as never[]));
   }) as typeof res.end;

--- a/test/conditional-request.test.ts
+++ b/test/conditional-request.test.ts
@@ -1,6 +1,7 @@
 import { describe, it } from "node:test";
 import assert from "node:assert";
-import { datedUrl, isNotModified, isRevalidation, parseHttpDate, revalidationHeaders } from "../dist/conditional-request.js";
+import { createHash } from "node:crypto";
+import { datedUrl, entityTag, isNotModified, isRevalidation, matchesEntityTag, parseEntityTags, parseHttpDate, revalidationHeaders } from "../dist/conditional-request.js";
 
 const GET = { method: "GET" };
 
@@ -88,6 +89,90 @@ describe("the response that answers a revalidation", () => {
 
   it("survives a response that named no headers at all", () => {
     assert.deepEqual(revalidationHeaders(undefined), {});
+  });
+});
+
+describe("the entity tag a response carries", () => {
+  const body = "<!doctype html><title>Supabase</title>";
+
+  it("is a quoted fingerprint of the bytes being sent, and of nothing else", () => {
+    const expected = createHash("sha256").update(body).digest("hex").slice(0, 16);
+    assert.equal(entityTag(body), `"${expected}"`);
+    assert.match(entityTag(body), /^"[0-9a-f]{16}"$/);
+  });
+
+  it("moves when a single byte of the body moves", () => {
+    assert.notEqual(entityTag(body), entityTag(body + " "));
+    assert.notEqual(entityTag(body), entityTag(body.replace("Supabase", "Supabasf")));
+  });
+
+  it("is the same tag for the same bytes, so a page that did not change keeps its tag", () => {
+    assert.equal(entityTag(body), entityTag(`${body}`));
+  });
+
+  it("is unaffected by the day, the route or anything outside the body", () => {
+    assert.equal(entityTag(""), entityTag(""));
+  });
+});
+
+describe("reading the tags a client says it already holds", () => {
+  it("reads one tag, a list of them, and the wildcard", () => {
+    assert.deepEqual(parseEntityTags('"abc"'), ['"abc"']);
+    assert.deepEqual(parseEntityTags('"abc", "def"'), ['"abc"', '"def"']);
+    assert.deepEqual(parseEntityTags('W/"abc","def"'), ['W/"abc"', '"def"']);
+    assert.deepEqual(parseEntityTags("*"), ["*"]);
+  });
+
+  it("reads nothing from a header that was not sent or was sent twice", () => {
+    assert.deepEqual(parseEntityTags(undefined), []);
+    assert.deepEqual(parseEntityTags(""), []);
+    assert.deepEqual(parseEntityTags(['"abc"', '"def"']), []);
+  });
+});
+
+describe("deciding whether the client already holds the bytes we would send", () => {
+  const served = '"4951f239b9145e03"';
+  const GET_TAG = (ifNoneMatch: string) => ({ method: "GET", ifNoneMatch });
+
+  it("answers not-modified when the client names the tag we would serve", () => {
+    assert.equal(matchesEntityTag(GET_TAG(served), served), true);
+    assert.equal(matchesEntityTag({ method: "HEAD", ifNoneMatch: served }, served), true);
+  });
+
+  it("compares weakly, so W/ in front of our own tag still matches", () => {
+    assert.equal(matchesEntityTag(GET_TAG(`W/${served}`), served), true);
+    assert.equal(matchesEntityTag(GET_TAG(served), `W/${served}`), true);
+  });
+
+  it("answers not-modified for the wildcard, which asks whether anything is there", () => {
+    assert.equal(matchesEntityTag(GET_TAG("*"), served), true);
+  });
+
+  it("finds our tag anywhere in a list the client offers", () => {
+    assert.equal(matchesEntityTag(GET_TAG(`"0000000000000000", ${served}`), served), true);
+    assert.equal(matchesEntityTag(GET_TAG(`"0000000000000000", "1111111111111111"`), served), false);
+  });
+
+  it("answers modified for a tag that is not ours, however close", () => {
+    assert.equal(matchesEntityTag(GET_TAG('"4951f239b9145e04"'), served), false);
+    assert.equal(matchesEntityTag(GET_TAG('"4951f239b9145e0"'), served), false);
+    assert.equal(matchesEntityTag(GET_TAG("4951f239b9145e03"), served), false);
+  });
+
+  it("answers modified when we have no tag to compare, whatever the client asks", () => {
+    assert.equal(matchesEntityTag(GET_TAG(served), null), false);
+    assert.equal(matchesEntityTag(GET_TAG("*"), null), false);
+  });
+
+  it("answers modified when nothing was asked", () => {
+    assert.equal(matchesEntityTag({ method: "GET" }, served), false);
+    assert.equal(matchesEntityTag(GET_TAG(""), served), false);
+  });
+
+  it("treats a method that is not a read as no revalidation at all", () => {
+    for (const method of ["POST", "PUT", "DELETE", "OPTIONS", undefined]) {
+      assert.equal(matchesEntityTag({ method, ifNoneMatch: served }, served), false, `${method} revalidated`);
+    }
   });
 });
 

--- a/test/page-lastmod.test.ts
+++ b/test/page-lastmod.test.ts
@@ -10,6 +10,7 @@ import {
   daysBetween, emptyPageLastmod, fallbackDay, hashPageBody, httpDate, lastmodFor, newestLastmod, parsePageLastmod,
   readPageLastmod, serializePageLastmod, updatePageLastmod, type PageLastmodLedger,
 } from "../dist/page-lastmod.js";
+import { entityTag } from "../dist/conditional-request.js";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const REPO = path.join(__dirname, "..");
@@ -306,6 +307,107 @@ describe("a page keeps the day it changed, whenever that was", () => {
     });
     await response.text();
     assert.equal(response.status, 200);
+  });
+
+  it("tags every page with a fingerprint of the bytes it just sent", async () => {
+    for (const page of ["/privacy", "/vendor/supabase", "/"]) {
+      const response = await fetch(`${fixtureBase}${page}`);
+      const body = await response.text();
+      const tag = response.headers.get("etag");
+      assert.ok(tag, `${page} served no entity tag`);
+      assert.equal(tag, entityTag(body), `${page} tagged something other than the body it sent`);
+    }
+  });
+
+  it("gives two pages different tags, and the same page the same tag twice", async () => {
+    const readTag = async (page: string) => {
+      const response = await fetch(`${fixtureBase}${page}`);
+      await response.text();
+      return response.headers.get("etag");
+    };
+    const privacy = await readTag("/privacy");
+    const comparison = await readTag("/compare/netlify-vs-vercel");
+    const privacyAgain = await readTag("/privacy");
+    assert.ok(privacy && comparison);
+    assert.notEqual(privacy, comparison, "two different pages share an entity tag");
+    assert.equal(privacy, privacyAgain, "one unchanged page changed its entity tag between two reads");
+  });
+
+  it("answers a client holding our own tag with 304 and no body", async () => {
+    const first = await fetch(`${fixtureBase}/privacy`);
+    await first.text();
+    const tag = first.headers.get("etag")!;
+    const second = await fetch(`${fixtureBase}/privacy`, { headers: { "If-None-Match": tag } });
+    const body = await second.text();
+    assert.equal(second.status, 304);
+    assert.equal(body, "");
+    assert.equal(second.headers.get("etag"), tag, "the 304 dropped the validator the client must keep");
+    assert.equal(second.headers.get("content-type"), null);
+  });
+
+  it("revalidates a vendor page, which carries a day it must not be revalidated against", async () => {
+    const first = await fetch(`${fixtureBase}/vendor/supabase`);
+    const body = await first.text();
+    const tag = first.headers.get("etag")!;
+    const advertised = first.headers.get("last-modified");
+    assert.ok(advertised, "/vendor/supabase stopped advertising a day");
+    assert.ok(body.length > 1000, "/vendor/supabase served no page to compare against");
+
+    const byTag = await fetch(`${fixtureBase}/vendor/supabase`, { headers: { "If-None-Match": tag } });
+    assert.equal(await byTag.text(), "");
+    assert.equal(byTag.status, 304, "a vendor page re-sent a body the client already holds");
+
+    const byDay = await fetch(`${fixtureBase}/vendor/supabase`, { headers: { "If-Modified-Since": advertised! } });
+    await byDay.text();
+    assert.equal(byDay.status, 200, "a vendor page answered 304 against a day nothing read off its body");
+  });
+
+  it("sends the whole page to a client holding a tag that is not ours", async () => {
+    for (const asked of ['"0000000000000000"', 'W/"0000000000000000"', '"0000000000000000", "1111111111111111"']) {
+      const response = await fetch(`${fixtureBase}/privacy`, { headers: { "If-None-Match": asked } });
+      const body = await response.text();
+      assert.equal(response.status, 200, `${asked} was read as our own tag`);
+      assert.ok(body.includes("</html>"), `the body was withheld from a client holding ${asked}`);
+    }
+  });
+
+  it("compares weakly, so a cache that weakened our tag still revalidates", async () => {
+    const first = await fetch(`${fixtureBase}/privacy`);
+    await first.text();
+    const tag = first.headers.get("etag")!;
+    const response = await fetch(`${fixtureBase}/privacy`, { headers: { "If-None-Match": `W/${tag}` } });
+    await response.text();
+    assert.equal(response.status, 304);
+  });
+
+  it("tags a URL carrying a query string, which carries no day to revalidate against", async () => {
+    const first = await fetch(`${fixtureBase}/privacy?utm_source=elsewhere`);
+    await first.text();
+    const tag = first.headers.get("etag");
+    assert.ok(tag, "a query-string URL served no entity tag");
+    assert.equal(first.headers.get("last-modified"), null);
+    const second = await fetch(`${fixtureBase}/privacy?utm_source=elsewhere`, { headers: { "If-None-Match": tag! } });
+    await second.text();
+    assert.equal(second.status, 304);
+  });
+
+  it("tags an answer to HEAD, which is how a crawler asks what it would get", async () => {
+    const head = await fetch(`${fixtureBase}/vendor/supabase`, { method: "HEAD" });
+    await head.text();
+    const get = await fetch(`${fixtureBase}/vendor/supabase`);
+    await get.text();
+    assert.ok(head.headers.get("etag"), "HEAD served no entity tag");
+    assert.equal(head.headers.get("etag"), get.headers.get("etag"));
+  });
+
+  it("leaves a response that is not a page untagged, so nothing revalidates against a guess", async () => {
+    const json = await fetch(`${fixtureBase}/api/offers`);
+    await json.text();
+    assert.equal(json.headers.get("etag"), null, "a JSON response carried an entity tag");
+    const missing = await fetch(`${fixtureBase}/vendor/a-vendor-we-do-not-list`);
+    await missing.text();
+    assert.equal(missing.status, 404);
+    assert.equal(missing.headers.get("etag"), null, "a 404 carried an entity tag");
   });
 });
 

--- a/test/page-lastmod.test.ts
+++ b/test/page-lastmod.test.ts
@@ -351,7 +351,7 @@ describe("a page keeps the day it changed, whenever that was", () => {
     const tag = first.headers.get("etag")!;
     const advertised = first.headers.get("last-modified");
     assert.ok(advertised, "/vendor/supabase stopped advertising a day");
-    assert.ok(body.length > 1000, "/vendor/supabase served no page to compare against");
+    assert.ok(body.includes("</html>"), "/vendor/supabase served no whole page to compare against");
 
     const byTag = await fetch(`${fixtureBase}/vendor/supabase`, { headers: { "If-None-Match": tag } });
     assert.equal(await byTag.text(), "");


### PR DESCRIPTION
Refs #1347

`#1536` shipped a `304` on the 473 pages whose day is hashed off their own rendered output. It could not ship one on `/vendor/*`, and I reported why: that page's `Last-Modified` is one vendor's `verifiedDate`, and the page renders far more than that vendor. 120 of 140 sampled vendor pages print content dated later than the day they advertise, median 33 days. Revalidating against that day would freeze the largest crawler surface permanently.

This is the mechanism that does compose. **An entity tag is a claim about the bytes, so it can be made on every page.**

## What changed

Every HTML `200` carries an `ETag` — a SHA-256 fingerprint of the body, taken *after* `withPageFreshness` and `withLedeBeforeNav`, because the tag has to name what was actually sent. A `GET` or `HEAD` offering that tag back in `If-None-Match` is answered `304` with no body and the tag echoed.

Headers for an HTML `200` are now held until the body is finished. Nothing else changes: `res.write()` appears twice in `src/serve.ts` and both are SSE keepalives, so no HTML route streams; `res.headersSent` is read in one place, also SSE; `Content-Length` is set on the favicon, the OG image and two SVGs, never on HTML.

`If-None-Match` already took precedence over `If-Modified-Since` — `isRevalidation` has stood aside for it since #1536. Comparison is weak because RFC 9110 §13.1.2 requires it for `If-None-Match`. It also matters in front of Cloudflare, which converts a strong tag to a weak one whenever it transforms the body — compression being the usual case. Under a strong comparison that conversion would silently cost us every revalidation, with nothing anywhere reporting an error.

## Measured

`/vendor/*`, which is the whole point of this:

```
GET /vendor/supabase                      200  48,746 bytes  ETag: "4951f239b9145e03"
GET /vendor/supabase  If-None-Match: it   304       0 bytes
GET /vendor/supabase  If-Modified-Since   200  48,746 bytes   ← still refuses the day, by design
```

200 vendor pages sampled from the sitemap's 1,539:

| | |
|---|---|
| body, median | 31,189 bytes |
| carry the UTC-date-seeded alternatives block, so change daily by construction | 25 / 200 (12%) |
| stable day over day | **175 / 200 (88%)** |

At the 1,377 requests a day `/vendor/*` takes, that is 42.9 MB/day today and up to 37.6 MB/day not sent — **if** crawlers send conditional requests. That is the same open question #1347 states, and the same Cloudflare query answers it: the count of `304` responses, which was 0 of 18,592.

A daily-rotating page is not a problem here, which is the difference from the date. Its bytes really did change, so its tag really does change, and it gets a `200`.

## Tests

`test/conditional-request.test.ts` covers the tag and the comparison: weak matching, the `*` wildcard, a list, a header sent twice, a tag that is not ours, a method that is not a read.

`test/page-lastmod.test.ts` covers the server: that every page's tag equals `entityTag(body)` for the body it just sent, that two pages differ and one page is stable, that `/vendor/supabase` revalidates by tag and still refuses to revalidate by day, that a query-string URL is tagged where it carries no day, that `HEAD` is tagged, and that JSON and a 404 are not.

Verified on a running server, not only in tests: four pages and two consecutive `304`s over one keep-alive connection, bodies intact.

**20 mutants, 20 killed.** `scripts/mutate-1347-etag.mjs`. Two needed reformulating: one did not compile, and one — passing the body to `end()` on the 304 path — is equivalent, because Node clears `_hasBody` for a 304 and sends nothing regardless. I served that mutant to check rather than assuming.
