### PR TITLE
Publish the same names tomorrow on every surface that names a few of a tied set

### DIFF
--- a/data/page-lastmod.json
+++ b/data/page-lastmod.json
@@ -3601,107 +3601,107 @@
       "changed": "2026-09-11"
     },
     "/vendor/10minutemail": {
-      "hash": "ef0295aa3c77b46e",
+      "hash": "4517a340b16eb6b6",
       "changed": "2026-09-11"
     },
     "/vendor/1984-is": {
-      "hash": "ceb42265bee48219",
+      "hash": "e3bc5732ca9eef1f",
       "changed": "2026-09-11"
     },
     "/vendor/1password": {
-      "hash": "85de0654c7986edc",
+      "hash": "06d2789ec489e8ce",
       "changed": "2026-09-11"
     },
     "/vendor/360-monitoring": {
       "daily": true
     },
     "/vendor/360username": {
-      "hash": "1d5fdc61b795b99f",
+      "hash": "0fecd38794550b71",
       "changed": "2026-09-11"
     },
     "/vendor/3cols": {
-      "hash": "22efe4b794ac9c60",
+      "hash": "6aaa2551976bc1fa",
       "changed": "2026-09-11"
     },
     "/vendor/4everland": {
-      "hash": "c0da1a29bee39b19",
+      "hash": "26330c94d40f2b5f",
       "changed": "2026-09-11"
     },
     "/vendor/8base-com": {
       "daily": true
     },
     "/vendor/abby": {
-      "hash": "0f507e3f57d967ee",
+      "hash": "7571996f42f1b22b",
       "changed": "2026-09-11"
     },
     "/vendor/ably": {
-      "hash": "20c08a3c3a06ca4a",
+      "hash": "b77ec1434301f9fa",
       "changed": "2026-09-11"
     },
     "/vendor/abstractapi": {
-      "hash": "9c916c8cd560ec44",
+      "hash": "eaa22ecacfe8bf98",
       "changed": "2026-09-11"
     },
     "/vendor/achieved": {
-      "hash": "e68f337ae8eaad6e",
+      "hash": "824cad5fe681b540",
       "changed": "2026-09-11"
     },
     "/vendor/activepieces": {
-      "hash": "3b54ac7d10c7592e",
+      "hash": "ed898152ba2e80f9",
       "changed": "2026-09-11"
     },
     "/vendor/acunote-com": {
-      "hash": "3352ca66906fd349",
+      "hash": "b781dcd2889b5df5",
       "changed": "2026-09-11"
     },
     "/vendor/adapty-io": {
-      "hash": "dbf9191d5afd4e73",
+      "hash": "d737f3bc7e58fa36",
       "changed": "2026-09-11"
     },
     "/vendor/addy-io": {
-      "hash": "cb86bd64d0e19231",
+      "hash": "acf662e2d54ed920",
       "changed": "2026-09-11"
     },
     "/vendor/ahasend": {
-      "hash": "102e3eef2f1476b5",
+      "hash": "eda8063e4009914e",
       "changed": "2026-09-11"
     },
     "/vendor/aider": {
-      "hash": "0d1d8bc92601f730",
+      "hash": "2d3048b305c59600",
       "changed": "2026-09-11"
     },
     "/vendor/aikido-dev": {
-      "hash": "b251adf45da44a4b",
+      "hash": "d91c1ad880ab6883",
       "changed": "2026-09-11"
     },
     "/vendor/aionda-mail": {
-      "hash": "bf272a71815565be",
+      "hash": "8066421bf00a4dc0",
       "changed": "2026-09-11"
     },
     "/vendor/aircall": {
-      "hash": "245ff89986ddabfc",
+      "hash": "8628104f28dfb27c",
       "changed": "2026-09-11"
     },
     "/vendor/airtable": {
-      "hash": "34afa6b7c8905f09",
+      "hash": "fc26c1f9b6c434a8",
       "changed": "2026-09-11"
     },
     "/vendor/aiven": {
       "daily": true
     },
     "/vendor/algolia": {
-      "hash": "904292e8dd7bb6e1",
+      "hash": "12eb19d1d1ffcaf5",
       "changed": "2026-09-11"
     },
     "/vendor/alias-email": {
-      "hash": "61f23fe2a7895d96",
+      "hash": "f27f3facd9280925",
       "changed": "2026-09-11"
     },
     "/vendor/alibaba-cloud-qwen-code": {
       "daily": true
     },
     "/vendor/allthefreestock": {
-      "hash": "9250307afb7856c9",
+      "hash": "9b6727b5afe7777d",
       "changed": "2026-09-11"
     },
     "/vendor/alwaysdata": {
@@ -3711,11 +3711,11 @@
       "daily": true
     },
     "/vendor/amazon-aws": {
-      "hash": "411a01b31c56bc9e",
+      "hash": "9ef9c62cb660f75a",
       "changed": "2026-09-11"
     },
     "/vendor/amazon-ecr-public": {
-      "hash": "1eb03699f0a5a7c6",
+      "hash": "690cb1061e8fc3b3",
       "changed": "2026-09-11"
     },
     "/vendor/amazon-kiro": {
@@ -3725,107 +3725,107 @@
       "daily": true
     },
     "/vendor/amazon-q-developer": {
-      "hash": "200d9cb5c2e0c42a",
+      "hash": "78a96074aaad9138",
       "changed": "2026-09-11"
     },
     "/vendor/amazon-ses": {
       "daily": true
     },
     "/vendor/amazon-sp-api": {
-      "hash": "0c02cb4dbbc91954",
+      "hash": "e28bfb80ac1142bb",
       "changed": "2026-09-11"
     },
     "/vendor/amplitude": {
-      "hash": "b20e19374d133804",
+      "hash": "32a6eb955ff22999",
       "changed": "2026-09-11"
     },
     "/vendor/ampt-dev": {
       "daily": true
     },
     "/vendor/android-studio": {
-      "hash": "62918a41ebbc7e5f",
+      "hash": "f2ff0a35c85e6a4b",
       "changed": "2026-09-11"
     },
     "/vendor/androidide": {
-      "hash": "f415a52a3642f55a",
+      "hash": "0f2e31aaa59913a8",
       "changed": "2026-09-11"
     },
     "/vendor/ant-design-landing-page": {
-      "hash": "167b5598f65a77a8",
+      "hash": "1f9f6afc6a4955b2",
       "changed": "2026-09-11"
     },
     "/vendor/anthropic-api": {
       "daily": true
     },
     "/vendor/antideo": {
-      "hash": "e7ce0fb0e1fa4b13",
+      "hash": "70609327e9772e7d",
       "changed": "2026-09-11"
     },
     "/vendor/anvil-works": {
       "daily": true
     },
     "/vendor/apache-netbeans": {
-      "hash": "d9b87c14656d896d",
+      "hash": "5e948a588a7e0cee",
       "changed": "2026-09-11"
     },
     "/vendor/apiary-io": {
-      "hash": "3654bfdb952f9d6c",
+      "hash": "a51977530017cd25",
       "changed": "2026-09-11"
     },
     "/vendor/apidog": {
-      "hash": "b7b26118ed066870",
+      "hash": "6b9e2b0684316ca1",
       "changed": "2026-09-11"
     },
     "/vendor/apiflash": {
-      "hash": "a534f19a5b91ff40",
+      "hash": "4e2bd0cef1a58abb",
       "changed": "2026-09-11"
     },
     "/vendor/apify": {
-      "hash": "44c78f9accde5646",
+      "hash": "d442a75e274fbe5c",
       "changed": "2026-09-11"
     },
     "/vendor/apilayer": {
-      "hash": "827a59976ff37f12",
+      "hash": "1e9ae456ddf163c4",
       "changed": "2026-09-11"
     },
     "/vendor/apitemplate-io": {
-      "hash": "4e583f8d3e7fc377",
+      "hash": "a1157734623eeaea",
       "changed": "2026-09-11"
     },
     "/vendor/apiverve": {
-      "hash": "459f880b5c42de25",
+      "hash": "be65d444876666a2",
       "changed": "2026-09-11"
     },
     "/vendor/apollo-graphos": {
-      "hash": "c46db91979118d7a",
+      "hash": "affdd3700996a87a",
       "changed": "2026-09-11"
     },
     "/vendor/appcircle": {
-      "hash": "6bc3dc90839f6503",
+      "hash": "1442c8800eadde41",
       "changed": "2026-09-11"
     },
     "/vendor/appetize": {
-      "hash": "d83f0387fec74187",
+      "hash": "ce21ea5702ba53b1",
       "changed": "2026-09-11"
     },
     "/vendor/appfit": {
-      "hash": "3957178b2f708b6a",
+      "hash": "f43b544f143bad91",
       "changed": "2026-09-11"
     },
     "/vendor/appho-st": {
-      "hash": "b921f59d3ffb9f43",
+      "hash": "2f5534008bd794c4",
       "changed": "2026-09-11"
     },
     "/vendor/appinvento": {
-      "hash": "ee59f1fd37a88d11",
+      "hash": "c07c925e82ad39e2",
       "changed": "2026-09-11"
     },
     "/vendor/apple-notes": {
-      "hash": "cd1afe2b8c881ab3",
+      "hash": "3722eb8e80871639",
       "changed": "2026-09-11"
     },
     "/vendor/apple-passwords": {
-      "hash": "88df84d49fd25976",
+      "hash": "989e8eadeecd6c63",
       "changed": "2026-09-11"
     },
     "/vendor/applitools-eyes": {
@@ -3838,45 +3838,45 @@
       "daily": true
     },
     "/vendor/appsmith": {
-      "hash": "1cb5679ac16163a0",
+      "hash": "9ed361e1f83853b5",
       "changed": "2026-09-11"
     },
     "/vendor/appveyor-com": {
-      "hash": "d9c72f7c901a841f",
+      "hash": "163713e72e21a4ba",
       "changed": "2026-09-11"
     },
     "/vendor/appwrite-cloud": {
       "daily": true
     },
     "/vendor/aptabase": {
-      "hash": "6526591d56e3cfd7",
+      "hash": "a21de7859e680823",
       "changed": "2026-09-11"
     },
     "/vendor/argo-cd": {
-      "hash": "bbf2f4c037c5c6c5",
+      "hash": "a0073c54800d5070",
       "changed": "2026-09-11"
     },
     "/vendor/argos": {
-      "hash": "b80a867195c5cc5b",
+      "hash": "bdd8c1da4116fc37",
       "changed": "2026-09-11"
     },
     "/vendor/arize-ax": {
       "daily": true
     },
     "/vendor/artillery": {
-      "hash": "500ae3bb5398ec74",
+      "hash": "c3e910519f07e508",
       "changed": "2026-09-11"
     },
     "/vendor/asana-com": {
-      "hash": "cc68ef12f41c269d",
+      "hash": "6a4f8a00694ee1cb",
       "changed": "2026-09-11"
     },
     "/vendor/aserto": {
-      "hash": "11910673daffc9a4",
+      "hash": "bf7d58c45c04f265",
       "changed": "2026-09-11"
     },
     "/vendor/asgardeo-io": {
-      "hash": "f3683e45357f4c45",
+      "hash": "d0466b99da342ba1",
       "changed": "2026-09-11"
     },
     "/vendor/assemblyai": {
@@ -3889,11 +3889,11 @@
       "daily": true
     },
     "/vendor/atlassian-statuspage": {
-      "hash": "b4f42be46b46266c",
+      "hash": "41bb2ca2bd55854a",
       "changed": "2026-09-11"
     },
     "/vendor/audio-enhancer": {
-      "hash": "99a37f7e0015bc78",
+      "hash": "91257cf46332ade7",
       "changed": "2026-09-11"
     },
     "/vendor/augment-code": {
@@ -3903,35 +3903,35 @@
       "daily": true
     },
     "/vendor/authentik": {
-      "hash": "9ffd07d544fe76a5",
+      "hash": "38cd970341406ad8",
       "changed": "2026-09-11"
     },
     "/vendor/authgear": {
-      "hash": "97645fe144a7f88f",
+      "hash": "9008875f16ba4269",
       "changed": "2026-09-11"
     },
     "/vendor/authress": {
-      "hash": "65fffeb93dd801ee",
+      "hash": "f4eb912eb1c2f252",
       "changed": "2026-09-11"
     },
     "/vendor/authy": {
-      "hash": "5cfb3d4d2d5c0953",
+      "hash": "dd977a0a15ad5d05",
       "changed": "2026-09-11"
     },
     "/vendor/autodesk-fusion-360-for-startups": {
-      "hash": "90cfd0f6cc16a5cd",
+      "hash": "cf2b1142040873cf",
       "changed": "2026-09-11"
     },
     "/vendor/autolocalise-com": {
-      "hash": "d33f56bfde1aed48",
+      "hash": "5b4215809db67aba",
       "changed": "2026-09-11"
     },
     "/vendor/automatisch": {
-      "hash": "feb92e2e55198785",
+      "hash": "ac72f97f994a571c",
       "changed": "2026-09-11"
     },
     "/vendor/avo": {
-      "hash": "ed3f2b9d532f35d4",
+      "hash": "e517e4aefabb0d5f",
       "changed": "2026-09-11"
     },
     "/vendor/awardspace-com": {
@@ -3941,419 +3941,419 @@
       "daily": true
     },
     "/vendor/aws-activate": {
-      "hash": "b741efa1112abae7",
+      "hash": "92dea4620f1e16bc",
       "changed": "2026-09-11"
     },
     "/vendor/aws-sam-cli": {
-      "hash": "63bccf8c87d714b3",
+      "hash": "eab7a7006ed02381",
       "changed": "2026-09-11"
     },
     "/vendor/axiom": {
       "daily": true
     },
     "/vendor/axonaut": {
-      "hash": "b8f1be7558c236dc",
+      "hash": "e0009eb0b48f80a5",
       "changed": "2026-09-11"
     },
     "/vendor/azameo": {
-      "hash": "ba95ad2e89a4055a",
+      "hash": "871ea72922591587",
       "changed": "2026-09-11"
     },
     "/vendor/azure": {
-      "hash": "f08f675b60d5f8e8",
+      "hash": "d3ea1d77bb983fef",
       "changed": "2026-09-11"
     },
     "/vendor/back4app": {
       "daily": true
     },
     "/vendor/backblaze": {
-      "hash": "6c712a8f5d4b5653",
+      "hash": "417980ea1baac256",
       "changed": "2026-09-11"
     },
     "/vendor/backblaze-b2": {
-      "hash": "ee7f7df03d8ef80a",
+      "hash": "dbea5601338f4eb1",
       "changed": "2026-09-11"
     },
     "/vendor/backgroundstyler-com": {
-      "hash": "fddf04fcbf7562f9",
+      "hash": "a6d0fa08d4b970e6",
       "changed": "2026-09-11"
     },
     "/vendor/backlog": {
-      "hash": "bde1bfd70090bfa0",
+      "hash": "ad80e93fb50ad7f9",
       "changed": "2026-09-11"
     },
     "/vendor/base64-decoder-encoder": {
-      "hash": "68ac0e1b1626d1b0",
+      "hash": "e4998c634fbf4180",
       "changed": "2026-09-11"
     },
     "/vendor/basecamp": {
-      "hash": "22074e7fb0f27a47",
+      "hash": "b5cd8cf1db5f888b",
       "changed": "2026-09-11"
     },
     "/vendor/baselime": {
-      "hash": "8dc6488c673ccea9",
+      "hash": "e1ad777dea96345f",
       "changed": "2026-09-11"
     },
     "/vendor/baseten": {
       "daily": true
     },
     "/vendor/batch": {
-      "hash": "aaaeb7cec715b5f2",
+      "hash": "cc250dfb37f4313a",
       "changed": "2026-09-11"
     },
     "/vendor/bbedit": {
-      "hash": "362a905192ed6112",
+      "hash": "bffc8457aa2000d5",
       "changed": "2026-09-11"
     },
     "/vendor/beampipe-io": {
-      "hash": "22c40d81c1fcab2d",
+      "hash": "36843aca3261ea00",
       "changed": "2026-09-11"
     },
     "/vendor/beanstalkapp-com": {
-      "hash": "1f05e87dc76dd961",
+      "hash": "dd98391b2d9cb94f",
       "changed": "2026-09-11"
     },
     "/vendor/bearer": {
-      "hash": "27a045d1e0beea1e",
+      "hash": "b9b6c83df1de85b3",
       "changed": "2026-09-11"
     },
     "/vendor/beeceptor": {
-      "hash": "59d90c3b3a515742",
+      "hash": "ad6fc09aacf24ac4",
       "changed": "2026-09-11"
     },
     "/vendor/bench": {
-      "hash": "28a1daf7593114e8",
+      "hash": "8754190af0610bd3",
       "changed": "2026-09-11"
     },
     "/vendor/bencher": {
-      "hash": "86eb6ed3011e0575",
+      "hash": "8b68e295a1d81ce5",
       "changed": "2026-09-11"
     },
     "/vendor/better-stack-logs": {
-      "hash": "02f9eeb0faaf1c5c",
+      "hash": "dbce9f48629b614b",
       "changed": "2026-09-11"
     },
     "/vendor/betterstack": {
       "daily": true
     },
     "/vendor/bigdatacloud": {
-      "hash": "81a888cf41997369",
+      "hash": "498d1c4fdd1f2d88",
       "changed": "2026-09-11"
     },
     "/vendor/binder": {
-      "hash": "497c5924052ceeae",
+      "hash": "5bd566df8a17bfc5",
       "changed": "2026-09-11"
     },
     "/vendor/binshare-net": {
-      "hash": "4f4e247f89034e55",
+      "hash": "de3e32fd000c99cd",
       "changed": "2026-09-11"
     },
     "/vendor/bismuth-cloud": {
-      "hash": "5424d578f7b9f304",
+      "hash": "44a35935e75db321",
       "changed": "2026-09-11"
     },
     "/vendor/bitbucket-pipelines": {
-      "hash": "7aab4c6bcf1db667",
+      "hash": "3bae4454bcc80d8a",
       "changed": "2026-09-11"
     },
     "/vendor/bitnami-com": {
-      "hash": "e291a2ff96b9cfe7",
+      "hash": "381f61d0e52dc67a",
       "changed": "2026-09-11"
     },
     "/vendor/bitrise": {
-      "hash": "c616968348432140",
+      "hash": "9658be8536160211",
       "changed": "2026-09-11"
     },
     "/vendor/bitrix24-com": {
-      "hash": "273ff1a2e25b404d",
+      "hash": "fa79a7b760497ee2",
       "changed": "2026-09-11"
     },
     "/vendor/bitwarden": {
-      "hash": "abada192f867eedd",
+      "hash": "c2bb819ec5bf5c8a",
       "changed": "2026-09-11"
     },
     "/vendor/blazemeter": {
-      "hash": "212b73d7eed042b1",
+      "hash": "9e85747259b5508b",
       "changed": "2026-09-11"
     },
     "/vendor/bleemeo-com": {
       "daily": true
     },
     "/vendor/blender": {
-      "hash": "c1a13c6f3f74ed8f",
+      "hash": "018d55f077996635",
       "changed": "2026-09-11"
     },
     "/vendor/bluej": {
-      "hash": "0efceac4668595c6",
+      "hash": "be297b470252ffec",
       "changed": "2026-09-11"
     },
     "/vendor/blynk": {
-      "hash": "d4bbd8582fb9bbc8",
+      "hash": "62d66e453dbc1ff9",
       "changed": "2026-09-11"
     },
     "/vendor/bolt-new": {
-      "hash": "1fae71fd9351a597",
+      "hash": "96b9241c7cbf54f8",
       "changed": "2026-09-11"
     },
     "/vendor/bonsai-io": {
-      "hash": "ae5fb0197f9f1aca",
+      "hash": "0547626c1c911a57",
       "changed": "2026-09-11"
     },
     "/vendor/bookmarkos-com": {
-      "hash": "de5a2919fd0dba11",
+      "hash": "d358862a1cfc7906",
       "changed": "2026-09-11"
     },
     "/vendor/bootify-io": {
-      "hash": "f8b66f083ffc4308",
+      "hash": "abe4c1fedc7ce7d0",
       "changed": "2026-09-11"
     },
     "/vendor/bootstrapcdn-com": {
-      "hash": "ba0d1d2c694f6c06",
+      "hash": "ac33ac9dbe46bede",
       "changed": "2026-09-11"
     },
     "/vendor/borgbase-com": {
-      "hash": "a3321f68786efb31",
+      "hash": "97842638e5ebb620",
       "changed": "2026-09-11"
     },
     "/vendor/botnation": {
-      "hash": "caa4c4b1e9e110bf",
+      "hash": "66ad53030eab1e7e",
       "changed": "2026-09-11"
     },
     "/vendor/brackets": {
-      "hash": "501a7b5261a8403a",
+      "hash": "2afc70c030397ae9",
       "changed": "2026-09-11"
     },
     "/vendor/braid": {
-      "hash": "2546b514ae9fd5e3",
+      "hash": "0b073d9ff93c2e70",
       "changed": "2026-09-11"
     },
     "/vendor/brainboard": {
-      "hash": "8021b96fcc79a9a4",
+      "hash": "384ab2142746117b",
       "changed": "2026-09-11"
     },
     "/vendor/braintrust": {
       "daily": true
     },
     "/vendor/brave-search-api": {
-      "hash": "1c39d10b1caf822e",
+      "hash": "c3db992b342ce7ae",
       "changed": "2026-09-11"
     },
     "/vendor/brevo": {
-      "hash": "5ff5c0c24c2a95d1",
+      "hash": "a294a346ff0789e3",
       "changed": "2026-09-11"
     },
     "/vendor/brex": {
-      "hash": "bb8a52856aa40c52",
+      "hash": "e456655b63b7001e",
       "changed": "2026-09-11"
     },
     "/vendor/bricks-note-calculator": {
-      "hash": "12b13b05a095d783",
+      "hash": "047516546748a1a1",
       "changed": "2026-09-11"
     },
     "/vendor/bright-data-mcp-server": {
-      "hash": "8613c8c82c61e59b",
+      "hash": "4abca00fc57a0bce",
       "changed": "2026-09-11"
     },
     "/vendor/browse-ai": {
-      "hash": "bc8b3d810356ff6c",
+      "hash": "afb33fa3c3a9c3f3",
       "changed": "2026-09-11"
     },
     "/vendor/browserbase": {
-      "hash": "cd060e594c35e388",
+      "hash": "ef05c497ddfc73ed",
       "changed": "2026-09-11"
     },
     "/vendor/browsercat": {
-      "hash": "ea3500f266ca6ceb",
+      "hash": "9126de927d4817b2",
       "changed": "2026-09-11"
     },
     "/vendor/browserless": {
-      "hash": "08a8cc200a8b9d23",
+      "hash": "75f467f3d38f0577",
       "changed": "2026-09-11"
     },
     "/vendor/browserstack": {
-      "hash": "1e933a8a1b3f4131",
+      "hash": "46201278a5cd9f79",
       "changed": "2026-09-11"
     },
     "/vendor/browserstack-percy": {
-      "hash": "a2eee3abe7bd074b",
+      "hash": "5fd09f0ebe05a712",
       "changed": "2026-09-11"
     },
     "/vendor/bruno": {
-      "hash": "ddf004d1356deae7",
+      "hash": "2b333bea98ec1344",
       "changed": "2026-09-11"
     },
     "/vendor/btunnel": {
-      "hash": "697a6edbbcb461ed",
+      "hash": "169ad4ab3e34c198",
       "changed": "2026-09-11"
     },
     "/vendor/bubble": {
       "daily": true
     },
     "/vendor/buddy": {
-      "hash": "f9fb028be99ea5dd",
+      "hash": "fcab232b338b63d5",
       "changed": "2026-09-11"
     },
     "/vendor/buddyns": {
-      "hash": "9dbe823d54487645",
+      "hash": "a0d7c220539e94c2",
       "changed": "2026-09-11"
     },
     "/vendor/budibase": {
-      "hash": "c88b056414ed944a",
+      "hash": "9091f7c625c71c8b",
       "changed": "2026-09-11"
     },
     "/vendor/bugbug": {
-      "hash": "02688b7d96f50c89",
+      "hash": "2b76b85f3d5262cf",
       "changed": "2026-09-11"
     },
     "/vendor/bugfender-com": {
-      "hash": "c162870cc256dafa",
+      "hash": "f9b98846b8eae05b",
       "changed": "2026-09-11"
     },
     "/vendor/bugsink": {
-      "hash": "107cfd2c4ef35bdb",
+      "hash": "0004ac96bcf81fc1",
       "changed": "2026-09-11"
     },
     "/vendor/bugsnag": {
-      "hash": "b75a499e1140aa28",
+      "hash": "96fd3303d879c239",
       "changed": "2026-09-11"
     },
     "/vendor/build-opensuse-org": {
-      "hash": "6264a19a965ce769",
+      "hash": "9a404e98f4cff4ea",
       "changed": "2026-09-11"
     },
     "/vendor/buildkite": {
-      "hash": "f90d03db5c0368a5",
+      "hash": "a766800c6ba9bdf1",
       "changed": "2026-09-11"
     },
     "/vendor/bullmq": {
-      "hash": "80ce7d65cd17f91c",
+      "hash": "45994046e6ec88fb",
       "changed": "2026-09-11"
     },
     "/vendor/burnermail": {
-      "hash": "50c821cbbd723f4b",
+      "hash": "654b8e5b67c55eb6",
       "changed": "2026-09-11"
     },
     "/vendor/buttondown": {
-      "hash": "2431bc6b73dd149a",
+      "hash": "e7014fe130b2ddf8",
       "changed": "2026-09-11"
     },
     "/vendor/bytebase-com": {
-      "hash": "8ed40c19f8b94bde",
+      "hash": "9a14216d80f9bb93",
       "changed": "2026-09-11"
     },
     "/vendor/c2-object-storage": {
-      "hash": "01452b0cf4e25c34",
+      "hash": "01a4608f9d5595ad",
       "changed": "2026-09-11"
     },
     "/vendor/cachefly": {
-      "hash": "123f8fc02547695f",
+      "hash": "05398b4cb36ad2de",
       "changed": "2026-09-11"
     },
     "/vendor/cacher-io": {
-      "hash": "8f0f44313cd6be60",
+      "hash": "d5e4b2b746d791a9",
       "changed": "2026-09-11"
     },
     "/vendor/cachet": {
-      "hash": "873a49444f7f154b",
+      "hash": "c50f6887401a1850",
       "changed": "2026-09-11"
     },
     "/vendor/cacoo-com": {
-      "hash": "e6a7436cb3e37bd5",
+      "hash": "4536f38cb53bdc06",
       "changed": "2026-09-11"
     },
     "/vendor/cal-com": {
-      "hash": "77da8e62431204a3",
+      "hash": "318bac7a25924e13",
       "changed": "2026-09-11"
     },
     "/vendor/calendar-icons-generator": {
-      "hash": "7a4df62a1ded27f1",
+      "hash": "aa0449f806abc8b1",
       "changed": "2026-09-11"
     },
     "/vendor/calendarific": {
-      "hash": "28b8497653121b25",
+      "hash": "d7d013182eff673b",
       "changed": "2026-09-11"
     },
     "/vendor/calendly": {
-      "hash": "707858eb09767f54",
+      "hash": "29f5ea80fc19081d",
       "changed": "2026-09-11"
     },
     "/vendor/cally-com": {
-      "hash": "4391921dd8cf3643",
+      "hash": "32a508c50fba1ae4",
       "changed": "2026-09-11"
     },
     "/vendor/canopy": {
-      "hash": "6f93e9499612d68f",
+      "hash": "5e58f7d3d234b7f3",
       "changed": "2026-09-11"
     },
     "/vendor/canva": {
-      "hash": "138cbd0655435e36",
+      "hash": "f344b153f04fa43c",
       "changed": "2026-09-11"
     },
     "/vendor/captaindata": {
-      "hash": "592d755ddce67313",
+      "hash": "d51a4e0eafed0ce5",
       "changed": "2026-09-11"
     },
     "/vendor/carapi-dev": {
-      "hash": "cdbc11c7773808b3",
+      "hash": "ce0ee1d1c26986b7",
       "changed": "2026-09-11"
     },
     "/vendor/carbon-now-sh": {
-      "hash": "7814b25d2bb96cb0",
+      "hash": "60147faedf9cbb53",
       "changed": "2026-09-11"
     },
     "/vendor/carousel-hero": {
-      "hash": "77b9267a537dcf86",
+      "hash": "88c2f1917f5579fd",
       "changed": "2026-09-11"
     },
     "/vendor/carta": {
-      "hash": "352a95f5e6745ee2",
+      "hash": "019fd74d26c84055",
       "changed": "2026-09-11"
     },
     "/vendor/catchjs-com": {
-      "hash": "b9ae1da0cfdaff85",
+      "hash": "d56658917400ab71",
       "changed": "2026-09-11"
     },
     "/vendor/caviar": {
-      "hash": "6dc008d8bc4e21a7",
+      "hash": "866cfa68a8bd0842",
       "changed": "2026-09-11"
     },
     "/vendor/cdnjs-com": {
-      "hash": "9d9162c3502589fe",
+      "hash": "6927e606dc7f0e7b",
       "changed": "2026-09-11"
     },
     "/vendor/cdox": {
-      "hash": "d4f3c780342ea45c",
+      "hash": "fce88ca8cbb61943",
       "changed": "2026-09-11"
     },
     "/vendor/cerbos-hub": {
-      "hash": "4d5b3bce723eab4a",
+      "hash": "f21bea472d234df4",
       "changed": "2026-09-11"
     },
     "/vendor/cerebras": {
       "daily": true
     },
     "/vendor/certkit": {
-      "hash": "c577c9bb2eba3a42",
+      "hash": "b9db646151624212",
       "changed": "2026-09-11"
     },
     "/vendor/chanty-com": {
-      "hash": "1c10083a9319783f",
+      "hash": "91d14e44633f3cc8",
       "changed": "2026-09-11"
     },
     "/vendor/chargebee-launch-programme": {
-      "hash": "61c3ac09971c664c",
+      "hash": "b263fe6270b4a3cf",
       "changed": "2026-09-11"
     },
     "/vendor/checkbot-io": {
-      "hash": "2c29a1b25efacd9c",
+      "hash": "eab96f801d5bbd37",
       "changed": "2026-09-11"
     },
     "/vendor/checkly": {
-      "hash": "483d23c2f0c7dc50",
+      "hash": "f1cc390909ae30e8",
       "changed": "2026-09-11"
     },
     "/vendor/checkov": {
-      "hash": "c9fa88425e7bd792",
+      "hash": "68b469226c91c52c",
       "changed": "2026-09-11"
     },
     "/vendor/choreo": {
@@ -4363,120 +4363,120 @@
       "daily": true
     },
     "/vendor/chromatic": {
-      "hash": "4f8308317f808e28",
+      "hash": "33981871146d9cbe",
       "changed": "2026-09-11"
     },
     "/vendor/circleci": {
-      "hash": "97ff946b08cff08a",
+      "hash": "1912d11aabc0979a",
       "changed": "2026-09-11"
     },
     "/vendor/circum-icons": {
-      "hash": "b018b1b8e01fe720",
+      "hash": "2990f45acf85873c",
       "changed": "2026-09-11"
     },
     "/vendor/cirrus-ci-org": {
-      "hash": "dc25fad9ae190dad",
+      "hash": "1d83906be6352748",
       "changed": "2026-09-11"
     },
     "/vendor/cirun-io": {
-      "hash": "5bb833919b7537b9",
+      "hash": "f722305efb06f999",
       "changed": "2026-09-11"
     },
     "/vendor/clair": {
-      "hash": "1c055582934af528",
+      "hash": "a0a76c4a96a1f2cb",
       "changed": "2026-09-11"
     },
     "/vendor/clappia": {
-      "hash": "3b06213c71027658",
+      "hash": "b800faf2dfae192b",
       "changed": "2026-09-11"
     },
     "/vendor/clarifai": {
-      "hash": "23f2b6285fb3ba58",
+      "hash": "e7e7859a8d6a010a",
       "changed": "2026-09-11"
     },
     "/vendor/claude-code": {
       "daily": true
     },
     "/vendor/claw-cloud": {
-      "hash": "9607c348ee724c0e",
+      "hash": "3032d0ce6e672a7c",
       "changed": "2026-09-11"
     },
     "/vendor/clear-channel-outdoor": {
-      "hash": "e642fde33c38d36e",
+      "hash": "b4513b11dfd12f2c",
       "changed": "2026-09-11"
     },
     "/vendor/clerk": {
-      "hash": "272efe8fd79da4fc",
+      "hash": "974f85ce4203c3c9",
       "changed": "2026-09-11"
     },
     "/vendor/clevebrush-com": {
-      "hash": "175a433932ec6235",
+      "hash": "678bcb38003e0b28",
       "changed": "2026-09-11"
     },
     "/vendor/clever-bootstrap-program": {
-      "hash": "255943aa67115c11",
+      "hash": "4350ebd8bb5da979",
       "changed": "2026-09-11"
     },
     "/vendor/clever-cloud": {
       "daily": true
     },
     "/vendor/clickup": {
-      "hash": "4772927cf389bde5",
+      "hash": "82bc411b4522b954",
       "changed": "2026-09-11"
     },
     "/vendor/clickup-com": {
-      "hash": "d1b1e5a19b0c2f6d",
+      "hash": "85e2fc0a85ac2300",
       "changed": "2026-09-11"
     },
     "/vendor/clicky": {
-      "hash": "f44a5c362a23c1f5",
+      "hash": "fc64e0b4ec7a9dd9",
       "changed": "2026-09-11"
     },
     "/vendor/cline": {
-      "hash": "f2c6c79409ae7929",
+      "hash": "b2dbf8776c790b0b",
       "changed": "2026-09-11"
     },
     "/vendor/clockify": {
-      "hash": "a14ba2e330b11b35",
+      "hash": "ffc9c0f152f32ce8",
       "changed": "2026-09-11"
     },
     "/vendor/clockwork-micro": {
-      "hash": "def316f7358430ea",
+      "hash": "5b7cdaa636d10282",
       "changed": "2026-09-11"
     },
     "/vendor/cloud-66": {
-      "hash": "fc57e05b064af531",
+      "hash": "608e5011c14342ee",
       "changed": "2026-09-11"
     },
     "/vendor/cloud-iam": {
-      "hash": "c8d6fbb7f8d4f194",
+      "hash": "427bc901065b600e",
       "changed": "2026-09-11"
     },
     "/vendor/cloudamqp": {
-      "hash": "d94e2d04bd03f36f",
+      "hash": "34a0e2e6db3ecc49",
       "changed": "2026-09-11"
     },
     "/vendor/cloudconvert-com": {
-      "hash": "5f6d817022c969a8",
+      "hash": "357e210b6e2a2af5",
       "changed": "2026-09-11"
     },
     "/vendor/cloudcraft": {
-      "hash": "dd859ec4908c54d1",
+      "hash": "e8803f6ee8deb38c",
       "changed": "2026-09-11"
     },
     "/vendor/clouddev": {
-      "hash": "5c6afea7308ab761",
+      "hash": "a583740e9704b500",
       "changed": "2026-09-11"
     },
     "/vendor/cloudflare": {
-      "hash": "12f370289f0b6463",
+      "hash": "a4e62fcd08f90472",
       "changed": "2026-09-11"
     },
     "/vendor/cloudflare-d1": {
       "daily": true
     },
     "/vendor/cloudflare-dns": {
-      "hash": "e74c8310b54d36e9",
+      "hash": "c064bf1cce0241cd",
       "changed": "2026-09-11"
     },
     "/vendor/cloudflare-durable-objects": {
@@ -4489,25 +4489,25 @@
       "daily": true
     },
     "/vendor/cloudflare-mesh": {
-      "hash": "545f569f51912a09",
+      "hash": "a1ba286aea6df275",
       "changed": "2026-09-11"
     },
     "/vendor/cloudflare-pages": {
       "daily": true
     },
     "/vendor/cloudflare-queues": {
-      "hash": "4bfcd9e8f07876f2",
+      "hash": "6ac69a77dd6a8096",
       "changed": "2026-09-11"
     },
     "/vendor/cloudflare-r2": {
-      "hash": "c9169e0f56c5753c",
+      "hash": "5c0f07c601007c25",
       "changed": "2026-09-11"
     },
     "/vendor/cloudflare-sandboxes": {
       "daily": true
     },
     "/vendor/cloudflare-warp": {
-      "hash": "b08701530c968877",
+      "hash": "cd00d9b8af7dba98",
       "changed": "2026-09-11"
     },
     "/vendor/cloudflare-workers": {
@@ -4517,407 +4517,407 @@
       "daily": true
     },
     "/vendor/cloudimage": {
-      "hash": "967e7a1306642452",
+      "hash": "30dad80927d26c44",
       "changed": "2026-09-11"
     },
     "/vendor/cloudinary": {
-      "hash": "93ae8de4c7f5b610",
+      "hash": "d421cbaf2d20b756",
       "changed": "2026-09-11"
     },
     "/vendor/cloudmersive": {
-      "hash": "06870c6445168303",
+      "hash": "0e0b531e3363084a",
       "changed": "2026-09-11"
     },
     "/vendor/cloudns": {
-      "hash": "53dcf76d6aab4926",
+      "hash": "9450bf3721acdab1",
       "changed": "2026-09-11"
     },
     "/vendor/cloudtalk": {
-      "hash": "0a5f14939f8310af",
+      "hash": "02f18a4047350fd4",
       "changed": "2026-09-11"
     },
     "/vendor/cloudways": {
-      "hash": "c8a17879aac872b6",
+      "hash": "e9ca1725bce7eb06",
       "changed": "2026-09-11"
     },
     "/vendor/cmyk-pantone": {
-      "hash": "0c86d55e8a726219",
+      "hash": "e206cfbf9b32dfba",
       "changed": "2026-09-11"
     },
     "/vendor/cname-dev": {
-      "hash": "6efdf9518e21e545",
+      "hash": "102eb5568560e7f2",
       "changed": "2026-09-11"
     },
     "/vendor/cocalc-com": {
-      "hash": "aa2a12bda0277ff7",
+      "hash": "d1b6e4d6f7945d49",
       "changed": "2026-09-11"
     },
     "/vendor/cockroachdb": {
       "daily": true
     },
     "/vendor/coda": {
-      "hash": "0ee98ab475894cc6",
+      "hash": "7125025e6409e86e",
       "changed": "2026-09-11"
     },
     "/vendor/codacy-com": {
-      "hash": "f7c211f5b4c31108",
+      "hash": "bce08941b6d89575",
       "changed": "2026-09-11"
     },
     "/vendor/code-blocks": {
-      "hash": "78ad40b9a498bea2",
+      "hash": "7a3e34133f7b6ab3",
       "changed": "2026-09-11"
     },
     "/vendor/code-cs50-io": {
-      "hash": "5437c834636de1eb",
+      "hash": "050d476c29b5090d",
       "changed": "2026-09-11"
     },
     "/vendor/code-time": {
-      "hash": "4d154d1677328788",
+      "hash": "cace95d2fc09b17f",
       "changed": "2026-09-11"
     },
     "/vendor/codeac-io": {
-      "hash": "863c6c7752337461",
+      "hash": "b14c95bcb3d21168",
       "changed": "2026-09-11"
     },
     "/vendor/codeberg": {
-      "hash": "2a04bcecbdbf1d4b",
+      "hash": "8ee0243d8ff9e659",
       "changed": "2026-09-11"
     },
     "/vendor/codecov": {
-      "hash": "7e7cbd8833698040",
+      "hash": "e0082da707a555a1",
       "changed": "2026-09-11"
     },
     "/vendor/codedthemes": {
-      "hash": "3f8f6dd3bcc8ab39",
+      "hash": "4b01768fa35666fc",
       "changed": "2026-09-11"
     },
     "/vendor/codefactor": {
-      "hash": "556bd115b678e1e7",
+      "hash": "7f2ab0777915ba73",
       "changed": "2026-09-11"
     },
     "/vendor/codefresh": {
-      "hash": "0888a146d93ff757",
+      "hash": "1d9ed5113ee31dad",
       "changed": "2026-09-11"
     },
     "/vendor/codehooks-io": {
       "daily": true
     },
     "/vendor/codekeep": {
-      "hash": "8ea6e1001b1994ec",
+      "hash": "b0e65f47cad11e7b",
       "changed": "2026-09-11"
     },
     "/vendor/codemagic": {
-      "hash": "1d64dd0de0039fea",
+      "hash": "45c2ba101f0f55b9",
       "changed": "2026-09-11"
     },
     "/vendor/codemyui": {
-      "hash": "fadb63ab3524ad9e",
+      "hash": "39bedc122451cb9e",
       "changed": "2026-09-11"
     },
     "/vendor/codenameone-com": {
-      "hash": "537296a2b4e6999c",
+      "hash": "8b4c653154e8f080",
       "changed": "2026-09-11"
     },
     "/vendor/codepen-io": {
-      "hash": "9b13ea80d576608f",
+      "hash": "490dd3352d587654",
       "changed": "2026-09-11"
     },
     "/vendor/codepng": {
-      "hash": "a93b878d6c0ebfed",
+      "hash": "f680c54bb9204e50",
       "changed": "2026-09-11"
     },
     "/vendor/codeql": {
-      "hash": "ccd187298bc846e8",
+      "hash": "ffb633dcc25db069",
       "changed": "2026-09-11"
     },
     "/vendor/coderabbit-ai": {
-      "hash": "132e3c18014a6add",
+      "hash": "0e2658c5d0d09b16",
       "changed": "2026-09-11"
     },
     "/vendor/codesandbox-io": {
-      "hash": "f9cd9563e0a426da",
+      "hash": "a49326f1494473b1",
       "changed": "2026-09-11"
     },
     "/vendor/codetoimage": {
-      "hash": "9b0d90b15a0230f4",
+      "hash": "77cd048dcaebb7a9",
       "changed": "2026-09-11"
     },
     "/vendor/codspeed": {
-      "hash": "52738b331e6799af",
+      "hash": "352a01e4b7995698",
       "changed": "2026-09-11"
     },
     "/vendor/cohere": {
       "daily": true
     },
     "/vendor/coinmarketcap": {
-      "hash": "57b3c2f9cf420b5f",
+      "hash": "b1f794878d58d2fe",
       "changed": "2026-09-11"
     },
     "/vendor/coldcrm": {
-      "hash": "aa5012f68ed5deab",
+      "hash": "860a61defd400999",
       "changed": "2026-09-11"
     },
     "/vendor/colorkit": {
-      "hash": "4de808f021499c16",
+      "hash": "a487abfc54edf42e",
       "changed": "2026-09-11"
     },
     "/vendor/comet-ml": {
       "daily": true
     },
     "/vendor/composio": {
-      "hash": "75dc8de92d82cf72",
+      "hash": "47463af0cfc2e957",
       "changed": "2026-09-11"
     },
     "/vendor/configcat": {
-      "hash": "12060d6ae34aacee",
+      "hash": "590f3ce172596d7c",
       "changed": "2026-09-11"
     },
     "/vendor/connectycube-com": {
-      "hash": "c639296fbcae89f4",
+      "hash": "4335999e12dc8966",
       "changed": "2026-09-11"
     },
     "/vendor/container-registry-service": {
-      "hash": "1ce03b2dbf35f014",
+      "hash": "e9041ce51c73e65c",
       "changed": "2026-09-11"
     },
     "/vendor/contentful": {
-      "hash": "42181646c70b974c",
+      "hash": "551b5d18ab6d862d",
       "changed": "2026-09-11"
     },
     "/vendor/conversion-tools": {
-      "hash": "541671df83496b70",
+      "hash": "aad72a5a47eea3d5",
       "changed": "2026-09-11"
     },
     "/vendor/convex": {
       "daily": true
     },
     "/vendor/conveyor-cloud": {
-      "hash": "3d58194d19949943",
+      "hash": "b36064bb5e62b600",
       "changed": "2026-09-11"
     },
     "/vendor/coolify": {
-      "hash": "211ba4dc4c012655",
+      "hash": "a6f7789fa8c3b117",
       "changed": "2026-09-11"
     },
     "/vendor/coolors": {
-      "hash": "9590922a15deef02",
+      "hash": "39fa543c42b733dd",
       "changed": "2026-09-11"
     },
     "/vendor/copr-fedorainfracloud-org": {
-      "hash": "e6b5b7162804c9b9",
+      "hash": "fb500ff8a0f891dd",
       "changed": "2026-09-11"
     },
     "/vendor/core-web-vitals-history": {
-      "hash": "0235eae55f6d8e76",
+      "hash": "38e4d345c33fabfc",
       "changed": "2026-09-11"
     },
     "/vendor/corgea": {
-      "hash": "fdc2602a96fa5d4d",
+      "hash": "2cabd5acd425b58f",
       "changed": "2026-09-11"
     },
     "/vendor/cors-tester": {
-      "hash": "ae9a577b14e1f5d7",
+      "hash": "7f2f4336339eda41",
       "changed": "2026-09-11"
     },
     "/vendor/cosmic": {
-      "hash": "a34e0f36f647f08e",
+      "hash": "4d4541c922bb1911",
       "changed": "2026-09-11"
     },
     "/vendor/couchbase-capella": {
       "daily": true
     },
     "/vendor/counter-dev": {
-      "hash": "630f6f7eb5f9eae8",
+      "hash": "9e4ab649705874de",
       "changed": "2026-09-11"
     },
     "/vendor/country-state-city-microservice-api": {
-      "hash": "2c2084a2c5f3f5dd",
+      "hash": "c022450b3a880702",
       "changed": "2026-09-11"
     },
     "/vendor/coupler": {
-      "hash": "d37b54f73b7ba0a9",
+      "hash": "b69de395d0586a95",
       "changed": "2026-09-11"
     },
     "/vendor/courier-com": {
-      "hash": "abee8a32e5196298",
+      "hash": "48fa39cdcb2b9f69",
       "changed": "2026-09-11"
     },
     "/vendor/coursera": {
-      "hash": "231b4b5d6f39e0dc",
+      "hash": "13763c5a5e9f505a",
       "changed": "2026-09-11"
     },
     "/vendor/coveralls-io": {
-      "hash": "5b21dc2676c510d5",
+      "hash": "746965df9e2a340f",
       "changed": "2026-09-11"
     },
     "/vendor/craftmypdf": {
-      "hash": "13281d2c8da1d0bb",
+      "hash": "144bdb4bdfa2c8e1",
       "changed": "2026-09-11"
     },
     "/vendor/cratedb": {
       "daily": true
     },
     "/vendor/create-alibaba-cloud": {
-      "hash": "c70a0ae57ec16d42",
+      "hash": "820bb568e119d10a",
       "changed": "2026-09-11"
     },
     "/vendor/crisp": {
-      "hash": "56a842b96671fc3f",
+      "hash": "eae63df95d442a33",
       "changed": "2026-09-11"
     },
     "/vendor/cron-job-org": {
-      "hash": "b5a903a27cee6006",
+      "hash": "561706b704c09f55",
       "changed": "2026-09-11"
     },
     "/vendor/cronhooks": {
-      "hash": "8e56b20144702595",
+      "hash": "bddeb28852985de9",
       "changed": "2026-09-11"
     },
     "/vendor/cronitor": {
       "daily": true
     },
     "/vendor/crosswork": {
-      "hash": "60fcea8e29547a18",
+      "hash": "7209a9f4f4be393e",
       "changed": "2026-09-11"
     },
     "/vendor/crowdfire": {
-      "hash": "903267f94843d926",
+      "hash": "4977f882c5b9800b",
       "changed": "2026-09-11"
     },
     "/vendor/crowdin": {
-      "hash": "4a229e33f40ea379",
+      "hash": "43014c13c57f09d1",
       "changed": "2026-09-11"
     },
     "/vendor/crypteron-com": {
-      "hash": "9556e9940792f2e1",
+      "hash": "eb9ab654ed6a99f1",
       "changed": "2026-09-11"
     },
     "/vendor/crystallize": {
-      "hash": "2b3fc1f4ee032a3e",
+      "hash": "d64dff160ac81e21",
       "changed": "2026-09-11"
     },
     "/vendor/css-glass": {
-      "hash": "9306f8e5937bab7c",
+      "hash": "4ce9a7f9d7ff297a",
       "changed": "2026-09-11"
     },
     "/vendor/css-gradient-com": {
-      "hash": "2b8dce3e6f4902ea",
+      "hash": "7873b4f031e109f6",
       "changed": "2026-09-11"
     },
     "/vendor/cstate": {
-      "hash": "cfa96cb681e9e704",
+      "hash": "af99534f0ae2f634",
       "changed": "2026-09-11"
     },
     "/vendor/cube": {
-      "hash": "565ab849e606a59e",
+      "hash": "789d04301f0b7191",
       "changed": "2026-09-11"
     },
     "/vendor/curlhub": {
-      "hash": "e995f8ed152cfa1b",
+      "hash": "a881485147d27f1c",
       "changed": "2026-09-11"
     },
     "/vendor/currencyapi": {
-      "hash": "3d0eac4b1f41a7b0",
+      "hash": "3e35f72d011ce7f0",
       "changed": "2026-09-11"
     },
     "/vendor/currencyfreaks": {
-      "hash": "983e8c81176e4f55",
+      "hash": "82d3f4ca9b660938",
       "changed": "2026-09-11"
     },
     "/vendor/currencylayer": {
-      "hash": "aecfa7bb82445786",
+      "hash": "70ff2ffff6ac1a05",
       "changed": "2026-09-11"
     },
     "/vendor/currencyscoop": {
-      "hash": "4bf1393a3f19deef",
+      "hash": "929ba502032afc62",
       "changed": "2026-09-11"
     },
     "/vendor/cursor": {
       "daily": true
     },
     "/vendor/customjs": {
-      "hash": "836cca2282effd80",
+      "hash": "788d5db7ce9b3bb6",
       "changed": "2026-09-11"
     },
     "/vendor/cyberchef": {
-      "hash": "6d2df329af723e4b",
+      "hash": "92cccd4f58035aaf",
       "changed": "2026-09-11"
     },
     "/vendor/cypress-cloud": {
-      "hash": "ee2edcd5d059642d",
+      "hash": "cfdb4c0e6e73a53e",
       "changed": "2026-09-11"
     },
     "/vendor/dadroit-v-web": {
-      "hash": "40f701daed4a69b7",
+      "hash": "8a5cf18f9215274a",
       "changed": "2026-09-11"
     },
     "/vendor/daestro": {
       "daily": true
     },
     "/vendor/daily-co": {
-      "hash": "29de999d94af844a",
+      "hash": "fddb9117f0af5ee1",
       "changed": "2026-09-11"
     },
     "/vendor/daisyui": {
-      "hash": "f18f015dd7d8b198",
+      "hash": "1cbf122666e5a3a1",
       "changed": "2026-09-11"
     },
     "/vendor/dappling-network": {
       "daily": true
     },
     "/vendor/dareboost": {
-      "hash": "a8edef05f7143043",
+      "hash": "095b12ab62afb51c",
       "changed": "2026-09-11"
     },
     "/vendor/data-fetcher": {
-      "hash": "eb9d59f39894fc81",
+      "hash": "87172afeb0c37287",
       "changed": "2026-09-11"
     },
     "/vendor/data-miner": {
-      "hash": "f6373a5203dd8941",
+      "hash": "1f27638435dc5177",
       "changed": "2026-09-11"
     },
     "/vendor/databricks-lakeflow-connect": {
-      "hash": "907327e104148067",
+      "hash": "f47ab7293c32a272",
       "changed": "2026-09-11"
     },
     "/vendor/datadog": {
       "daily": true
     },
     "/vendor/dataimporter-io": {
-      "hash": "23ea1125351b7fd4",
+      "hash": "bb28f13a80463cdb",
       "changed": "2026-09-11"
     },
     "/vendor/datalore": {
-      "hash": "bfeef2ec24fed4cb",
+      "hash": "8ff23bc190d2219f",
       "changed": "2026-09-11"
     },
     "/vendor/datananas": {
-      "hash": "ec68e72af16843bb",
+      "hash": "0544049d992fbac9",
       "changed": "2026-09-11"
     },
     "/vendor/datelist-io": {
-      "hash": "18a2314a23bc91b5",
+      "hash": "884e288f7541118b",
       "changed": "2026-09-11"
     },
     "/vendor/datocms": {
-      "hash": "5f56419c97548b33",
+      "hash": "5f1eb848c8b4fd51",
       "changed": "2026-09-11"
     },
     "/vendor/datree": {
-      "hash": "8d6da50c572f6848",
+      "hash": "501d04a3e8577cbe",
       "changed": "2026-09-11"
     },
     "/vendor/davinci-resolve": {
-      "hash": "f40f4e889e093bf1",
+      "hash": "d6620e6e1d48d107",
       "changed": "2026-09-11"
     },
     "/vendor/db-designer": {
-      "hash": "a150769614c4d435",
+      "hash": "49acb728cdf4c5b2",
       "changed": "2026-09-11"
     },
     "/vendor/db-ip": {
-      "hash": "caa71499bdc6eba7",
+      "hash": "cf2ca310c0f0caaf",
       "changed": "2026-09-11"
     },
     "/vendor/dbos": {
@@ -4927,329 +4927,329 @@
       "daily": true
     },
     "/vendor/debugmail-io": {
-      "hash": "6c94c4c50d65ad56",
+      "hash": "d9c645f9899dbf45",
       "changed": "2026-09-11"
     },
     "/vendor/deepar": {
-      "hash": "45274b40e242d4a6",
+      "hash": "f17e2c91256d16d3",
       "changed": "2026-09-11"
     },
     "/vendor/deepgram": {
       "daily": true
     },
     "/vendor/deepnote": {
-      "hash": "4c76505d55ac7d07",
+      "hash": "67261997d911aa71",
       "changed": "2026-09-11"
     },
     "/vendor/deepscan-io": {
-      "hash": "c34846bde2099939",
+      "hash": "4f60d4aa0c1b664d",
       "changed": "2026-09-11"
     },
     "/vendor/deepseek-api": {
       "daily": true
     },
     "/vendor/deepsource": {
-      "hash": "906ad8288de35238",
+      "hash": "a65b3390c549b1da",
       "changed": "2026-09-11"
     },
     "/vendor/degoo-com": {
-      "hash": "9243845497596094",
+      "hash": "7863b5c7d57977cf",
       "changed": "2026-09-11"
     },
     "/vendor/deno-deploy": {
       "daily": true
     },
     "/vendor/dependabot": {
-      "hash": "249a086856dae431",
+      "hash": "adfa453dc35d4aae",
       "changed": "2026-09-11"
     },
     "/vendor/deployhq-com": {
-      "hash": "f74827802264ce60",
+      "hash": "d89c8d47db091bc0",
       "changed": "2026-09-11"
     },
     "/vendor/deployment-io": {
-      "hash": "d81cead7c5f45b56",
+      "hash": "d29604d578ccc4a6",
       "changed": "2026-09-11"
     },
     "/vendor/descope": {
-      "hash": "78520a259adaccf5",
+      "hash": "eedd1349f8c4c8d8",
       "changed": "2026-09-11"
     },
     "/vendor/desec": {
-      "hash": "71675db74c8ef7f6",
+      "hash": "8d7d269dfd4a8949",
       "changed": "2026-09-11"
     },
     "/vendor/developers-google-com": {
-      "hash": "3c7e8639b19a6ceb",
+      "hash": "322820028071beb0",
       "changed": "2026-09-11"
     },
     "/vendor/devin": {
-      "hash": "9169fe843cf66f2b",
+      "hash": "b644c42fbc18c1d7",
       "changed": "2026-09-11"
     },
     "/vendor/devtoollab": {
-      "hash": "6aaed93049339477",
+      "hash": "2bb74d88860e2cf4",
       "changed": "2026-09-11"
     },
     "/vendor/dhiwise": {
-      "hash": "415424938591aef6",
+      "hash": "49cdc6da0fa2d24d",
       "changed": "2026-09-11"
     },
     "/vendor/diagrams-net": {
-      "hash": "6b4a16913af69638",
+      "hash": "3a47ed960113fd6f",
       "changed": "2026-09-11"
     },
     "/vendor/diawi": {
-      "hash": "712854c671113797",
+      "hash": "4e01984aee5bf482",
       "changed": "2026-09-11"
     },
     "/vendor/diffjson": {
-      "hash": "8ba5aff9fc2feaa0",
+      "hash": "e078af714c3a0fb3",
       "changed": "2026-09-11"
     },
     "/vendor/difftext": {
-      "hash": "948439f5c346950b",
+      "hash": "8978689fbb9155d3",
       "changed": "2026-09-11"
     },
     "/vendor/digitalocean": {
       "daily": true
     },
     "/vendor/digitalocean-dns": {
-      "hash": "f452db3477924853",
+      "hash": "37b43b5fb5987bbf",
       "changed": "2026-09-11"
     },
     "/vendor/digitalplat": {
-      "hash": "6f17212e4599a1aa",
+      "hash": "f79403e7a4b23e87",
       "changed": "2026-09-11"
     },
     "/vendor/directus": {
-      "hash": "e09cfdd6ec49115e",
+      "hash": "95b3643ea4340951",
       "changed": "2026-09-11"
     },
     "/vendor/discord": {
-      "hash": "043283c0fc59322d",
+      "hash": "0aac16261c433a67",
       "changed": "2026-09-11"
     },
     "/vendor/discord-api": {
-      "hash": "fcd171fd34290949",
+      "hash": "03d3f614582b35de",
       "changed": "2026-09-11"
     },
     "/vendor/disease-sh": {
-      "hash": "0db8367c33c681ce",
+      "hash": "21f12142b8b40f71",
       "changed": "2026-09-11"
     },
     "/vendor/dj-checkup": {
-      "hash": "9baa0fa7e24a778c",
+      "hash": "6fd6df1918a5738c",
       "changed": "2026-09-11"
     },
     "/vendor/dkimvalidator-com": {
-      "hash": "fb645d0caf5a898f",
+      "hash": "ab28679e9a8dde2c",
       "changed": "2026-09-11"
     },
     "/vendor/dnsexit": {
-      "hash": "12c612d3f7e08a56",
+      "hash": "ee30bff4185a4c16",
       "changed": "2026-09-11"
     },
     "/vendor/dnspod-com": {
-      "hash": "9f21a0ca7b346f6d",
+      "hash": "e66b5b0bce88d72d",
       "changed": "2026-09-11"
     },
     "/vendor/docbeacon": {
-      "hash": "7b5c0235d4ab3804",
+      "hash": "fda6283957779678",
       "changed": "2026-09-11"
     },
     "/vendor/docker-hub": {
       "daily": true
     },
     "/vendor/docsend": {
-      "hash": "fa160e048c2b9a34",
+      "hash": "4841ca3511f61843",
       "changed": "2026-09-11"
     },
     "/vendor/docusaurus": {
-      "hash": "e22c13eea42e99a5",
+      "hash": "cbdb7254f5444890",
       "changed": "2026-09-11"
     },
     "/vendor/doczilla": {
-      "hash": "fda3833e672d349f",
+      "hash": "7ceb0927c893da15",
       "changed": "2026-09-11"
     },
     "/vendor/domain-forward": {
-      "hash": "736731a7ac24c3f1",
+      "hash": "bf5133ce48774c70",
       "changed": "2026-09-11"
     },
     "/vendor/domcloud-co": {
       "daily": true
     },
     "/vendor/doppio": {
-      "hash": "b6428f2f73b3b4da",
+      "hash": "6ab9fb3588943305",
       "changed": "2026-09-11"
     },
     "/vendor/doppler": {
-      "hash": "8389e741e6b10784",
+      "hash": "d2a62ae65f955749",
       "changed": "2026-09-11"
     },
     "/vendor/dotenv": {
-      "hash": "6edad9b929a6198f",
+      "hash": "937607099a64117c",
       "changed": "2026-09-11"
     },
     "/vendor/downtimemonkey-com": {
       "daily": true
     },
     "/vendor/drawdb": {
-      "hash": "6fa88b80f7288071",
+      "hash": "e685ba293497ad14",
       "changed": "2026-09-11"
     },
     "/vendor/drift-for-early-stage-startups": {
-      "hash": "001041b699ee60b5",
+      "hash": "797e307088330d67",
       "changed": "2026-09-11"
     },
     "/vendor/drone-ci": {
-      "hash": "1f0ed0aa82ee1816",
+      "hash": "b00b89d5b6b36585",
       "changed": "2026-09-11"
     },
     "/vendor/dropbox": {
-      "hash": "97a33200a4e92115",
+      "hash": "01e02a63d2655354",
       "changed": "2026-09-11"
     },
     "/vendor/dropshare": {
-      "hash": "72cd1eeeb02dfb3d",
+      "hash": "9ccc0f1a678bec23",
       "changed": "2026-09-11"
     },
     "/vendor/dub-co": {
-      "hash": "81dbe6cc40636d9a",
+      "hash": "12fa757b8971e3a7",
       "changed": "2026-09-11"
     },
     "/vendor/duckdns-org": {
-      "hash": "28405cd36e78c289",
+      "hash": "0256a90c182067fa",
       "changed": "2026-09-11"
     },
     "/vendor/duckly": {
-      "hash": "02529f417943657f",
+      "hash": "6d4535eaca334d5b",
       "changed": "2026-09-11"
     },
     "/vendor/duo-com": {
-      "hash": "472fc0c92dc835bd",
+      "hash": "e46d3e83631e8c41",
       "changed": "2026-09-11"
     },
     "/vendor/duolingo": {
-      "hash": "1917829b383ed76d",
+      "hash": "8be876e3a29a69c6",
       "changed": "2026-09-11"
     },
     "/vendor/dwh-dev": {
-      "hash": "21e0198724ae7f07",
+      "hash": "c8ba37e941d1c00e",
       "changed": "2026-09-11"
     },
     "/vendor/dynamicdocs": {
-      "hash": "e17b3285cba5ef05",
+      "hash": "037e67a30bb0d658",
       "changed": "2026-09-11"
     },
     "/vendor/dynamodb-local": {
-      "hash": "3b82a39ddc26942e",
+      "hash": "00fd2f6cd11a569d",
       "changed": "2026-09-11"
     },
     "/vendor/dynv6-com": {
-      "hash": "7aef6658bb437853",
+      "hash": "8b04a46451a1d2d1",
       "changed": "2026-09-11"
     },
     "/vendor/e-goi": {
-      "hash": "a39c2ae9ca7aa1b4",
+      "hash": "d47775aa7550708e",
       "changed": "2026-09-11"
     },
     "/vendor/e2b": {
       "daily": true
     },
     "/vendor/easyretro-io": {
-      "hash": "cbec8a0b38e2cb63",
+      "hash": "06ef0b85b1069027",
       "changed": "2026-09-11"
     },
     "/vendor/eclipse-che": {
-      "hash": "e71c251721fd4ca5",
+      "hash": "7f0c8c85a5925d3a",
       "changed": "2026-09-11"
     },
     "/vendor/economize-cloud": {
-      "hash": "bb6e7149558a13e0",
+      "hash": "5e54f0b0e8a0b000",
       "changed": "2026-09-11"
     },
     "/vendor/edx": {
-      "hash": "dc9397adf36e32e3",
+      "hash": "aff0a7b3b069c90a",
       "changed": "2026-09-11"
     },
     "/vendor/elastic": {
       "daily": true
     },
     "/vendor/elasticmq": {
-      "hash": "9cdfdbb5d04de847",
+      "hash": "628892b9bfcffa19",
       "changed": "2026-09-11"
     },
     "/vendor/element-io": {
-      "hash": "46630d728912eb05",
+      "hash": "f12ea498ffd2d22c",
       "changed": "2026-09-11"
     },
     "/vendor/elmah-io": {
-      "hash": "95e74105b78d1da7",
+      "hash": "dc4afb4010f2b602",
       "changed": "2026-09-11"
     },
     "/vendor/emailjs": {
-      "hash": "f14f1787e3bb60b5",
+      "hash": "136c80de6f9527c7",
       "changed": "2026-09-11"
     },
     "/vendor/emaillabs-io": {
-      "hash": "cd2c6911abce0a11",
+      "hash": "def55e68493d66ee",
       "changed": "2026-09-11"
     },
     "/vendor/emailoctopus": {
-      "hash": "b660c81bacb4f813",
+      "hash": "5c3d06a594da9d6c",
       "changed": "2026-09-11"
     },
     "/vendor/emailvalidation-io": {
-      "hash": "215420cb00b6b611",
+      "hash": "d71cb7ebb2e87cd8",
       "changed": "2026-09-11"
     },
     "/vendor/embed-ly": {
-      "hash": "47bd8bbf2e0bbee0",
+      "hash": "9e75ad3356129844",
       "changed": "2026-09-11"
     },
     "/vendor/embrace": {
-      "hash": "b5bb9d8eed6cb199",
+      "hash": "c3ee2a8bafcc077f",
       "changed": "2026-09-11"
     },
     "/vendor/emqx-serverless": {
-      "hash": "68d4b53c35bf2946",
+      "hash": "69c9420dcb1727b2",
       "changed": "2026-09-11"
     },
     "/vendor/encore-dev": {
       "daily": true
     },
     "/vendor/engage": {
-      "hash": "29709f4efc8e37c3",
+      "hash": "e97c6343dd31047a",
       "changed": "2026-09-11"
     },
     "/vendor/engagespot-co": {
-      "hash": "294b269188982971",
+      "hash": "b4cb2bf05842cafa",
       "changed": "2026-09-11"
     },
     "/vendor/ente": {
-      "hash": "77dce77d82165b89",
+      "hash": "851fabe91650949b",
       "changed": "2026-09-11"
     },
     "/vendor/esm-sh": {
-      "hash": "a2db0f9908101176",
+      "hash": "11828934b8d22e89",
       "changed": "2026-09-11"
     },
     "/vendor/esri-startup-program": {
-      "hash": "18299e3433b86c8e",
+      "hash": "cba8b44e465619a8",
       "changed": "2026-09-11"
     },
     "/vendor/etherealmail": {
-      "hash": "1bb1828c032c3a93",
+      "hash": "bde1ddb1e85c884f",
       "changed": "2026-09-11"
     },
     "/vendor/etlr": {
-      "hash": "cee8e1b82e38c5d0",
+      "hash": "78e939996e556d6d",
       "changed": "2026-09-11"
     },
     "/vendor/evernote": {
-      "hash": "9faa39fd5f793487",
+      "hash": "9bdab49b51c04467",
       "changed": "2026-09-11"
     },
     "/vendor/everystep-automation-com": {
@@ -5259,109 +5259,109 @@
       "daily": true
     },
     "/vendor/excalidraw": {
-      "hash": "697694c5f0ac2301",
+      "hash": "1200686befd13a1a",
       "changed": "2026-09-11"
     },
     "/vendor/exceptionless": {
-      "hash": "ee69696b0a10af00",
+      "hash": "d1b52c79ca260d5d",
       "changed": "2026-09-11"
     },
     "/vendor/exchangerate-api-com": {
-      "hash": "fbe729b02dc37373",
+      "hash": "e3ec13c1f172e3e2",
       "changed": "2026-09-11"
     },
     "/vendor/exif-editor": {
-      "hash": "64eef17864267ea5",
+      "hash": "6108f64256229e91",
       "changed": "2026-09-11"
     },
     "/vendor/expensify": {
-      "hash": "1451185e8148aef9",
+      "hash": "3e7818f67ee576c5",
       "changed": "2026-09-11"
     },
     "/vendor/experian": {
-      "hash": "64be2676b780451a",
+      "hash": "d8705991d7c7a148",
       "changed": "2026-09-11"
     },
     "/vendor/expo": {
-      "hash": "df65eb6ae2cdf60e",
+      "hash": "99dfdd4a3c72f8e1",
       "changed": "2026-09-11"
     },
     "/vendor/export-sdk": {
-      "hash": "425c5d5eb96e6d90",
+      "hash": "f44c89b113c1a6d6",
       "changed": "2026-09-11"
     },
     "/vendor/expose": {
-      "hash": "4a974505241ae8b6",
+      "hash": "542ef9dc0babdc07",
       "changed": "2026-09-11"
     },
     "/vendor/extendsclass": {
-      "hash": "d48061137d58c386",
+      "hash": "9b8d8f5ddd180f8f",
       "changed": "2026-09-11"
     },
     "/vendor/fabform": {
-      "hash": "e1f142152502fa7f",
+      "hash": "4574fdbff1d565d1",
       "changed": "2026-09-11"
     },
     "/vendor/falco": {
-      "hash": "133152e9edb00e53",
+      "hash": "b8dbf72fc0cdd213",
       "changed": "2026-09-11"
     },
     "/vendor/fastly": {
-      "hash": "3a2894cac653aa8f",
+      "hash": "a7140b943d1ac2d9",
       "changed": "2026-09-11"
     },
     "/vendor/feathery": {
-      "hash": "4a3c3ca87995fea4",
+      "hash": "03c86894b6a1b9cc",
       "changed": "2026-09-11"
     },
     "/vendor/feedback-fish": {
-      "hash": "230ae786cac363a4",
+      "hash": "29a5466a041ea90f",
       "changed": "2026-09-11"
     },
     "/vendor/feedbear": {
-      "hash": "0e1067e0c5b95a2c",
+      "hash": "fa7ed6da810d2626",
       "changed": "2026-09-11"
     },
     "/vendor/fibery": {
-      "hash": "6f478e672387534c",
+      "hash": "db594e166d6bc45e",
       "changed": "2026-09-11"
     },
     "/vendor/fibo": {
-      "hash": "c67aac95ed072ca0",
+      "hash": "ba6e529bf6f56be0",
       "changed": "2026-09-11"
     },
     "/vendor/figma": {
-      "hash": "93379661366e2f90",
+      "hash": "8bd3df26147ac387",
       "changed": "2026-09-11"
     },
     "/vendor/file-io": {
-      "hash": "b38065ccd122ef6f",
+      "hash": "8d1d302ed76a8fb6",
       "changed": "2026-09-11"
     },
     "/vendor/filebase": {
-      "hash": "dbdc1d2b563b5711",
+      "hash": "c028cb78634c47d9",
       "changed": "2026-09-11"
     },
     "/vendor/filess-io": {
       "daily": true
     },
     "/vendor/financial-data": {
-      "hash": "9db8c06c9ff1b9c6",
+      "hash": "e3fb975a6ab4ddbf",
       "changed": "2026-09-11"
     },
     "/vendor/findmassleads": {
-      "hash": "0844e13ee544da87",
+      "hash": "17dee373cd87a311",
       "changed": "2026-09-11"
     },
     "/vendor/fingerprint": {
-      "hash": "ed3937ddc92a3c62",
+      "hash": "bc978ecbda457791",
       "changed": "2026-09-11"
     },
     "/vendor/firebase": {
       "daily": true
     },
     "/vendor/firecrawl": {
-      "hash": "aa958f77343d9d6a",
+      "hash": "123c0d2007229276",
       "changed": "2026-09-11"
     },
     "/vendor/fireworks-ai": {
@@ -5371,314 +5371,314 @@
       "daily": true
     },
     "/vendor/fivetran-activations": {
-      "hash": "fa7d483a56357f00",
+      "hash": "434e2fc269f57da0",
       "changed": "2026-09-11"
     },
     "/vendor/fizzy": {
-      "hash": "e860a3eddf019d91",
+      "hash": "8937032f31ac62d4",
       "changed": "2026-09-11"
     },
     "/vendor/flagsmith": {
-      "hash": "9bf7f4a566ff0bc4",
+      "hash": "0125593b26960f5c",
       "changed": "2026-09-11"
     },
     "/vendor/flat-social": {
-      "hash": "90da39bb51802fe7",
+      "hash": "06f89d95c4c8edf4",
       "changed": "2026-09-11"
     },
     "/vendor/flickr": {
-      "hash": "a310942169ac95c7",
+      "hash": "25ca3c853299dfd1",
       "changed": "2026-09-11"
     },
     "/vendor/flightcontrol-dev": {
       "daily": true
     },
     "/vendor/float-ui": {
-      "hash": "5476298eebb04d05",
+      "hash": "ffb918ca02e45b3d",
       "changed": "2026-09-11"
     },
     "/vendor/floci": {
-      "hash": "95cfd7ce98919892",
+      "hash": "4b49e4964e4fff47",
       "changed": "2026-09-11"
     },
     "/vendor/flock-com": {
-      "hash": "1b5f995be1773d32",
+      "hash": "62573de99142284f",
       "changed": "2026-09-11"
     },
     "/vendor/flows": {
-      "hash": "176e33a9e99e1dfb",
+      "hash": "08c15e1b26cec02a",
       "changed": "2026-09-11"
     },
     "/vendor/flutlab": {
-      "hash": "231918b9fa0c1943",
+      "hash": "c95140952aa8709c",
       "changed": "2026-09-11"
     },
     "/vendor/flutter-flow": {
-      "hash": "a855eaa14ce8fae2",
+      "hash": "2e925139811dca45",
       "changed": "2026-09-11"
     },
     "/vendor/fly-io": {
       "daily": true
     },
     "/vendor/flyon-ui": {
-      "hash": "7b9d04fe76af6a9f",
+      "hash": "c7d877335b6e10f9",
       "changed": "2026-09-11"
     },
     "/vendor/forgecode": {
-      "hash": "901f6713c57a8de3",
+      "hash": "fd313b66d6d485bf",
       "changed": "2026-09-11"
     },
     "/vendor/form-taxi": {
-      "hash": "623912d082c167e1",
+      "hash": "e950218a0c41f0a6",
       "changed": "2026-09-11"
     },
     "/vendor/format-express": {
-      "hash": "93348b95f5f6253e",
+      "hash": "f85a165c987e6bf1",
       "changed": "2026-09-11"
     },
     "/vendor/formatjsononline-com": {
-      "hash": "967c2d3fce0ce62e",
+      "hash": "b0c6238a9d79e176",
       "changed": "2026-09-11"
     },
     "/vendor/formbricks": {
-      "hash": "b8a7fd0da917a3bc",
+      "hash": "af29ea3449de6508",
       "changed": "2026-09-11"
     },
     "/vendor/formcarry-com": {
-      "hash": "4cdd17f04e2ef983",
+      "hash": "6364f150b0db0ef1",
       "changed": "2026-09-11"
     },
     "/vendor/formester-com": {
-      "hash": "a556d6f8056fab3d",
+      "hash": "c41e11e6bafc74ca",
       "changed": "2026-09-11"
     },
     "/vendor/formkeep-com": {
-      "hash": "7eba8042d3d6fc23",
+      "hash": "e7fa06dc68e112c3",
       "changed": "2026-09-11"
     },
     "/vendor/formlets-com": {
-      "hash": "61e1afecfa0860d9",
+      "hash": "eb095ad069880b56",
       "changed": "2026-09-11"
     },
     "/vendor/formspark-io": {
-      "hash": "eb7210ebe4930f12",
+      "hash": "ed82df7e07100f83",
       "changed": "2026-09-11"
     },
     "/vendor/formspree": {
-      "hash": "c8136745254ef473",
+      "hash": "982aee2d516a0743",
       "changed": "2026-09-11"
     },
     "/vendor/formsubmit-co": {
-      "hash": "4cec21792ae57d3e",
+      "hash": "b99381e2ed902b1b",
       "changed": "2026-09-11"
     },
     "/vendor/formware-io": {
-      "hash": "fe7e3ec21a05ccca",
+      "hash": "eba7a34d6dfd1b35",
       "changed": "2026-09-11"
     },
     "/vendor/forter": {
-      "hash": "3ff6b284ff4e3664",
+      "hash": "c02aea07d1d9f63d",
       "changed": "2026-09-11"
     },
     "/vendor/forwardemail-net": {
-      "hash": "524afc24b3ba0a74",
+      "hash": "42e105daa053b5b9",
       "changed": "2026-09-11"
     },
     "/vendor/fossa": {
-      "hash": "41ec960f6ba2422d",
+      "hash": "bd1545be3fb7e414",
       "changed": "2026-09-11"
     },
     "/vendor/foursquare": {
-      "hash": "021413faa745ac5e",
+      "hash": "eb40e71a13348fd0",
       "changed": "2026-09-11"
     },
     "/vendor/framagit-org": {
-      "hash": "86d93155584a2de5",
+      "hash": "31fa84d2d6bd7cf0",
       "changed": "2026-09-11"
     },
     "/vendor/framer-com": {
-      "hash": "785f44410676eea0",
+      "hash": "f37b5a2ceac57c96",
       "changed": "2026-09-11"
     },
     "/vendor/fraudlabs-pro": {
-      "hash": "349391e4716d8d13",
+      "hash": "ea16b20363f8c53f",
       "changed": "2026-09-11"
     },
     "/vendor/free-po-editor": {
-      "hash": "7cbf9422171cf4f9",
+      "hash": "846b46888e713e6a",
       "changed": "2026-09-11"
     },
     "/vendor/freebe": {
-      "hash": "6cfa3b6ef3cda5a8",
+      "hash": "af2f6702353d764b",
       "changed": "2026-09-11"
     },
     "/vendor/freedcamp-com": {
-      "hash": "e3ad901aca9298cf",
+      "hash": "0f9dbe66f9683ccc",
       "changed": "2026-09-11"
     },
     "/vendor/freedns-afraid-org": {
-      "hash": "4ff1b7ca4032d968",
+      "hash": "d69da1d429ba7e45",
       "changed": "2026-09-11"
     },
     "/vendor/freeflarum": {
       "daily": true
     },
     "/vendor/freeipapi": {
-      "hash": "166ae352c301b055",
+      "hash": "9db20a5d420a70ae",
       "changed": "2026-09-11"
     },
     "/vendor/freetools-site": {
-      "hash": "900d4420e037a88e",
+      "hash": "4bade6ff7ecf7878",
       "changed": "2026-09-11"
     },
     "/vendor/freshchat": {
-      "hash": "3ccfce9a6e769eab",
+      "hash": "6c7ea6d5187f6077",
       "changed": "2026-09-11"
     },
     "/vendor/freshdesk": {
-      "hash": "2a3834401bdd1922",
+      "hash": "7d6b82f920e640e2",
       "changed": "2026-09-11"
     },
     "/vendor/freshmarketer": {
-      "hash": "1c61ce89d5534a8a",
+      "hash": "e2ea9d92f65a9696",
       "changed": "2026-09-11"
     },
     "/vendor/freshsales": {
-      "hash": "f04b57ad6d698091",
+      "hash": "96515f51764f536b",
       "changed": "2026-09-11"
     },
     "/vendor/freshworks-for-startups": {
-      "hash": "5ebcf5464fd38371",
+      "hash": "e94732346d9ff46e",
       "changed": "2026-09-11"
     },
     "/vendor/front": {
-      "hash": "bb2ccd7344bfc503",
+      "hash": "397ec984b8795d77",
       "changed": "2026-09-11"
     },
     "/vendor/fullstory-com": {
-      "hash": "e0e67a041290f666",
+      "hash": "37feca51065096e8",
       "changed": "2026-09-11"
     },
     "/vendor/fusionauth": {
-      "hash": "e52a4612fd8d3cf1",
+      "hash": "1f94b03e7e941b55",
       "changed": "2026-09-11"
     },
     "/vendor/fxratesapi": {
-      "hash": "dbba48f72d855ab5",
+      "hash": "c4da88ad839fa999",
       "changed": "2026-09-11"
     },
     "/vendor/gatling": {
-      "hash": "b1dbd40fd6d215ef",
+      "hash": "7d7c96c444b055dd",
       "changed": "2026-09-11"
     },
     "/vendor/gcore-dns": {
-      "hash": "07e0d9147a3fb54d",
+      "hash": "b5c5ae17de83d04a",
       "changed": "2026-09-11"
     },
     "/vendor/geekflare-api": {
-      "hash": "d2af03d6eeebbf81",
+      "hash": "2b44958d39cf0a2e",
       "changed": "2026-09-11"
     },
     "/vendor/gel": {
-      "hash": "b2c2762c539bf86a",
+      "hash": "b663e75d0aed8a25",
       "changed": "2026-09-11"
     },
     "/vendor/gemfury": {
-      "hash": "634417f72b357c10",
+      "hash": "81f9fe14c73e99a1",
       "changed": "2026-09-11"
     },
     "/vendor/gemini-cli": {
-      "hash": "3fd956c11b4aff95",
+      "hash": "c99817e02c76b96f",
       "changed": "2026-09-11"
     },
     "/vendor/geoapify-com": {
-      "hash": "462c50ce8f9f8ac8",
+      "hash": "92c03ecbfaadc393",
       "changed": "2026-09-11"
     },
     "/vendor/geocodify-com": {
-      "hash": "5e739a4fa91ae675",
+      "hash": "85db23c281af5342",
       "changed": "2026-09-11"
     },
     "/vendor/geocodio": {
-      "hash": "e3d5a8355d98577a",
+      "hash": "a951d403ed9196dc",
       "changed": "2026-09-11"
     },
     "/vendor/geojs-io": {
-      "hash": "066263853978cf40",
+      "hash": "5fb1a0a029c9c1f0",
       "changed": "2026-09-11"
     },
     "/vendor/geokeo-api": {
-      "hash": "d82952abd9c67405",
+      "hash": "96c5165dcab7a7b8",
       "changed": "2026-09-11"
     },
     "/vendor/geolocated-io": {
-      "hash": "761678837f8ba2aa",
+      "hash": "aed1b2ad4d0410cf",
       "changed": "2026-09-11"
     },
     "/vendor/gerrithub-io": {
-      "hash": "fedcbd64ca500ace",
+      "hash": "ada1ed9ac33252f3",
       "changed": "2026-09-11"
     },
     "/vendor/getinsights-io": {
-      "hash": "574c68393b769c9e",
+      "hash": "69fb0b7799725710",
       "changed": "2026-09-11"
     },
     "/vendor/getpantry-cloud": {
-      "hash": "531c1f728ee1e434",
+      "hash": "eedb45911794f1e4",
       "changed": "2026-09-11"
     },
     "/vendor/getupdraft": {
-      "hash": "3fb5ff30dbbb7d64",
+      "hash": "f3c27517b78f3158",
       "changed": "2026-09-11"
     },
     "/vendor/getvm": {
-      "hash": "3b66fe2a1f8160f4",
+      "hash": "10759514d1419f00",
       "changed": "2026-09-11"
     },
     "/vendor/gforge": {
-      "hash": "9900334b5065e98b",
+      "hash": "e70735fceee55d27",
       "changed": "2026-09-11"
     },
     "/vendor/gigalixir-com": {
       "daily": true
     },
     "/vendor/gimp": {
-      "hash": "f47ab0d39afc1400",
+      "hash": "f537447bdfb3a6ef",
       "changed": "2026-09-11"
     },
     "/vendor/gitbook": {
-      "hash": "ecc708abdb5d49fb",
+      "hash": "8b22e6011c5fc332",
       "changed": "2026-09-11"
     },
     "/vendor/gitdailies": {
-      "hash": "a7c47524fa8cd571",
+      "hash": "28cefa2961afc95b",
       "changed": "2026-09-11"
     },
     "/vendor/gitea": {
-      "hash": "e9f7535c483a5e1a",
+      "hash": "c475d0f2a45eabdb",
       "changed": "2026-09-11"
     },
     "/vendor/gitguardian": {
-      "hash": "bc0c1218f8a8bfe2",
+      "hash": "97ef71f9b6854cc9",
       "changed": "2026-09-11"
     },
     "/vendor/gitgud": {
-      "hash": "1187809580bbbc23",
+      "hash": "b3d45c295ae6daf9",
       "changed": "2026-09-11"
     },
     "/vendor/github": {
-      "hash": "d3ede7a9be83cc88",
+      "hash": "d09057b086d609ba",
       "changed": "2026-09-11"
     },
     "/vendor/github-actions": {
       "daily": true
     },
     "/vendor/github-codespaces": {
-      "hash": "25af93e3ad62a5a8",
+      "hash": "3af0ccade749ea6f",
       "changed": "2026-09-11"
     },
     "/vendor/github-container-registry": {
-      "hash": "423fb490d6fffae3",
+      "hash": "eacc54c8ab279eaf",
       "changed": "2026-09-11"
     },
     "/vendor/github-copilot": {
@@ -5691,71 +5691,71 @@
       "daily": true
     },
     "/vendor/gitlab-ci": {
-      "hash": "7db31f6de192255f",
+      "hash": "17183af945d94e77",
       "changed": "2026-09-11"
     },
     "/vendor/gitleaks": {
-      "hash": "c57d7724053d24a4",
+      "hash": "1e49ad8788c4cc14",
       "changed": "2026-09-11"
     },
     "/vendor/gitter-im": {
-      "hash": "dfc1cf4625baf1e3",
+      "hash": "03368fdb1b26fc0c",
       "changed": "2026-09-11"
     },
     "/vendor/glauca": {
-      "hash": "f0847ccc36962ef6",
+      "hash": "9318249fb2408d14",
       "changed": "2026-09-11"
     },
     "/vendor/gleek-io": {
-      "hash": "87bdd98cb2f85792",
+      "hash": "f6d32c131624e51d",
       "changed": "2026-09-11"
     },
     "/vendor/glitchtip": {
-      "hash": "61dbf22b7130ccd7",
+      "hash": "23779e437ae05fdd",
       "changed": "2026-09-11"
     },
     "/vendor/glyphs": {
-      "hash": "9c82fd1604db280c",
+      "hash": "7eadbe00334298e5",
       "changed": "2026-09-11"
     },
     "/vendor/gmail": {
-      "hash": "dcbf2175fd70ea4d",
+      "hash": "827e3d299223f896",
       "changed": "2026-09-11"
     },
     "/vendor/goatcounter": {
-      "hash": "e52622502e1f575a",
+      "hash": "abd4ca6d0bcbaafe",
       "changed": "2026-09-11"
     },
     "/vendor/gocardless": {
-      "hash": "8face27877b30c21",
+      "hash": "615f26da2d53fdc7",
       "changed": "2026-09-11"
     },
     "/vendor/gofile-io": {
-      "hash": "95b58def8e358606",
+      "hash": "5b23f50326d7d592",
       "changed": "2026-09-11"
     },
     "/vendor/gokanban-io": {
-      "hash": "e5a5d98bcb2cebe1",
+      "hash": "19397003c0f8350f",
       "changed": "2026-09-11"
     },
     "/vendor/google-ads": {
-      "hash": "9a2cd5c2e0b0887e",
+      "hash": "008893a9498e5791",
       "changed": "2026-09-11"
     },
     "/vendor/google-ai-pro-ultra": {
-      "hash": "ade28321aa01e326",
+      "hash": "db60d8dcafe756e9",
       "changed": "2026-09-11"
     },
     "/vendor/google-analytics": {
-      "hash": "39dcef083cda3ffc",
+      "hash": "0aa99d5c7b847a4f",
       "changed": "2026-09-11"
     },
     "/vendor/google-antigravity": {
-      "hash": "268da3cf1911520c",
+      "hash": "13f51c549a402a80",
       "changed": "2026-09-11"
     },
     "/vendor/google-artifact-registry": {
-      "hash": "eef11877b14978f4",
+      "hash": "49d7a54fb9a2b586",
       "changed": "2026-09-11"
     },
     "/vendor/google-cloud": {
@@ -5765,98 +5765,98 @@
       "daily": true
     },
     "/vendor/google-cloud-build": {
-      "hash": "6171932888fba3d7",
+      "hash": "00fd85d4cf8693f7",
       "changed": "2026-09-11"
     },
     "/vendor/google-cloud-logging": {
-      "hash": "551eba35fc92794f",
+      "hash": "14e912604d49cb81",
       "changed": "2026-09-11"
     },
     "/vendor/google-cloud-monitoring": {
       "daily": true
     },
     "/vendor/google-cloud-pub-sub": {
-      "hash": "f8cba1d535c7fe4f",
+      "hash": "ff709d77c0ae79a9",
       "changed": "2026-09-11"
     },
     "/vendor/google-cloud-run": {
       "daily": true
     },
     "/vendor/google-cloud-shell": {
-      "hash": "c84eb2ffa63bfbcb",
+      "hash": "0df277b18e9729cb",
       "changed": "2026-09-11"
     },
     "/vendor/google-cloud-storage": {
-      "hash": "cead082e114a8023",
+      "hash": "9a5611ab99898a12",
       "changed": "2026-09-11"
     },
     "/vendor/google-colab": {
-      "hash": "e920fc1f03d5f2f1",
+      "hash": "979505905279655d",
       "changed": "2026-09-11"
     },
     "/vendor/google-compute-engine": {
-      "hash": "e5b13f3f31e58a6e",
+      "hash": "95bfb25340992651",
       "changed": "2026-09-11"
     },
     "/vendor/google-content-api-for-shopping": {
-      "hash": "f88071eb72cfe87d",
+      "hash": "356192f96f37c3d8",
       "changed": "2026-09-11"
     },
     "/vendor/google-drive": {
-      "hash": "e326806567f2a8ce",
+      "hash": "2b2243af6fc7388b",
       "changed": "2026-09-11"
     },
     "/vendor/google-gemini-api": {
       "daily": true
     },
     "/vendor/google-gemini-code-assist": {
-      "hash": "53737c086fac7e98",
+      "hash": "76ce958d7702ae1b",
       "changed": "2026-09-11"
     },
     "/vendor/google-gemini-embedding-2": {
       "daily": true
     },
     "/vendor/google-keep": {
-      "hash": "5b56850c4398680d",
+      "hash": "9571010601c6ab06",
       "changed": "2026-09-11"
     },
     "/vendor/google-maps-platform": {
-      "hash": "4f81d10e37220f56",
+      "hash": "56ca43d50e9ee2f2",
       "changed": "2026-09-11"
     },
     "/vendor/google-meet": {
-      "hash": "ac3aa7051333e16f",
+      "hash": "a94690e049b57fe9",
       "changed": "2026-09-11"
     },
     "/vendor/google-photos": {
-      "hash": "dde23c4dab75b00e",
+      "hash": "0a33c5ac6ce5da03",
       "changed": "2026-09-11"
     },
     "/vendor/google-secret-manager": {
-      "hash": "d6b5b9d6c75bbfa4",
+      "hash": "e83a0e5c760baf40",
       "changed": "2026-09-11"
     },
     "/vendor/google-vector-search-2-0": {
       "daily": true
     },
     "/vendor/google-vertex-ai-agent-engine": {
-      "hash": "f16eb9e2e7022e2b",
+      "hash": "f00fcf7dc3b583b8",
       "changed": "2026-09-11"
     },
     "/vendor/goreportcard-com": {
-      "hash": "0bc20a6c2c64ccac",
+      "hash": "d8e21d0c47de4436",
       "changed": "2026-09-11"
     },
     "/vendor/gorgias": {
-      "hash": "cc7024acdbdb1a01",
+      "hash": "4fa1ae6e14624b1e",
       "changed": "2026-09-11"
     },
     "/vendor/gpu-bridge": {
-      "hash": "0d77cc5d765a6b6b",
+      "hash": "0ae590c24a7630e5",
       "changed": "2026-09-11"
     },
     "/vendor/gradientos": {
-      "hash": "78f429e81675eeb1",
+      "hash": "7d59e0d803dc10b0",
       "changed": "2026-09-11"
     },
     "/vendor/grafana": {
@@ -5866,90 +5866,90 @@
       "daily": true
     },
     "/vendor/grafana-k6-cloud": {
-      "hash": "37e81000cd9ddee3",
+      "hash": "e2d8f27cda3bda93",
       "changed": "2026-09-11"
     },
     "/vendor/grafana-loki": {
-      "hash": "66880e8ac5055dbb",
+      "hash": "01bb2d2710c5458b",
       "changed": "2026-09-11"
     },
     "/vendor/grapedrop": {
-      "hash": "2eb7bd80368d7623",
+      "hash": "64e9295b9681f60a",
       "changed": "2026-09-11"
     },
     "/vendor/graphcomment": {
-      "hash": "68f8f4ffa541305c",
+      "hash": "5e53e149aa59c11b",
       "changed": "2026-09-11"
     },
     "/vendor/gridlastic-com": {
-      "hash": "b2dcaa6422bfc71e",
+      "hash": "06f76bfd5fc7a809",
       "changed": "2026-09-11"
     },
     "/vendor/groq": {
       "daily": true
     },
     "/vendor/growthbook": {
-      "hash": "6bc09262ff90a4b4",
+      "hash": "51d9f0a4777f1f6f",
       "changed": "2026-09-11"
     },
     "/vendor/grype": {
-      "hash": "bbbf1fdb6b178e98",
+      "hash": "210814ee6432d22a",
       "changed": "2026-09-11"
     },
     "/vendor/gtmetrix-com": {
-      "hash": "fca72adbd336874b",
+      "hash": "33f53584eeef0dc8",
       "changed": "2026-09-11"
     },
     "/vendor/guideline-401-k": {
-      "hash": "ecbb6db6ab96bfc8",
+      "hash": "3a285aad85d1be44",
       "changed": "2026-09-11"
     },
     "/vendor/gumlet-com": {
-      "hash": "5ba450cb951db783",
+      "hash": "8e963585366c880b",
       "changed": "2026-09-11"
     },
     "/vendor/hackmd-io": {
-      "hash": "f2a4068c55403c20",
+      "hash": "c3bf071c49ae4f1d",
       "changed": "2026-09-11"
     },
     "/vendor/haikei-app": {
-      "hash": "d42838f2329bd4b5",
+      "hash": "0ff1b6d6d8aec6dc",
       "changed": "2026-09-11"
     },
     "/vendor/hamachi": {
-      "hash": "efc24b0a3dfdd2c2",
+      "hash": "928826962db282cf",
       "changed": "2026-09-11"
     },
     "/vendor/hanko": {
-      "hash": "f473fd5b0954e0f3",
+      "hash": "429772b49385b686",
       "changed": "2026-09-11"
     },
     "/vendor/harbor": {
-      "hash": "b9158876fbe03e95",
+      "hash": "1321db3fef149abc",
       "changed": "2026-09-11"
     },
     "/vendor/harness-ci": {
-      "hash": "12b8d8d4a9a45e7f",
+      "hash": "10c8369e17ded47d",
       "changed": "2026-09-11"
     },
     "/vendor/harness-feature-flags": {
-      "hash": "f82a17d729f98b04",
+      "hash": "00600874f4da983d",
       "changed": "2026-09-11"
     },
     "/vendor/harvestr": {
-      "hash": "0f6e93965ad1900e",
+      "hash": "ddc910b92e9ec7c8",
       "changed": "2026-09-11"
     },
     "/vendor/hashicorp-vault": {
-      "hash": "a0f9a709171ba3a9",
+      "hash": "3c4bf2d46f5e0ea2",
       "changed": "2026-09-11"
     },
     "/vendor/hasura": {
-      "hash": "161bceaad02e7f4d",
+      "hash": "490bd7eccce1c29f",
       "changed": "2026-09-11"
     },
     "/vendor/have-i-been-pwned": {
-      "hash": "a239988f6b861188",
+      "hash": "d05c1f1f3018b630",
       "changed": "2026-09-11"
     },
     "/vendor/hcp-terraform": {
@@ -5959,219 +5959,219 @@
       "daily": true
     },
     "/vendor/heap-io": {
-      "hash": "41b2d715170be207",
+      "hash": "aeaa4dcddba578a0",
       "changed": "2026-09-11"
     },
     "/vendor/help-scout-for-startups": {
-      "hash": "36eb8d1b63146839",
+      "hash": "0b943defed9cd42b",
       "changed": "2026-09-11"
     },
     "/vendor/helploom": {
-      "hash": "5ee8e9e92b0e8cdf",
+      "hash": "08f5938b9b6d5520",
       "changed": "2026-09-11"
     },
     "/vendor/heptapod-net": {
-      "hash": "6328569d390c3046",
+      "hash": "d4760b91dc0588f5",
       "changed": "2026-09-11"
     },
     "/vendor/heroku-for-startups-program": {
-      "hash": "4b3578dc34ea8741",
+      "hash": "f79e5ebe7c57990f",
       "changed": "2026-09-11"
     },
     "/vendor/herotofu-com": {
-      "hash": "94ea192bac71ee86",
+      "hash": "ab5aee82b0032763",
       "changed": "2026-09-11"
     },
     "/vendor/heroui": {
-      "hash": "d04f1dc839b1dc58",
+      "hash": "7bc4d1cb7bac2c38",
       "changed": "2026-09-11"
     },
     "/vendor/hetzner": {
       "daily": true
     },
     "/vendor/hetzner-dns": {
-      "hash": "c8f9ddf86f87254c",
+      "hash": "9be3f492249aa147",
       "changed": "2026-09-11"
     },
     "/vendor/hex": {
-      "hash": "54d693a8aa461c0d",
+      "hash": "f96fb50e87d89ff5",
       "changed": "2026-09-11"
     },
     "/vendor/highlight-io": {
-      "hash": "754871d2064ee3a7",
+      "hash": "6f25bcbb2c66fa7a",
       "changed": "2026-09-11"
     },
     "/vendor/hightouch": {
-      "hash": "ffec97b6f726adbc",
+      "hash": "60a1e525071b5d7e",
       "changed": "2026-09-11"
     },
     "/vendor/hivemq": {
-      "hash": "56c1e02b947c54e2",
+      "hash": "680c950bbfb418a8",
       "changed": "2026-09-11"
     },
     "/vendor/holistic-dev": {
-      "hash": "88d6a78d7e6c99de",
+      "hash": "0a6c51ccdd792ef1",
       "changed": "2026-09-11"
     },
     "/vendor/honeybadger-io": {
-      "hash": "5428d6e89be0b47b",
+      "hash": "15e4e41a797279ae",
       "changed": "2026-09-11"
     },
     "/vendor/hook-relay": {
-      "hash": "cf6429525cb4b975",
+      "hash": "ceca1ba3d2b18c6e",
       "changed": "2026-09-11"
     },
     "/vendor/hook0": {
-      "hash": "8b3ca362dcea9616",
+      "hash": "8de477189c33225b",
       "changed": "2026-09-11"
     },
     "/vendor/hookdeck": {
-      "hash": "c1c23b66009084b5",
+      "hash": "373d6cad2f4c3381",
       "changed": "2026-09-11"
     },
     "/vendor/hoppscotch": {
-      "hash": "4a49623b09e01f57",
+      "hash": "34d84f0943dcf9ed",
       "changed": "2026-09-11"
     },
     "/vendor/hosting-checker": {
-      "hash": "6b84c71af1081a83",
+      "hash": "0e7dc69c372ea276",
       "changed": "2026-09-11"
     },
     "/vendor/hotjar": {
-      "hash": "21a706e1c2aacd39",
+      "hash": "14db8be053bafe6f",
       "changed": "2026-09-11"
     },
     "/vendor/houndci-com": {
-      "hash": "7fa761857d511c67",
+      "hash": "ec69b35720c016cf",
       "changed": "2026-09-11"
     },
     "/vendor/howuku-com": {
-      "hash": "167d9e4d70102e1a",
+      "hash": "678d4255aaefa04f",
       "changed": "2026-09-11"
     },
     "/vendor/httpsms": {
-      "hash": "ccd743af9b7dd641",
+      "hash": "31e8c22535c7259c",
       "changed": "2026-09-11"
     },
     "/vendor/hubspot-for-startups": {
-      "hash": "db7562b0bfe12808",
+      "hash": "f2b6ef4b36509754",
       "changed": "2026-09-11"
     },
     "/vendor/hugging-face": {
       "daily": true
     },
     "/vendor/huly": {
-      "hash": "cd72a9ef1a44970c",
+      "hash": "3032fa4a05e74201",
       "changed": "2026-09-11"
     },
     "/vendor/hunter-io": {
-      "hash": "1baddc468a8f6884",
+      "hash": "a46f335405fd7a6c",
       "changed": "2026-09-11"
     },
     "/vendor/hurricane-electric-dns": {
-      "hash": "d781b1ca228d5445",
+      "hash": "2d42837a3136d033",
       "changed": "2026-09-11"
     },
     "/vendor/hygger": {
-      "hash": "e248944bb5d5c533",
+      "hash": "037f92202929f98b",
       "changed": "2026-09-11"
     },
     "/vendor/hygraph": {
-      "hash": "2bde8b5468ff6392",
+      "hash": "2da2e7295eedc558",
       "changed": "2026-09-11"
     },
     "/vendor/hyperbrowser": {
-      "hash": "4f6a8ea9fa5a1794",
+      "hash": "cd947f11a3110695",
       "changed": "2026-09-11"
     },
     "/vendor/hypercolor-dev": {
-      "hash": "5ae007ace489407e",
+      "hash": "786188fbfd1350f5",
       "changed": "2026-09-11"
     },
     "/vendor/hyperping": {
       "daily": true
     },
     "/vendor/hypertune": {
-      "hash": "184f3f661c9ecd78",
+      "hash": "806cb83a172d880e",
       "changed": "2026-09-11"
     },
     "/vendor/hyperui": {
-      "hash": "1c59f3c7cc3d0f8d",
+      "hash": "ef7f8f6fbdee3d3e",
       "changed": "2026-09-11"
     },
     "/vendor/ibm-cloud": {
-      "hash": "743de29d49be6dbd",
+      "hash": "7089c922979d3cae",
       "changed": "2026-09-11"
     },
     "/vendor/icedrive-net": {
-      "hash": "0c27cdd9f41bc753",
+      "hash": "0e3f5e88cdcbe814",
       "changed": "2026-09-11"
     },
     "/vendor/icloud": {
-      "hash": "f358f8551f7d7ab1",
+      "hash": "298c8fb2f24c4b02",
       "changed": "2026-09-11"
     },
     "/vendor/icon-horse": {
-      "hash": "9ec4b6d6cef4d3f1",
+      "hash": "08a54d3beb019b6e",
       "changed": "2026-09-11"
     },
     "/vendor/iconify-design": {
-      "hash": "ca475342fa6c4ae7",
+      "hash": "5178893c1b0a9293",
       "changed": "2026-09-11"
     },
     "/vendor/iconoir": {
-      "hash": "c994300ec245044d",
+      "hash": "4c509012b61f7f9a",
       "changed": "2026-09-11"
     },
     "/vendor/ifttt": {
-      "hash": "ecb8b1e7ae02df3e",
+      "hash": "82340b9d0016ac51",
       "changed": "2026-09-11"
     },
     "/vendor/ilograph": {
-      "hash": "77b9c6791aa15e4d",
+      "hash": "356ee61908aaa468",
       "changed": "2026-09-11"
     },
     "/vendor/image-bg-blurer": {
-      "hash": "c7ee64e6157095b0",
+      "hash": "ebea80602aded13d",
       "changed": "2026-09-11"
     },
     "/vendor/image-charts-com": {
-      "hash": "1d707f4e0669a2d6",
+      "hash": "1c2d7fbc43e31929",
       "changed": "2026-09-11"
     },
     "/vendor/imageengine": {
       "daily": true
     },
     "/vendor/imagekit": {
-      "hash": "9c0d8a2741ed7e2e",
+      "hash": "e325fa47ae913832",
       "changed": "2026-09-11"
     },
     "/vendor/imgbb": {
-      "hash": "00ae753463d883a0",
+      "hash": "b0e9274718983cea",
       "changed": "2026-09-11"
     },
     "/vendor/imgen": {
-      "hash": "0c30e6179efbc7d8",
+      "hash": "9d5164ec60bc418c",
       "changed": "2026-09-11"
     },
     "/vendor/imgix": {
-      "hash": "db7784593b772cd9",
+      "hash": "2fa0b1bdeec88898",
       "changed": "2026-09-11"
     },
     "/vendor/imitate-email": {
-      "hash": "9a44b5e9a5c20631",
+      "hash": "6beb2e74bee4c896",
       "changed": "2026-09-11"
     },
     "/vendor/improvmx": {
-      "hash": "98aa93985c1187ef",
+      "hash": "de9ffabb763fdd67",
       "changed": "2026-09-11"
     },
     "/vendor/inboxes-app": {
-      "hash": "1b0f9646bf911ac3",
+      "hash": "4f25e843ed9bcb04",
       "changed": "2026-09-11"
     },
     "/vendor/inboxkitten-com": {
-      "hash": "b3817554ae70f8f4",
+      "hash": "321937f49baa626f",
       "changed": "2026-09-11"
     },
     "/vendor/incident-io": {
@@ -6181,305 +6181,305 @@
       "daily": true
     },
     "/vendor/infisical": {
-      "hash": "905ce49127c9c068",
+      "hash": "9f4f50708ca158b5",
       "changed": "2026-09-11"
     },
     "/vendor/influxdb-cloud": {
-      "hash": "cb396b956423c305",
+      "hash": "ace98385f79528fa",
       "changed": "2026-09-11"
     },
     "/vendor/inkscape": {
-      "hash": "8536dec02c53431c",
+      "hash": "79bfb6c229ca5e91",
       "changed": "2026-09-11"
     },
     "/vendor/inngest": {
-      "hash": "5ca07965c4f6cb51",
+      "hash": "7b1b0613d039754a",
       "changed": "2026-09-11"
     },
     "/vendor/insomnia": {
-      "hash": "fa47e0653fb52741",
+      "hash": "055051acb24e5543",
       "changed": "2026-09-11"
     },
     "/vendor/inspectlet-com": {
-      "hash": "d5ebb33932480493",
+      "hash": "72fadfcf695f66a0",
       "changed": "2026-09-11"
     },
     "/vendor/inspector-dev": {
       "daily": true
     },
     "/vendor/instabug-for-startups": {
-      "hash": "2f00f9a426d50ff4",
+      "hash": "5157820750da2d19",
       "changed": "2026-09-11"
     },
     "/vendor/instacart": {
-      "hash": "66b06e0d9a6a3381",
+      "hash": "4ed1c7d5be1702e3",
       "changed": "2026-09-11"
     },
     "/vendor/installonair": {
-      "hash": "0992d2a3c7b0bef1",
+      "hash": "e7a85ef19ba3ff00",
       "changed": "2026-09-11"
     },
     "/vendor/instatus": {
-      "hash": "d0047a8c2a19c2f1",
+      "hash": "7e8f111d9f0b8c49",
       "changed": "2026-09-11"
     },
     "/vendor/integrately": {
-      "hash": "dc713d029e6e6a29",
+      "hash": "a925d5b8165f1098",
       "changed": "2026-09-11"
     },
     "/vendor/intensedebate": {
-      "hash": "b1bd103bd6dc9d5e",
+      "hash": "594a87ff88c03837",
       "changed": "2026-09-11"
     },
     "/vendor/intercom": {
-      "hash": "dfb5632a3834bdc5",
+      "hash": "8d710387ddc8d56b",
       "changed": "2026-09-11"
     },
     "/vendor/internet-nl": {
-      "hash": "22975a87be61a535",
+      "hash": "e9373d80e0603e1a",
       "changed": "2026-09-11"
     },
     "/vendor/internxt": {
-      "hash": "af711cd2f3460b8f",
+      "hash": "51e11c3a06d984a5",
       "changed": "2026-09-11"
     },
     "/vendor/invantive-cloud": {
-      "hash": "ff00de521b185205",
+      "hash": "206f0d5bebc3f1a6",
       "changed": "2026-09-11"
     },
     "/vendor/invision": {
-      "hash": "ca06477fc48b6544",
+      "hash": "34617b01502ce35c",
       "changed": "2026-09-11"
     },
     "/vendor/ip-city": {
-      "hash": "595afc8623db3363",
+      "hash": "6d34b530749b8f45",
       "changed": "2026-09-11"
     },
     "/vendor/ip-geolocation": {
-      "hash": "3b5c1b74afaa9237",
+      "hash": "86b5fdf1c86f8c88",
       "changed": "2026-09-11"
     },
     "/vendor/ip-geolocation-api-by-ipwho-org": {
-      "hash": "5d49839c84a09032",
+      "hash": "117cff1affdc1c45",
       "changed": "2026-09-11"
     },
     "/vendor/ip2location-io": {
-      "hash": "3a2c3022acd5a778",
+      "hash": "6a87a7afeb7361b2",
       "changed": "2026-09-11"
     },
     "/vendor/ipaddress-sh": {
-      "hash": "27f8645f6df53d4e",
+      "hash": "4849eb5cd6ef8a2a",
       "changed": "2026-09-11"
     },
     "/vendor/ipapi": {
-      "hash": "c4d78579ff577b65",
+      "hash": "677e8830951dfc09",
       "changed": "2026-09-11"
     },
     "/vendor/ipapi-is": {
-      "hash": "6aceaa45d2931b86",
+      "hash": "73592cff51f04dad",
       "changed": "2026-09-11"
     },
     "/vendor/ipbase-com": {
-      "hash": "49398ee64719364d",
+      "hash": "6cbbe91bf44ef4a2",
       "changed": "2026-09-11"
     },
     "/vendor/ipinfo-io": {
-      "hash": "dacb6d2a347ac50f",
+      "hash": "0fbf87967ab72015",
       "changed": "2026-09-11"
     },
     "/vendor/iplocate": {
-      "hash": "4f519b83cc83fcde",
+      "hash": "9f135a1d5042f27e",
       "changed": "2026-09-11"
     },
     "/vendor/ipstack": {
-      "hash": "9af280a45ec5cea3",
+      "hash": "757b777218583cee",
       "changed": "2026-09-11"
     },
     "/vendor/iptrace": {
-      "hash": "3068aec701fcbaa7",
+      "hash": "bb47a7a3118d5bf8",
       "changed": "2026-09-11"
     },
     "/vendor/isroot-in": {
-      "hash": "c71f401ec4f48079",
+      "hash": "2edd44fd04c1be1a",
       "changed": "2026-09-11"
     },
     "/vendor/iubenda": {
-      "hash": "e3e5ca9f8cedeb63",
+      "hash": "4257ac345af3809d",
       "changed": "2026-09-11"
     },
     "/vendor/jaeger": {
       "daily": true
     },
     "/vendor/jam": {
-      "hash": "a13d5a78ad37f489",
+      "hash": "b74b04f998f8f37f",
       "changed": "2026-09-11"
     },
     "/vendor/jamf-com": {
-      "hash": "5f30074ecf9e45e2",
+      "hash": "99558d258c0aefc9",
       "changed": "2026-09-11"
     },
     "/vendor/jdoodle": {
-      "hash": "ecfc47a762b027dd",
+      "hash": "b19d1f0b161f220a",
       "changed": "2026-09-11"
     },
     "/vendor/jetbrains": {
-      "hash": "70dd5bb6a6192434",
+      "hash": "2a4b78d3d48a3410",
       "changed": "2026-09-11"
     },
     "/vendor/jitpack-io": {
-      "hash": "9a28a996387b82bc",
+      "hash": "c18b9d3a8afb2850",
       "changed": "2026-09-11"
     },
     "/vendor/jotform": {
-      "hash": "67b2b99bd3d63964",
+      "hash": "c4b054d88018183d",
       "changed": "2026-09-11"
     },
     "/vendor/jsdelivr": {
-      "hash": "bf8f0d2be7f5e178",
+      "hash": "f160c7a8d9f2f25e",
       "changed": "2026-09-11"
     },
     "/vendor/json-ip": {
-      "hash": "115eee60c142aa67",
+      "hash": "21016fe2e025681a",
       "changed": "2026-09-11"
     },
     "/vendor/json-to-table": {
-      "hash": "c55af178742254b3",
+      "hash": "16e6054a9098d8b5",
       "changed": "2026-09-11"
     },
     "/vendor/json2video": {
-      "hash": "036891f99f88dd2c",
+      "hash": "0d529e26b10430f7",
       "changed": "2026-09-11"
     },
     "/vendor/jsongrid": {
-      "hash": "c37571c3a226e41e",
+      "hash": "9b524e3ebdf5089a",
       "changed": "2026-09-11"
     },
     "/vendor/jsoning": {
-      "hash": "07605293d207b965",
+      "hash": "9e3e7377bfceb2c5",
       "changed": "2026-09-11"
     },
     "/vendor/jsonswiss": {
-      "hash": "a282c229d2a8f670",
+      "hash": "3f1e6c800e1b6713",
       "changed": "2026-09-11"
     },
     "/vendor/kaggle": {
       "daily": true
     },
     "/vendor/kan-bn": {
-      "hash": "5fff955da132a097",
+      "hash": "b9e189510db71502",
       "changed": "2026-09-11"
     },
     "/vendor/kanbanflow-com": {
-      "hash": "0f06d892574c8ad6",
+      "hash": "e917eea2a68a05b4",
       "changed": "2026-09-11"
     },
     "/vendor/kanbantool-com": {
-      "hash": "5e4f0234f78239e6",
+      "hash": "9dbb30ffd3de7a42",
       "changed": "2026-09-11"
     },
     "/vendor/karbon-sites": {
-      "hash": "31ede531beeb3586",
+      "hash": "67c63108f8930722",
       "changed": "2026-09-11"
     },
     "/vendor/kaspr": {
-      "hash": "4d8e09936caff375",
+      "hash": "207a1330afa658df",
       "changed": "2026-09-11"
     },
     "/vendor/katalon-com": {
-      "hash": "5400359644ee3639",
+      "hash": "105af5cc8e0aa30b",
       "changed": "2026-09-11"
     },
     "/vendor/keepassxc": {
-      "hash": "209207588eab1ed1",
+      "hash": "c1505d84accdfabc",
       "changed": "2026-09-11"
     },
     "/vendor/keploy": {
-      "hash": "3d1da50824436e09",
+      "hash": "0b1db69d207d277a",
       "changed": "2026-09-11"
     },
     "/vendor/ketch": {
-      "hash": "cdc618901ff783de",
+      "hash": "7251e18ed711cae0",
       "changed": "2026-09-11"
     },
     "/vendor/keybase": {
-      "hash": "61cb4abb4da3d423",
+      "hash": "7a33953583d18ecb",
       "changed": "2026-09-11"
     },
     "/vendor/keycloak": {
-      "hash": "f228ae1091492928",
+      "hash": "56755b4230f08a9a",
       "changed": "2026-09-11"
     },
     "/vendor/keywords-ai": {
       "daily": true
     },
     "/vendor/khan-academy": {
-      "hash": "76bab680be035090",
+      "hash": "878fbd6f61ef44f6",
       "changed": "2026-09-11"
     },
     "/vendor/killbait-api": {
-      "hash": "210a319390306901",
+      "hash": "4372c2b81e2ae3bf",
       "changed": "2026-09-11"
     },
     "/vendor/kinde": {
-      "hash": "d12d145d35b43238",
+      "hash": "5747454d6cb8983a",
       "changed": "2026-09-11"
     },
     "/vendor/klaviyo": {
-      "hash": "ad823519fae646c6",
+      "hash": "8c00f48ef2f3800a",
       "changed": "2026-09-11"
     },
     "/vendor/knock": {
-      "hash": "0e8ad4782b388178",
+      "hash": "89f223546be9d8f1",
       "changed": "2026-09-11"
     },
     "/vendor/knotel": {
-      "hash": "22b499f041d8ac9f",
+      "hash": "23771195e70ba467",
       "changed": "2026-09-11"
     },
     "/vendor/knowlarity-for-startups": {
-      "hash": "0fa5f3649381af25",
+      "hash": "6e633b96b5efdd22",
       "changed": "2026-09-11"
     },
     "/vendor/kogiqa": {
-      "hash": "aaaf4cb10845010d",
+      "hash": "edfc7dbb79f24b53",
       "changed": "2026-09-11"
     },
     "/vendor/kong": {
-      "hash": "af07384134653e40",
+      "hash": "ba0ed205adf21235",
       "changed": "2026-09-11"
     },
     "/vendor/koyeb": {
       "daily": true
     },
     "/vendor/kraken-io": {
-      "hash": "8dba2d468812e4ca",
+      "hash": "1c2ec0ae352b0fe5",
       "changed": "2026-09-11"
     },
     "/vendor/kreya": {
-      "hash": "c55d16eed4201501",
+      "hash": "74c7cc0dff4f2722",
       "changed": "2026-09-11"
     },
     "/vendor/krita": {
-      "hash": "ccd02ddb2ae99425",
+      "hash": "e6fc668b9d0b0b56",
       "changed": "2026-09-11"
     },
     "/vendor/kumu-io": {
-      "hash": "aedef5ce7f3f4ff2",
+      "hash": "b7e392c47869d272",
       "changed": "2026-09-11"
     },
     "/vendor/kwes-io": {
-      "hash": "3efdfc2030a597a1",
+      "hash": "d90eb7f52c67baf3",
       "changed": "2026-09-11"
     },
     "/vendor/la-fabrique-juridique": {
-      "hash": "94edbfb1c3cccbb6",
+      "hash": "5e32ec7818b6123e",
       "changed": "2026-09-11"
     },
     "/vendor/labelbox": {
       "daily": true
     },
     "/vendor/lambdatest": {
-      "hash": "ca7838aea25e345d",
+      "hash": "098119f441504f54",
       "changed": "2026-09-11"
     },
     "/vendor/lancedb": {
@@ -6492,18 +6492,18 @@
       "daily": true
     },
     "/vendor/langtrace": {
-      "hash": "8226bcc2090d3c9f",
+      "hash": "bcf3c5b9b7f278a6",
       "changed": "2026-09-11"
     },
     "/vendor/langwatch": {
       "daily": true
     },
     "/vendor/lastpass": {
-      "hash": "a139cb407235f487",
+      "hash": "c8187e3dbfecdde6",
       "changed": "2026-09-11"
     },
     "/vendor/launchdarkly": {
-      "hash": "5510f9c235906d8d",
+      "hash": "9f91ed6596932567",
       "changed": "2026-09-11"
     },
     "/vendor/leancloud": {
@@ -6513,504 +6513,504 @@
       "daily": true
     },
     "/vendor/legalstart": {
-      "hash": "90bfd54a8f0a3fa7",
+      "hash": "52d397ba5da12ad9",
       "changed": "2026-09-11"
     },
     "/vendor/leiga-com": {
-      "hash": "7e08541618264c8d",
+      "hash": "ed348666ef2255db",
       "changed": "2026-09-11"
     },
     "/vendor/lemon-squeezy": {
-      "hash": "dab61ca32571c214",
+      "hash": "c9b568920ddbebdd",
       "changed": "2026-09-11"
     },
     "/vendor/lensdump-com": {
-      "hash": "33eb7d27241b88eb",
+      "hash": "d045303bd432592f",
       "changed": "2026-09-11"
     },
     "/vendor/letsencrypt-org": {
-      "hash": "6d1ff459e8a064bb",
+      "hash": "c2d5c4793a0bd0e6",
       "changed": "2026-09-11"
     },
     "/vendor/libeo": {
-      "hash": "63eb2294012adcd3",
+      "hash": "0a2ac6d2c253118a",
       "changed": "2026-09-11"
     },
     "/vendor/libraries-io": {
-      "hash": "ad3278113d45a8e2",
+      "hash": "7defbb827d8c513c",
       "changed": "2026-09-11"
     },
     "/vendor/lil-bots": {
-      "hash": "24b82acb28fc1c32",
+      "hash": "8090dc2da810bbac",
       "changed": "2026-09-11"
     },
     "/vendor/linear": {
-      "hash": "d2949cb1d8380916",
+      "hash": "91fb3bff4da480a5",
       "changed": "2026-09-11"
     },
     "/vendor/lingohub-com": {
-      "hash": "6af6793afef293e4",
+      "hash": "7c4acb7e64f014b3",
       "changed": "2026-09-11"
     },
     "/vendor/linkinize": {
-      "hash": "ab7d0202161eba1a",
+      "hash": "a2dab45c02c1a4c2",
       "changed": "2026-09-11"
     },
     "/vendor/linkok-com": {
-      "hash": "26e538040ae5f96f",
+      "hash": "bb8057deb6cfdb3a",
       "changed": "2026-09-11"
     },
     "/vendor/liveblocks": {
-      "hash": "64665c77c6290eb1",
+      "hash": "203c62c890267f52",
       "changed": "2026-09-11"
     },
     "/vendor/livekit": {
-      "hash": "92078249139413f0",
+      "hash": "e267df39eacb8332",
       "changed": "2026-09-11"
     },
     "/vendor/llm7-io": {
       "daily": true
     },
     "/vendor/loader-io": {
-      "hash": "933d817dc248b4f1",
+      "hash": "e12abf3259c13632",
       "changed": "2026-09-11"
     },
     "/vendor/loadly": {
-      "hash": "1ae86e6d4a26a62c",
+      "hash": "0a00164b2dda0bc1",
       "changed": "2026-09-11"
     },
     "/vendor/loadmill-com": {
-      "hash": "4c374583353ad73c",
+      "hash": "a6cecca512af772f",
       "changed": "2026-09-11"
     },
     "/vendor/localazy-com": {
-      "hash": "c57ec97328fc5f78",
+      "hash": "6106c2fdf3a27a57",
       "changed": "2026-09-11"
     },
     "/vendor/localcert": {
-      "hash": "f58db2df7c391eee",
+      "hash": "2b1b7d4fa89703cf",
       "changed": "2026-09-11"
     },
     "/vendor/localhost-run": {
-      "hash": "9cfd3f22ee8cc7d7",
+      "hash": "ef3bdbacd3a52a2c",
       "changed": "2026-09-11"
     },
     "/vendor/localit": {
-      "hash": "b01696d68356746e",
+      "hash": "81f4fbdc29544225",
       "changed": "2026-09-11"
     },
     "/vendor/localizely-com": {
-      "hash": "3531fed60fff0ddb",
+      "hash": "d363ae89e014d75b",
       "changed": "2026-09-11"
     },
     "/vendor/localops": {
-      "hash": "006b067dd34b2152",
+      "hash": "962dcb95392d409a",
       "changed": "2026-09-11"
     },
     "/vendor/localstack": {
       "daily": true
     },
     "/vendor/localtunnel": {
-      "hash": "f32b9bd78d98f338",
+      "hash": "48623a8658302743",
       "changed": "2026-09-11"
     },
     "/vendor/localxpose": {
-      "hash": "25b10f37f42ab616",
+      "hash": "b283a5e04bfd4c50",
       "changed": "2026-09-11"
     },
     "/vendor/locationiq": {
-      "hash": "f66de5e04ddd5d04",
+      "hash": "c05c33688fad5c2d",
       "changed": "2026-09-11"
     },
     "/vendor/lockitbot": {
-      "hash": "f644e2a5a3f2ff77",
+      "hash": "022a2e78700e3336",
       "changed": "2026-09-11"
     },
     "/vendor/loco": {
-      "hash": "db3e1a5256226bc7",
+      "hash": "4e6779e67329e5f7",
       "changed": "2026-09-11"
     },
     "/vendor/locust": {
-      "hash": "b0a9aaf0767d14aa",
+      "hash": "e097a2df86279078",
       "changed": "2026-09-11"
     },
     "/vendor/log-dog": {
-      "hash": "05a5dba257114443",
+      "hash": "becf3c5120b8e52e",
       "changed": "2026-09-11"
     },
     "/vendor/logflare-app": {
-      "hash": "b5f2eec35f546797",
+      "hash": "17ffca89392b71b3",
       "changed": "2026-09-11"
     },
     "/vendor/loginllama": {
-      "hash": "a7b14ecd63143b6e",
+      "hash": "8e8694e9364271d8",
       "changed": "2026-09-11"
     },
     "/vendor/logintc-com": {
-      "hash": "177faf28ba48c835",
+      "hash": "21b6bc77a387a165",
       "changed": "2026-09-11"
     },
     "/vendor/logo-dev": {
-      "hash": "40dd1b338ecc881a",
+      "hash": "9405d209f4baed0c",
       "changed": "2026-09-11"
     },
     "/vendor/logrocket": {
-      "hash": "54f30663ce01616f",
+      "hash": "a84ef04f1dd6665b",
       "changed": "2026-09-11"
     },
     "/vendor/logspot": {
-      "hash": "339609bb74f88c45",
+      "hash": "ca492d3b1a328f09",
       "changed": "2026-09-11"
     },
     "/vendor/logto": {
-      "hash": "7541e00657a433d7",
+      "hash": "b3ebee73f52f45d5",
       "changed": "2026-09-11"
     },
     "/vendor/logz-io": {
       "daily": true
     },
     "/vendor/logzab-com": {
-      "hash": "6ac7b9fc4402bbcb",
+      "hash": "f2c2d2f707f38fbd",
       "changed": "2026-09-11"
     },
     "/vendor/lokalise": {
-      "hash": "212c4048139454c2",
+      "hash": "9bc944da6d164829",
       "changed": "2026-09-11"
     },
     "/vendor/loops": {
-      "hash": "53d14f22f5d51a10",
+      "hash": "9884a84fa1ff1cd2",
       "changed": "2026-09-11"
     },
     "/vendor/lorem-picsum": {
-      "hash": "9d6cb6166b871b27",
+      "hash": "732340843305ba43",
       "changed": "2026-09-11"
     },
     "/vendor/lost-pixel-com": {
-      "hash": "57d7d8dc82c124a4",
+      "hash": "a2c2dc15f2309012",
       "changed": "2026-09-11"
     },
     "/vendor/lottiefiles": {
-      "hash": "71abfe032101f613",
+      "hash": "b04aabf88c6415f8",
       "changed": "2026-09-11"
     },
     "/vendor/lovable": {
-      "hash": "edc6d3e10d785e9c",
+      "hash": "b3b33edc0106142d",
       "changed": "2026-09-11"
     },
     "/vendor/luadns-com": {
-      "hash": "e1f5433e9c637f30",
+      "hash": "997b6807a702c5f5",
       "changed": "2026-09-11"
     },
     "/vendor/lucidchart": {
-      "hash": "62ce7b5d6d2d9887",
+      "hash": "21eddc88749491c5",
       "changed": "2026-09-11"
     },
     "/vendor/lucide": {
-      "hash": "f3dcbcce664a567c",
+      "hash": "91932a6281c5f1b1",
       "changed": "2026-09-11"
     },
     "/vendor/lumenfall-ai": {
       "daily": true
     },
     "/vendor/lunacy": {
-      "hash": "de8f9b9ce43442a0",
+      "hash": "a51357a2cc4e2819",
       "changed": "2026-09-11"
     },
     "/vendor/lyssna": {
-      "hash": "fd12da4b105d48a7",
+      "hash": "9711e889133caa04",
       "changed": "2026-09-11"
     },
     "/vendor/magicpattern": {
-      "hash": "5142cc1046c76afa",
+      "hash": "e956891a60d13fee",
       "changed": "2026-09-11"
     },
     "/vendor/mail-tester-com": {
-      "hash": "a52768ae0c0eab6b",
+      "hash": "0391b8ba6f0c1310",
       "changed": "2026-09-11"
     },
     "/vendor/mailboxvalidator": {
-      "hash": "fbef147497ee3b69",
+      "hash": "210dad40ed7a7002",
       "changed": "2026-09-11"
     },
     "/vendor/mailcatcher-me": {
-      "hash": "9e4517597c6872b3",
+      "hash": "f423cb5adda66559",
       "changed": "2026-09-11"
     },
     "/vendor/mailchannels-com": {
-      "hash": "94dfc185ea4d658d",
+      "hash": "b51ea1264dc4bb23",
       "changed": "2026-09-11"
     },
     "/vendor/mailchimp": {
-      "hash": "46285963dd26a420",
+      "hash": "1d09ccfc5b34a0fe",
       "changed": "2026-09-11"
     },
     "/vendor/maildroppa": {
-      "hash": "579877a6ec9a6691",
+      "hash": "2d1fd71d6e6f80dd",
       "changed": "2026-09-11"
     },
     "/vendor/mailerlite-com": {
-      "hash": "cd383647e2cd5755",
+      "hash": "645eed505bef894e",
       "changed": "2026-09-11"
     },
     "/vendor/maileroo": {
-      "hash": "c71ab5b50c6af9ca",
+      "hash": "7a053bd99b56306d",
       "changed": "2026-09-11"
     },
     "/vendor/mailersend-com": {
-      "hash": "cc20a8384976b635",
+      "hash": "07fc4685df15d308",
       "changed": "2026-09-11"
     },
     "/vendor/mailinator-com": {
-      "hash": "c5a2b0976f551eb4",
+      "hash": "5a7019ff44b97040",
       "changed": "2026-09-11"
     },
     "/vendor/mailjet": {
-      "hash": "176fd76e9781c1cc",
+      "hash": "ac5959ac0ae56480",
       "changed": "2026-09-11"
     },
     "/vendor/mailsac-com": {
-      "hash": "b58ef2a7652450cb",
+      "hash": "c376f0684deb00a4",
       "changed": "2026-09-11"
     },
     "/vendor/mailtrap-io": {
-      "hash": "6b55b2a05fa7e9a6",
+      "hash": "7ed73d3e583c18b0",
       "changed": "2026-09-11"
     },
     "/vendor/make": {
-      "hash": "62f52937c498ee28",
+      "hash": "a8f3ab8ea8b85e9b",
       "changed": "2026-09-11"
     },
     "/vendor/manageengine-log360-cloud": {
-      "hash": "bb6b669ce9b106a9",
+      "hash": "86bbd03ed59ee6c2",
       "changed": "2026-09-11"
     },
     "/vendor/mantledb": {
-      "hash": "70216ac1edddec46",
+      "hash": "18b4a4493c9e0162",
       "changed": "2026-09-11"
     },
     "/vendor/manubes": {
-      "hash": "9523ee7d25b56b2c",
+      "hash": "f35e2d4c503058ea",
       "changed": "2026-09-11"
     },
     "/vendor/mapbox": {
-      "hash": "a0d4dd50ed3b7d36",
+      "hash": "11c0b0d7031da227",
       "changed": "2026-09-11"
     },
     "/vendor/maps-stamen-com": {
-      "hash": "8a5b28da797d9a47",
+      "hash": "b3f1b639814339dd",
       "changed": "2026-09-11"
     },
     "/vendor/maptiler-com": {
-      "hash": "86b08dd635701a62",
+      "hash": "1c95c96727c6ded8",
       "changed": "2026-09-11"
     },
     "/vendor/market-data-api": {
-      "hash": "72fca14495d6ea9e",
+      "hash": "489ad04e92b94ae4",
       "changed": "2026-09-11"
     },
     "/vendor/marscode": {
-      "hash": "9b2c308aa2d76658",
+      "hash": "2c51dbd7fa486726",
       "changed": "2026-09-11"
     },
     "/vendor/marvelapp-com": {
-      "hash": "52a801ac8403cdec",
+      "hash": "e8b54616bbb679e5",
       "changed": "2026-09-11"
     },
     "/vendor/mastershot": {
-      "hash": "c3ad9e1c740f0363",
+      "hash": "3b717985dfa8b744",
       "changed": "2026-09-11"
     },
     "/vendor/matlab-and-simulink-for-startups": {
-      "hash": "6c141f1b952765a7",
+      "hash": "5eeb5b3c273e1c3f",
       "changed": "2026-09-11"
     },
     "/vendor/maxim-ai": {
       "daily": true
     },
     "/vendor/mconverter": {
-      "hash": "187651728f679fd2",
+      "hash": "86a80d318108ec5a",
       "changed": "2026-09-11"
     },
     "/vendor/mdb-go": {
       "daily": true
     },
     "/vendor/mdbootstrap": {
-      "hash": "a2201aeb4039b293",
+      "hash": "b8ccb5254bdd9f69",
       "changed": "2026-09-11"
     },
     "/vendor/mediaworkbench-ai": {
-      "hash": "c98c77e30757877c",
+      "hash": "dc256911fe331020",
       "changed": "2026-09-11"
     },
     "/vendor/meet-jit-si": {
-      "hash": "c5d45a0cd42e47bc",
+      "hash": "5cf520ac11cb100b",
       "changed": "2026-09-11"
     },
     "/vendor/mega": {
-      "hash": "3c1bdc4ed50063e9",
+      "hash": "35f96533c016ab03",
       "changed": "2026-09-11"
     },
     "/vendor/meilisearch": {
-      "hash": "4a1482d1d050cbe6",
+      "hash": "2b65eb714bb0bbf5",
       "changed": "2026-09-11"
     },
     "/vendor/meistertask": {
-      "hash": "096d3b7166653d93",
+      "hash": "6c8304c180706eac",
       "changed": "2026-09-11"
     },
     "/vendor/memfault-com": {
-      "hash": "be2e046fbe18aadd",
+      "hash": "8c591604788587c7",
       "changed": "2026-09-11"
     },
     "/vendor/mendix": {
-      "hash": "f359b0fc19eb9bca",
+      "hash": "0b1b9b723a459610",
       "changed": "2026-09-11"
     },
     "/vendor/mention": {
-      "hash": "a78a60a83359dec0",
+      "hash": "5338a7062cbad078",
       "changed": "2026-09-11"
     },
     "/vendor/mercury": {
-      "hash": "419e15d750113191",
+      "hash": "0ce0988e3101b2b3",
       "changed": "2026-09-11"
     },
     "/vendor/mergify": {
-      "hash": "db1b76dae6b00388",
+      "hash": "e0152382856b6946",
       "changed": "2026-09-11"
     },
     "/vendor/metalama": {
-      "hash": "35009fb83c744101",
+      "hash": "7606241dcafb7b12",
       "changed": "2026-09-11"
     },
     "/vendor/meterian-io": {
-      "hash": "34b22abf626b1c35",
+      "hash": "83544677e00ee4b1",
       "changed": "2026-09-11"
     },
     "/vendor/metricswave": {
-      "hash": "de7efb5a02b8385b",
+      "hash": "a2f500784fb2fd54",
       "changed": "2026-09-11"
     },
     "/vendor/microlink-io": {
-      "hash": "0cdd1e2b5270a921",
+      "hash": "f6f0e1842f4fb4d4",
       "changed": "2026-09-11"
     },
     "/vendor/microsoft-ajax": {
-      "hash": "b69d43b28178a8b8",
+      "hash": "618bd3dfc0eab2ae",
       "changed": "2026-09-11"
     },
     "/vendor/microsoft-clarity": {
-      "hash": "b6c3d2a4c8bcc61e",
+      "hash": "6be7304c0c8c594f",
       "changed": "2026-09-11"
     },
     "/vendor/microsoft-for-startups": {
-      "hash": "391357f13f52f09a",
+      "hash": "2609035a63734b92",
       "changed": "2026-09-11"
     },
     "/vendor/microsoft-founders-hub": {
-      "hash": "7118355c0c47b017",
+      "hash": "80113ff17e0acbe9",
       "changed": "2026-09-11"
     },
     "/vendor/microsoft-teams": {
-      "hash": "3840a347794d3630",
+      "hash": "2c8b7af6c1a91b52",
       "changed": "2026-09-11"
     },
     "/vendor/microsoft-to-do": {
-      "hash": "e91c5c80a6a6ac4f",
+      "hash": "923bf1e63b20353c",
       "changed": "2026-09-11"
     },
     "/vendor/middleware-io": {
       "daily": true
     },
     "/vendor/mindmup-com": {
-      "hash": "df853798f1986095",
+      "hash": "d3aa57eeb4a56b01",
       "changed": "2026-09-11"
     },
     "/vendor/minimax": {
       "daily": true
     },
     "/vendor/minio": {
-      "hash": "bf458a0a7df8d1d9",
+      "hash": "8d626081864f8eab",
       "changed": "2026-09-11"
     },
     "/vendor/mintlify": {
-      "hash": "8eec8398eb21316d",
+      "hash": "36b59cd667532338",
       "changed": "2026-09-11"
     },
     "/vendor/miradore": {
-      "hash": "45c85fe4118497e7",
+      "hash": "446d44e9b14fdaa3",
       "changed": "2026-09-11"
     },
     "/vendor/miro": {
-      "hash": "c6a14f3504c0a3de",
+      "hash": "bdbdba807cc5abd6",
       "changed": "2026-09-11"
     },
     "/vendor/mistral-ai": {
       "daily": true
     },
     "/vendor/mit-opencourseware": {
-      "hash": "ec4075aa084c5037",
+      "hash": "3b5dc8ce0c313268",
       "changed": "2026-09-11"
     },
     "/vendor/mixpanel": {
-      "hash": "9b9d8db265d2fabd",
+      "hash": "399c8b56dda09566",
       "changed": "2026-09-11"
     },
     "/vendor/mockapi": {
-      "hash": "754f52f51ed90917",
+      "hash": "0dee2b1bfcb1169c",
       "changed": "2026-09-11"
     },
     "/vendor/mockaroo": {
-      "hash": "ec2d35cbb6a49fdf",
+      "hash": "e9e9073c22321927",
       "changed": "2026-09-11"
     },
     "/vendor/mockerito": {
-      "hash": "d794e2db871ec0fe",
+      "hash": "318b8428549809ec",
       "changed": "2026-09-11"
     },
     "/vendor/mockfly": {
-      "hash": "55fd9e7d21c1491e",
+      "hash": "5a3d854fafc4f82c",
       "changed": "2026-09-11"
     },
     "/vendor/mocklets": {
-      "hash": "2fd90a2d34375f2c",
+      "hash": "5012cda7c22aa007",
       "changed": "2026-09-11"
     },
     "/vendor/mocko-dev": {
-      "hash": "d89f5f234259537e",
+      "hash": "59889665237f0dbd",
       "changed": "2026-09-11"
     },
     "/vendor/mockoon": {
-      "hash": "4c4353f689eb3535",
+      "hash": "707eed5fd863ac25",
       "changed": "2026-09-11"
     },
     "/vendor/mockplus-idoc": {
-      "hash": "9f615676b8fc6849",
+      "hash": "77c0de2a12f0d4e3",
       "changed": "2026-09-11"
     },
     "/vendor/mockupmark-com": {
-      "hash": "a8395d3bfc62cf43",
+      "hash": "0b038ac309893929",
       "changed": "2026-09-11"
     },
     "/vendor/modal": {
       "daily": true
     },
     "/vendor/moesif": {
-      "hash": "bdf06896acae7a05",
+      "hash": "e75b998cf9707968",
       "changed": "2026-09-11"
     },
     "/vendor/moesif-api-monetization": {
-      "hash": "7e4b7f403315df2a",
+      "hash": "d274b3def4627d82",
       "changed": "2026-09-11"
     },
     "/vendor/mojoauth": {
-      "hash": "3417a23c7aade8db",
+      "hash": "1eb2c27c8aed313d",
       "changed": "2026-09-11"
     },
     "/vendor/momento": {
       "daily": true
     },
     "/vendor/mongodb": {
-      "hash": "a84003178b2de520",
+      "hash": "4beef46d2fb977cc",
       "changed": "2026-09-11"
     },
     "/vendor/mongodb-atlas": {
@@ -7020,58 +7020,58 @@
       "daily": true
     },
     "/vendor/moss-sh": {
-      "hash": "04eb6adc9db862f0",
+      "hash": "dde6dd943b0c1023",
       "changed": "2026-09-11"
     },
     "/vendor/mossaik": {
-      "hash": "7196cc48f7aabd48",
+      "hash": "ca8e2c0460e027cf",
       "changed": "2026-09-11"
     },
     "/vendor/moto": {
-      "hash": "2c9e9a563b3f7009",
+      "hash": "5806f5dfb31bfd57",
       "changed": "2026-09-11"
     },
     "/vendor/mouseflow-com": {
-      "hash": "153d8280cb9eac4b",
+      "hash": "17cadfcd294c3491",
       "changed": "2026-09-11"
     },
     "/vendor/mozilla-observatory": {
-      "hash": "9e9d2b02a2d0ad61",
+      "hash": "a5b590b2c64d49b6",
       "changed": "2026-09-11"
     },
     "/vendor/multi-exit-ip-address-checker": {
-      "hash": "51b3f71ccb744481",
+      "hash": "fb628bbc8f1386b5",
       "changed": "2026-09-11"
     },
     "/vendor/mutant-mail": {
-      "hash": "164cd13c89ca2d87",
+      "hash": "71f3dfc5da82f3b8",
       "changed": "2026-09-11"
     },
     "/vendor/mux": {
-      "hash": "f5d78b884cc91206",
+      "hash": "4b961a3707827248",
       "changed": "2026-09-11"
     },
     "/vendor/n8n": {
       "daily": true
     },
     "/vendor/namae": {
-      "hash": "2d320277d1b2b26e",
+      "hash": "5ef1ed10e8f7841f",
       "changed": "2026-09-11"
     },
     "/vendor/namecheap-com": {
-      "hash": "ecbef2253471b394",
+      "hash": "ab3db568da9babec",
       "changed": "2026-09-11"
     },
     "/vendor/namecheap-supersonic": {
-      "hash": "12c5934a078c999c",
+      "hash": "de6f0dba121259a7",
       "changed": "2026-09-11"
     },
     "/vendor/nango": {
-      "hash": "ee7cb5db0d28a1b5",
+      "hash": "ed6dfe96a2eac963",
       "changed": "2026-09-11"
     },
     "/vendor/nappy": {
-      "hash": "29c63ca9eb04df7a",
+      "hash": "374058d90dfb1f5d",
       "changed": "2026-09-11"
     },
     "/vendor/neo4j-auradb": {
@@ -7084,7 +7084,7 @@
       "daily": true
     },
     "/vendor/neptune-ai": {
-      "hash": "aa4dfa76923e7a12",
+      "hash": "aba96ef4f67091a1",
       "changed": "2026-09-11"
     },
     "/vendor/netdata-cloud": {
@@ -7097,23 +7097,23 @@
       "daily": true
     },
     "/vendor/newreleases-io": {
-      "hash": "f7b2923d0393d67b",
+      "hash": "6673d34b7a6bc316",
       "changed": "2026-09-11"
     },
     "/vendor/news-api": {
-      "hash": "135571fbccd3ab2d",
+      "hash": "bd75c7225de355bc",
       "changed": "2026-09-11"
     },
     "/vendor/nextdns-io": {
-      "hash": "627aaef6bf4d01cc",
+      "hash": "11415dd5e306c9c3",
       "changed": "2026-09-11"
     },
     "/vendor/nextra": {
-      "hash": "2385fc659ba2f208",
+      "hash": "2b3b51ee43d1a681",
       "changed": "2026-09-11"
     },
     "/vendor/ngrok": {
-      "hash": "7420d3c183dab9c6",
+      "hash": "39d3ae6cecbdbd78",
       "changed": "2026-09-11"
     },
     "/vendor/nhost": {
@@ -7123,138 +7123,138 @@
       "daily": true
     },
     "/vendor/ninja-outreach": {
-      "hash": "86958f6f829b42a1",
+      "hash": "b061c6135acf1ebd",
       "changed": "2026-09-11"
     },
     "/vendor/nitropack-io": {
-      "hash": "98fcfba2affe344c",
+      "hash": "415c9a22351ed7eb",
       "changed": "2026-09-11"
     },
     "/vendor/nocrm": {
-      "hash": "9b6b424f9451f99f",
+      "hash": "5f0382da9db7c1e8",
       "changed": "2026-09-11"
     },
     "/vendor/noip": {
-      "hash": "8d0ac72d355f2e02",
+      "hash": "c4eb1f8df821867c",
       "changed": "2026-09-11"
     },
     "/vendor/nominatim-org": {
-      "hash": "ccbafb4af3107333",
+      "hash": "2da9b16986d25270",
       "changed": "2026-09-11"
     },
     "/vendor/nordpass": {
-      "hash": "4b8019f89059e9ca",
+      "hash": "d7932dbf6928cc81",
       "changed": "2026-09-11"
     },
     "/vendor/northflank": {
       "daily": true
     },
     "/vendor/notion": {
-      "hash": "5c8f32921b765780",
+      "hash": "1203fd201571c9fe",
       "changed": "2026-09-11"
     },
     "/vendor/novu": {
-      "hash": "b02a404f7009d5c6",
+      "hash": "0df9aa90ae4bd665",
       "changed": "2026-09-11"
     },
     "/vendor/npoint-io": {
-      "hash": "486964264a3061a5",
+      "hash": "09c19d683d3f86e7",
       "changed": "2026-09-11"
     },
     "/vendor/ns1-connect": {
-      "hash": "84ee8031d826a9a8",
+      "hash": "747c5c03c03ff94e",
       "changed": "2026-09-11"
     },
     "/vendor/nspolygon": {
-      "hash": "242711e57c723d21",
+      "hash": "67d9e4c385fd83a4",
       "changed": "2026-09-11"
     },
     "/vendor/ntask": {
-      "hash": "3878ef70a6c1b599",
+      "hash": "62c16cafb2d8c686",
       "changed": "2026-09-11"
     },
     "/vendor/nuclei": {
-      "hash": "a5dd23d114cd5932",
+      "hash": "363d965d72a449cb",
       "changed": "2026-09-11"
     },
     "/vendor/nuclino": {
-      "hash": "3cecc12940169db9",
+      "hash": "d555970b663863b4",
       "changed": "2026-09-11"
     },
     "/vendor/numlookupapi-com": {
-      "hash": "daf9159d208cacc4",
+      "hash": "198b08d0a27f111d",
       "changed": "2026-09-11"
     },
     "/vendor/numverify": {
-      "hash": "f1d086f14991444c",
+      "hash": "22c8784ba8b0fc2b",
       "changed": "2026-09-11"
     },
     "/vendor/nvidia-nim": {
       "daily": true
     },
     "/vendor/nx-cloud": {
-      "hash": "b021df409af2a054",
+      "hash": "c3e0efb1cf68aac7",
       "changed": "2026-09-11"
     },
     "/vendor/oaysus": {
-      "hash": "cc65c3071d1c0734",
+      "hash": "5d3e4d985a54ea9c",
       "changed": "2026-09-11"
     },
     "/vendor/obsidian": {
-      "hash": "36412d6cdc66a19e",
+      "hash": "b87c2a00ab71df87",
       "changed": "2026-09-11"
     },
     "/vendor/ocr-space": {
       "daily": true
     },
     "/vendor/octopus-do": {
-      "hash": "76f4a03f7cbce76f",
+      "hash": "34afc0af8adee2fe",
       "changed": "2026-09-11"
     },
     "/vendor/odrive": {
-      "hash": "aa9413ce28ebf6e7",
+      "hash": "b43c8e9078f31420",
       "changed": "2026-09-11"
     },
     "/vendor/oklch": {
-      "hash": "334b3802847d27b8",
+      "hash": "a9b8a48da38f10b8",
       "changed": "2026-09-11"
     },
     "/vendor/okso-app": {
-      "hash": "0957464bbe85c3f0",
+      "hash": "b65df9699174d738",
       "changed": "2026-09-11"
     },
     "/vendor/okta": {
-      "hash": "1218378e6d95d356",
+      "hash": "9cdc3ae099c92254",
       "changed": "2026-09-11"
     },
     "/vendor/ollama-cloud": {
       "daily": true
     },
     "/vendor/onecompiler": {
-      "hash": "5b0a3268930a6b84",
+      "hash": "e83028ecf2560625",
       "changed": "2026-09-11"
     },
     "/vendor/onedrive": {
-      "hash": "5e729c4c980c7826",
+      "hash": "b4d26d06cddcd63b",
       "changed": "2026-09-11"
     },
     "/vendor/onesignal": {
-      "hash": "610eee9d539c92ad",
+      "hash": "9e557a1f60b64411",
       "changed": "2026-09-11"
     },
     "/vendor/onlineexifviewer": {
-      "hash": "fcabb668e6b160da",
+      "hash": "2b98676858c137e7",
       "changed": "2026-09-11"
     },
     "/vendor/onlineinterview-io": {
-      "hash": "b15557143ee5f6e5",
+      "hash": "7f26bce73c0f2bb5",
       "changed": "2026-09-11"
     },
     "/vendor/onlineornot": {
       "daily": true
     },
     "/vendor/ontarionet-ca-cn-test": {
-      "hash": "0cd257333d9d0ffb",
+      "hash": "e7a7dd671951abd7",
       "changed": "2026-09-11"
     },
     "/vendor/openai": {
@@ -7264,88 +7264,88 @@
       "daily": true
     },
     "/vendor/openapi3-designer": {
-      "hash": "9f1b51122c6129be",
+      "hash": "22792ab2fb1dc2e8",
       "changed": "2026-09-11"
     },
     "/vendor/opencagedata-com": {
-      "hash": "db34b5642013fa57",
+      "hash": "fd6432ca1cd9c06e",
       "changed": "2026-09-11"
     },
     "/vendor/openobserve-ai": {
-      "hash": "1a6de0ba6e45b59f",
+      "hash": "5bde012340c4ff6f",
       "changed": "2026-09-11"
     },
     "/vendor/openreplay-com": {
-      "hash": "7d5249c4d304d19e",
+      "hash": "685bbd2277b0317a",
       "changed": "2026-09-11"
     },
     "/vendor/openrouter": {
       "daily": true
     },
     "/vendor/openstatus": {
-      "hash": "ba299e4bca060556",
+      "hash": "e330131de69ea9fc",
       "changed": "2026-09-11"
     },
     "/vendor/openvps": {
-      "hash": "f989054a41dbf0c0",
+      "hash": "9956f4a110dd3fc1",
       "changed": "2026-09-11"
     },
     "/vendor/openweathermap": {
-      "hash": "e46ba1b9588e01b0",
+      "hash": "013dc68297d19332",
       "changed": "2026-09-11"
     },
     "/vendor/oracle-cloud": {
-      "hash": "941100f2f01df86f",
+      "hash": "971df0bba425cda4",
       "changed": "2026-09-11"
     },
     "/vendor/orama": {
-      "hash": "6b34d7ccf19e0f7f",
+      "hash": "92f60c0bcba4a7b0",
       "changed": "2026-09-11"
     },
     "/vendor/ory": {
-      "hash": "2d4bbb5e902be0d0",
+      "hash": "bdbbddd2ec1b5e3d",
       "changed": "2026-09-11"
     },
     "/vendor/osmnames": {
-      "hash": "441f21d0492f1fff",
+      "hash": "5369ca60159bfe32",
       "changed": "2026-09-11"
     },
     "/vendor/othor-ai": {
-      "hash": "0e89041193e08bfd",
+      "hash": "2db0bc8fedb937df",
       "changed": "2026-09-11"
     },
     "/vendor/outlook-com": {
-      "hash": "8f0f01d696d57b08",
+      "hash": "1119f2e37f544136",
       "changed": "2026-09-11"
     },
     "/vendor/outsystems-com": {
-      "hash": "552a968f45d1cab2",
+      "hash": "1b86d905941d78e5",
       "changed": "2026-09-11"
     },
     "/vendor/ovhcloud": {
       "daily": true
     },
     "/vendor/owasp-zap": {
-      "hash": "7417a4ba2c5f60d5",
+      "hash": "4e8283cce673f111",
       "changed": "2026-09-11"
     },
     "/vendor/packagecloud-io": {
-      "hash": "f0a03d4fb6bd4b86",
+      "hash": "647933ca5bed59f3",
       "changed": "2026-09-11"
     },
     "/vendor/paddle": {
-      "hash": "f8104be29e610e1d",
+      "hash": "2f6fbe742acceba3",
       "changed": "2026-09-11"
     },
     "/vendor/pageclip": {
-      "hash": "28d7139ef8002dce",
+      "hash": "88e73197f3b1dbdc",
       "changed": "2026-09-11"
     },
     "/vendor/pagecrawl-io": {
       "daily": true
     },
     "/vendor/pagegym-com": {
-      "hash": "8213fbd025438026",
+      "hash": "29e186923ee5fdf8",
       "changed": "2026-09-11"
     },
     "/vendor/pagerduty": {
@@ -7355,11 +7355,11 @@
       "daily": true
     },
     "/vendor/pagure-io": {
-      "hash": "d85fa643284a0564",
+      "hash": "8cae77dff55c4695",
       "changed": "2026-09-11"
     },
     "/vendor/paiza": {
-      "hash": "72782ab32ebaa1ef",
+      "hash": "dbba3795b84998d1",
       "changed": "2026-09-11"
     },
     "/vendor/pandastack": {
@@ -7375,66 +7375,66 @@
       "daily": true
     },
     "/vendor/pareto-security": {
-      "hash": "652f3aefdfae9cac",
+      "hash": "3fda46d0df2fa13e",
       "changed": "2026-09-11"
     },
     "/vendor/parityvend": {
-      "hash": "0410828864fd36c2",
+      "hash": "dd863ace3ab8a347",
       "changed": "2026-09-11"
     },
     "/vendor/parseur": {
       "daily": true
     },
     "/vendor/payfit": {
-      "hash": "5db56f59d72f6083",
+      "hash": "3ed38b075d33c140",
       "changed": "2026-09-11"
     },
     "/vendor/payload-cms": {
-      "hash": "7f7424facc5c368d",
+      "hash": "effa0bac747e7377",
       "changed": "2026-09-11"
     },
     "/vendor/pcloud": {
-      "hash": "1623639ace31309f",
+      "hash": "0fe67a7ab4b47ff0",
       "changed": "2026-09-11"
     },
     "/vendor/pdf-api-io": {
-      "hash": "46a5af4c877357b7",
+      "hash": "26ca7d1ced1e83ec",
       "changed": "2026-09-11"
     },
     "/vendor/pdfbolt": {
-      "hash": "312b347ff49fe739",
+      "hash": "88de73d550710431",
       "changed": "2026-09-11"
     },
     "/vendor/pdfendpoint-com": {
-      "hash": "b8b017f73bb55b5c",
+      "hash": "7a67e3ca2cc523cb",
       "changed": "2026-09-11"
     },
     "/vendor/pdfmonkey": {
-      "hash": "8f1d6fbc9fd520e3",
+      "hash": "dc3ab9ffc204fb3d",
       "changed": "2026-09-11"
     },
     "/vendor/pendulums": {
-      "hash": "3aeed8db1fc844a5",
+      "hash": "358c401c97ae6523",
       "changed": "2026-09-11"
     },
     "/vendor/penpot": {
-      "hash": "330eed8120ef019e",
+      "hash": "91069ae1b4621507",
       "changed": "2026-09-11"
     },
     "/vendor/permit-io": {
-      "hash": "bc3258c256a8ed61",
+      "hash": "f93e2b89647ccef3",
       "changed": "2026-09-11"
     },
     "/vendor/pexels-com": {
-      "hash": "3dae76888ce90187",
+      "hash": "32c257afc24b2e2a",
       "changed": "2026-09-11"
     },
     "/vendor/phantom-buster": {
-      "hash": "3c4e860fb071cbce",
+      "hash": "090cd39c8fed7372",
       "changed": "2026-09-11"
     },
     "/vendor/phantomjscloud": {
-      "hash": "42a837534013dc2c",
+      "hash": "d6366c4f0c113787",
       "changed": "2026-09-11"
     },
     "/vendor/phare-io": {
@@ -7444,23 +7444,23 @@
       "daily": true
     },
     "/vendor/photopea": {
-      "hash": "d01d1bd2da46035e",
+      "hash": "abcb9a66419128e6",
       "changed": "2026-09-11"
     },
     "/vendor/phpsandbox": {
-      "hash": "7f74506d0cf02000",
+      "hash": "01cbab7dbbb35dce",
       "changed": "2026-09-11"
     },
     "/vendor/pijul-com": {
-      "hash": "8eca85002971260c",
+      "hash": "28cd1b05a4dee5ad",
       "changed": "2026-09-11"
     },
     "/vendor/pika-code-screenshots": {
-      "hash": "f2f87400c666d102",
+      "hash": "8ae34a7b974be1cd",
       "changed": "2026-09-11"
     },
     "/vendor/pinata-ipfs": {
-      "hash": "a892025d09b8ab70",
+      "hash": "759f935b8622e79f",
       "changed": "2026-09-11"
     },
     "/vendor/pinecone": {
@@ -7470,7 +7470,7 @@
       "daily": true
     },
     "/vendor/pinggy": {
-      "hash": "9adf9b7b83431325",
+      "hash": "b935fc19c358b70a",
       "changed": "2026-09-11"
     },
     "/vendor/pingmeter-com": {
@@ -7480,90 +7480,90 @@
       "daily": true
     },
     "/vendor/pingram-io": {
-      "hash": "be6b551d6fd023f9",
+      "hash": "4c9932e6ab35cd92",
       "changed": "2026-09-11"
     },
     "/vendor/pipedream": {
-      "hash": "0372fefb493fe36c",
+      "hash": "387e4fbe8173ebc3",
       "changed": "2026-09-11"
     },
     "/vendor/pipedrive": {
-      "hash": "f18002bfc0359ee9",
+      "hash": "aad456ea4cf7871d",
       "changed": "2026-09-11"
     },
     "/vendor/pixela": {
-      "hash": "46a03f05bc2f899b",
+      "hash": "b93025565663412e",
       "changed": "2026-09-11"
     },
     "/vendor/pixelme": {
-      "hash": "aa9d0fa33e0c7320",
+      "hash": "140384c23e679382",
       "changed": "2026-09-11"
     },
     "/vendor/pixlr": {
-      "hash": "25600fa6a5ef48ee",
+      "hash": "cf93b3ee6a1fa07c",
       "changed": "2026-09-11"
     },
     "/vendor/plane": {
-      "hash": "c252a0723a4ac2a2",
+      "hash": "66e9ffe008b033c9",
       "changed": "2026-09-11"
     },
     "/vendor/planitpoker-com": {
-      "hash": "63c0c1e4d66faf39",
+      "hash": "d5626916739d4686",
       "changed": "2026-09-11"
     },
     "/vendor/plasmic": {
-      "hash": "3ec114e5e2e1b3c4",
+      "hash": "5ba963c6488f8c57",
       "changed": "2026-09-11"
     },
     "/vendor/plausible-analytics": {
-      "hash": "3cb6b38d583e0ced",
+      "hash": "50f3f442e71feb9b",
       "changed": "2026-09-11"
     },
     "/vendor/play-with-docker": {
-      "hash": "305c21f2125565b5",
+      "hash": "8c1546703519fe33",
       "changed": "2026-09-11"
     },
     "/vendor/playwright": {
-      "hash": "877dfbeaf2936581",
+      "hash": "fdbc40eb47d004a8",
       "changed": "2026-09-11"
     },
     "/vendor/ploi-io": {
-      "hash": "0609b4ef78cc776d",
+      "hash": "c43104cd9c2f8e4f",
       "changed": "2026-09-11"
     },
     "/vendor/plot-ly": {
-      "hash": "ffe169fa132b9318",
+      "hash": "619b524c901ff24e",
       "changed": "2026-09-11"
     },
     "/vendor/plunk": {
-      "hash": "af930fdec21beb3d",
+      "hash": "2225b726d207d347",
       "changed": "2026-09-11"
     },
     "/vendor/png-to-webp-converter": {
-      "hash": "4dd9787fa2a90e2c",
+      "hash": "104de930ef0ac043",
       "changed": "2026-09-11"
     },
     "/vendor/pocket-alert": {
-      "hash": "d4d7e1eee1672a00",
+      "hash": "1400dd91d51d0eb4",
       "changed": "2026-09-11"
     },
     "/vendor/pocketbase": {
       "daily": true
     },
     "/vendor/podio-com": {
-      "hash": "802304fa2d0743f6",
+      "hash": "dc5daf4f60a131f2",
       "changed": "2026-09-11"
     },
     "/vendor/poeditor": {
-      "hash": "845a68ecf6927722",
+      "hash": "619cef0e0a1027f8",
       "changed": "2026-09-11"
     },
     "/vendor/point-poker": {
-      "hash": "4cc47b8e64801b1f",
+      "hash": "987a69f5282f8235",
       "changed": "2026-09-11"
     },
     "/vendor/polar": {
-      "hash": "cd857868c9101191",
+      "hash": "b32140ae2e9136b9",
       "changed": "2026-09-11"
     },
     "/vendor/pollinations-ai": {
@@ -7573,139 +7573,139 @@
       "daily": true
     },
     "/vendor/positionstack": {
-      "hash": "2472905dc28fb19d",
+      "hash": "9838fc5bd6832bb2",
       "changed": "2026-09-11"
     },
     "/vendor/postal": {
-      "hash": "a1fe8eb218c41258",
+      "hash": "102e1b5732755d66",
       "changed": "2026-09-11"
     },
     "/vendor/posthog": {
-      "hash": "427d0ebac912c18f",
+      "hash": "421936e739cc9169",
       "changed": "2026-09-11"
     },
     "/vendor/postman": {
       "daily": true
     },
     "/vendor/postmark": {
-      "hash": "e0529ae10454dc29",
+      "hash": "04a61ee6cb7cfaf8",
       "changed": "2026-09-11"
     },
     "/vendor/postscript": {
-      "hash": "633038a3623686ce",
+      "hash": "3a95697b43cc17db",
       "changed": "2026-09-11"
     },
     "/vendor/pp-ua": {
-      "hash": "2573e762db91eaaa",
+      "hash": "397a797d92cd564d",
       "changed": "2026-09-11"
     },
     "/vendor/pravatar": {
-      "hash": "f70dedb75bc97583",
+      "hash": "1ba5942707aaed61",
       "changed": "2026-09-11"
     },
     "/vendor/prefectcloud": {
-      "hash": "4fd683b76b9c5b36",
+      "hash": "625fe58a3e749517",
       "changed": "2026-09-11"
     },
     "/vendor/preset-cloud": {
-      "hash": "bc8e8841c8dd9dcf",
+      "hash": "6d66f0f46241a047",
       "changed": "2026-09-11"
     },
     "/vendor/prisma-accelerate": {
-      "hash": "34148c285a740b58",
+      "hash": "b84e65a4da54e3da",
       "changed": "2026-09-11"
     },
     "/vendor/prismic": {
-      "hash": "f3d1f165f2a2b957",
+      "hash": "2b5e7654d1064e53",
       "changed": "2026-09-11"
     },
     "/vendor/probely": {
-      "hash": "4fb3518b5358e8f2",
+      "hash": "67c55b8c7f2768c2",
       "changed": "2026-09-11"
     },
     "/vendor/prometheus": {
       "daily": true
     },
     "/vendor/promoproxy": {
-      "hash": "5a3d92364384d3cf",
+      "hash": "0a3cf878fe4bfc57",
       "changed": "2026-09-11"
     },
     "/vendor/propelauth": {
-      "hash": "e71c36343b70359d",
+      "hash": "c85a19cd1b453fda",
       "changed": "2026-09-11"
     },
     "/vendor/prospectin": {
-      "hash": "bf807d6d5e4fc265",
+      "hash": "623b8dedaeb606be",
       "changed": "2026-09-11"
     },
     "/vendor/proto-io": {
-      "hash": "f15df7c3839deb07",
+      "hash": "44d6d8ca2e602537",
       "changed": "2026-09-11"
     },
     "/vendor/proton-drive": {
-      "hash": "7c9f368fee298709",
+      "hash": "82bf5e765de635de",
       "changed": "2026-09-11"
     },
     "/vendor/proton-mail": {
-      "hash": "3a3613494af3e3b0",
+      "hash": "04a963827c88a4f1",
       "changed": "2026-09-11"
     },
     "/vendor/proton-pass": {
-      "hash": "4d8cf9922c0de1d6",
+      "hash": "3ae36c3b1aec76af",
       "changed": "2026-09-11"
     },
     "/vendor/proton-vpn": {
-      "hash": "2306be6e8ce7ebd7",
+      "hash": "ffd7d109b953d773",
       "changed": "2026-09-11"
     },
     "/vendor/proxysentry": {
-      "hash": "444850a9611042bb",
+      "hash": "82180675a8445c2c",
       "changed": "2026-09-11"
     },
     "/vendor/public-cloud-threat-intelligence": {
-      "hash": "4531654b79b9ba0c",
+      "hash": "14962ccf63846b7b",
       "changed": "2026-09-11"
     },
     "/vendor/publist": {
-      "hash": "5abe8f606b9b16ae",
+      "hash": "cd6349ff424c4550",
       "changed": "2026-09-11"
     },
     "/vendor/pubnub-com": {
-      "hash": "671ed79ea1ee2447",
+      "hash": "de0999a5df96d8e0",
       "changed": "2026-09-11"
     },
     "/vendor/pullflow": {
-      "hash": "0774b9137c3b88d7",
+      "hash": "74e62e2ddf5764da",
       "changed": "2026-09-11"
     },
     "/vendor/pulse-red": {
-      "hash": "bfae8d7fd2864d6d",
+      "hash": "aa6e285d473462f2",
       "changed": "2026-09-11"
     },
     "/vendor/pulsetic": {
       "daily": true
     },
     "/vendor/pulumi": {
-      "hash": "3d7d7878ee4bdbc4",
+      "hash": "fe7f82a75fdb60bf",
       "changed": "2026-09-11"
     },
     "/vendor/pumble": {
-      "hash": "1291b1aebfa0b37d",
+      "hash": "17737473eb7aa369",
       "changed": "2026-09-11"
     },
     "/vendor/puppeteer": {
-      "hash": "a042f15c2981db39",
+      "hash": "8ef6ec244e6e7cc6",
       "changed": "2026-09-11"
     },
     "/vendor/pusher": {
-      "hash": "f4dd3ee58701546a",
+      "hash": "c421a5d1f87634ba",
       "changed": "2026-09-11"
     },
     "/vendor/pythonanywhere": {
       "daily": true
     },
     "/vendor/qase-io": {
-      "hash": "5b863432a853fb73",
+      "hash": "4ee2a15ac9513186",
       "changed": "2026-09-11"
     },
     "/vendor/qdrant": {
@@ -7715,97 +7715,97 @@
       "daily": true
     },
     "/vendor/qonto": {
-      "hash": "11f30c33262f7337",
+      "hash": "b1477343ad4f73d0",
       "changed": "2026-09-11"
     },
     "/vendor/qonversion": {
-      "hash": "50ad093407dc2823",
+      "hash": "3023d49f7fcc9801",
       "changed": "2026-09-11"
     },
     "/vendor/qrme-sh": {
-      "hash": "6c8f587a6f719511",
+      "hash": "82218ef4a80ebf69",
       "changed": "2026-09-11"
     },
     "/vendor/qrtracer": {
-      "hash": "4c39d8d66cbbd600",
+      "hash": "e86857a7911f7cbe",
       "changed": "2026-09-11"
     },
     "/vendor/qstash": {
-      "hash": "b973ac1ca30f86f0",
+      "hash": "a7c6f4d708e8fdf6",
       "changed": "2026-09-11"
     },
     "/vendor/qualys-com": {
-      "hash": "e220de4e907368e1",
+      "hash": "243b095e9c5d36bc",
       "changed": "2026-09-11"
     },
     "/vendor/quant-ux": {
-      "hash": "9ff794e4dc6e4fb3",
+      "hash": "43250d4223b615fb",
       "changed": "2026-09-11"
     },
     "/vendor/quartzy": {
-      "hash": "3bd8c2113a269d3d",
+      "hash": "a518440a63b094c6",
       "changed": "2026-09-11"
     },
     "/vendor/quay-io": {
-      "hash": "740c6bfcfeb4229f",
+      "hash": "dbc82ed8ec1233fa",
       "changed": "2026-09-11"
     },
     "/vendor/quickbooks": {
-      "hash": "684d38d581872a08",
+      "hash": "ccc8d8399f39b2a8",
       "changed": "2026-09-11"
     },
     "/vendor/quickchart": {
-      "hash": "d585b7a6eaf69ea7",
+      "hash": "6df62f24fa06c07d",
       "changed": "2026-09-11"
     },
     "/vendor/quicktype-io": {
-      "hash": "95ebe4924915fb54",
+      "hash": "fbf6bee365b0a884",
       "changed": "2026-09-11"
     },
     "/vendor/radmin-vpn": {
-      "hash": "0e5020d84f7c77cd",
+      "hash": "af49f083d27812ff",
       "changed": "2026-09-11"
     },
     "/vendor/railway": {
       "daily": true
     },
     "/vendor/raindrop-io": {
-      "hash": "1a377173bee2f974",
+      "hash": "03929fb026bb13a3",
       "changed": "2026-09-11"
     },
     "/vendor/ramp": {
-      "hash": "10094b320f77f934",
+      "hash": "7d266603f14ae1b9",
       "changed": "2026-09-11"
     },
     "/vendor/randomkeygen": {
-      "hash": "9d770a0d090a08e7",
+      "hash": "afa5cfeeb780e013",
       "changed": "2026-09-11"
     },
     "/vendor/rapidapi": {
-      "hash": "e8d75c697b40472f",
+      "hash": "29cb4756e67f612b",
       "changed": "2026-09-11"
     },
     "/vendor/raw-githack-com": {
-      "hash": "624f5a55dcc84dfd",
+      "hash": "feea696d0dbfabdf",
       "changed": "2026-09-11"
     },
     "/vendor/ray-so": {
-      "hash": "2aa648633a99d7b9",
+      "hash": "90c302d36f3f2066",
       "changed": "2026-09-11"
     },
     "/vendor/readme": {
-      "hash": "5176faedf0c4834b",
+      "hash": "944f659c951f4296",
       "changed": "2026-09-11"
     },
     "/vendor/readthedocs-org": {
       "daily": true
     },
     "/vendor/redirect-pizza": {
-      "hash": "5879afb434b3741c",
+      "hash": "9388a4769a201215",
       "changed": "2026-09-11"
     },
     "/vendor/redirection-io": {
-      "hash": "92eab31bcfe60005",
+      "hash": "13a90b1571eee73f",
       "changed": "2026-09-11"
     },
     "/vendor/redis-cloud": {
@@ -7815,26 +7815,26 @@
       "daily": true
     },
     "/vendor/remarkbox": {
-      "hash": "5f557a265e3762b7",
+      "hash": "c72ac902d6526ce2",
       "changed": "2026-09-11"
     },
     "/vendor/remote-for-startups": {
-      "hash": "fe00bd1aa6c0489f",
+      "hash": "a18be9e8794d282b",
       "changed": "2026-09-11"
     },
     "/vendor/renamer-ai": {
-      "hash": "5de9a9a601630cec",
+      "hash": "ca9ef2a4111b48f0",
       "changed": "2026-09-11"
     },
     "/vendor/render": {
       "daily": true
     },
     "/vendor/rendi": {
-      "hash": "c0d492bf633b9a9a",
+      "hash": "d932621d9c2511e4",
       "changed": "2026-09-11"
     },
     "/vendor/renovate": {
-      "hash": "ce5f5845f9abf81e",
+      "hash": "91690f65d3a53e43",
       "changed": "2026-09-11"
     },
     "/vendor/replicate": {
@@ -7844,304 +7844,304 @@
       "daily": true
     },
     "/vendor/repoflow": {
-      "hash": "6a33a2b0296b068b",
+      "hash": "db07a2b743ac44ea",
       "changed": "2026-09-11"
     },
     "/vendor/repoforge": {
-      "hash": "ae91e3d211e28f62",
+      "hash": "c56166df8d9befc6",
       "changed": "2026-09-11"
     },
     "/vendor/repohistory": {
-      "hash": "ee7b2839135fddd7",
+      "hash": "95eeaaaee4fd0c9a",
       "changed": "2026-09-11"
     },
     "/vendor/reportgpt": {
-      "hash": "111d25864200bb8d",
+      "hash": "55aff342ee6ac087",
       "changed": "2026-09-11"
     },
     "/vendor/repsy-io": {
-      "hash": "daa2030ee918690f",
+      "hash": "2a24e70e3ffe973a",
       "changed": "2026-09-11"
     },
     "/vendor/reqbin": {
-      "hash": "ba8c885640cfff7c",
+      "hash": "eb49b6652d242a43",
       "changed": "2026-09-11"
     },
     "/vendor/requestbin-com": {
-      "hash": "f7513f40c4cd551d",
+      "hash": "2cef7370a08ac4f5",
       "changed": "2026-09-11"
     },
     "/vendor/resend": {
-      "hash": "7cc14a3d197287db",
+      "hash": "311aed68e1d8de06",
       "changed": "2026-09-11"
     },
     "/vendor/resizeappicon-com": {
-      "hash": "88e8d9c2064f746e",
+      "hash": "ee8fdd5e0e558497",
       "changed": "2026-09-11"
     },
     "/vendor/resmush-it": {
-      "hash": "1072aac94bc17607",
+      "hash": "3b73830bba57b6b0",
       "changed": "2026-09-11"
     },
     "/vendor/responsively-app": {
-      "hash": "4d80f9ad8e238489",
+      "hash": "6cb748d016884896",
       "changed": "2026-09-11"
     },
     "/vendor/restdb-io": {
       "daily": true
     },
     "/vendor/retool": {
-      "hash": "6b62582c7c450730",
+      "hash": "821e389a8563facd",
       "changed": "2026-09-11"
     },
     "/vendor/revenuecat": {
-      "hash": "235268d41c909ab2",
+      "hash": "830b41c4717cf7ee",
       "changed": "2026-09-11"
     },
     "/vendor/reviewable-io": {
-      "hash": "f19535227a496b48",
+      "hash": "6c3842e8c49de74e",
       "changed": "2026-09-11"
     },
     "/vendor/revolt-chat": {
-      "hash": "98c77b9f7014cc5f",
+      "hash": "3956f6803833ea0d",
       "changed": "2026-09-11"
     },
     "/vendor/rightfeature": {
-      "hash": "d2602d5f23f3c8c2",
+      "hash": "524f0e07e2b2c417",
       "changed": "2026-09-11"
     },
     "/vendor/rive": {
-      "hash": "bc7fd82c91694867",
+      "hash": "289f27a629ef4c85",
       "changed": "2026-09-11"
     },
     "/vendor/roboflow": {
       "daily": true
     },
     "/vendor/robohash": {
-      "hash": "eb2b3e100707a375",
+      "hash": "59486b4d5fcd80a5",
       "changed": "2026-09-11"
     },
     "/vendor/robusta-dev": {
-      "hash": "d02eec4346d6face",
+      "hash": "5e32fff7e0fe005a",
       "changed": "2026-09-11"
     },
     "/vendor/rocket-chat": {
-      "hash": "e110105cb1e59e08",
+      "hash": "f8c2362626c6a3fa",
       "changed": "2026-09-11"
     },
     "/vendor/rocketgit": {
-      "hash": "ad461f94222d7d69",
+      "hash": "519a1352f09a207e",
       "changed": "2026-09-11"
     },
     "/vendor/rollbar": {
-      "hash": "de5473ac307a3840",
+      "hash": "c7d3c8df06de9bf2",
       "changed": "2026-09-11"
     },
     "/vendor/row-zero": {
-      "hash": "3f8b1112777923e8",
+      "hash": "f423f5367a84138b",
       "changed": "2026-09-11"
     },
     "/vendor/runcloud-io": {
-      "hash": "42bef546a8b0fafb",
+      "hash": "e959ce7f0d5871c2",
       "changed": "2026-09-11"
     },
     "/vendor/runmyjob": {
-      "hash": "96117d940b75ab06",
+      "hash": "db012d3f1ac987b5",
       "changed": "2026-09-11"
     },
     "/vendor/ruttl-com": {
-      "hash": "4ac9159e967ecf33",
+      "hash": "e9d15b6e1f5221c3",
       "changed": "2026-09-11"
     },
     "/vendor/rybbit": {
-      "hash": "26f834a951e148e9",
+      "hash": "d2eea5e4aaa196e4",
       "changed": "2026-09-11"
     },
     "/vendor/safety": {
-      "hash": "cc97b0890795e612",
+      "hash": "1a68a776c9df03a3",
       "changed": "2026-09-11"
     },
     "/vendor/salesforce": {
-      "hash": "db73c50460ce0c97",
+      "hash": "24ede0d2059d5220",
       "changed": "2026-09-11"
     },
     "/vendor/sanity": {
-      "hash": "f81737ff7a7131fb",
+      "hash": "5f94b5c79a005a2e",
       "changed": "2026-09-11"
     },
     "/vendor/sauce-labs": {
-      "hash": "ceb023f9f4badd77",
+      "hash": "b187590d510e00e4",
       "changed": "2026-09-11"
     },
     "/vendor/savannah-gnu-org": {
-      "hash": "c03b4bf2f4a31e97",
+      "hash": "beba7781970152ae",
       "changed": "2026-09-11"
     },
     "/vendor/savannah-nongnu-org": {
-      "hash": "d1a6447918ddce70",
+      "hash": "6a460d2d641dc818",
       "changed": "2026-09-11"
     },
     "/vendor/scale-ai": {
       "daily": true
     },
     "/vendor/scaledrone-com": {
-      "hash": "d9f0c29f25c4a17e",
+      "hash": "04794b0aa1c29e66",
       "changed": "2026-09-11"
     },
     "/vendor/scalegrid-startup-program": {
-      "hash": "ed21d290eb4a45fc",
+      "hash": "728645abefc3be5c",
       "changed": "2026-09-11"
     },
     "/vendor/scaleway-startup-program": {
-      "hash": "c58a7030852f07d8",
+      "hash": "9f73d4fe4996b030",
       "changed": "2026-09-11"
     },
     "/vendor/scalingo": {
-      "hash": "942cc5e7d09ce6f1",
+      "hash": "5342f0e167373859",
       "changed": "2026-09-11"
     },
     "/vendor/scalr": {
-      "hash": "440affce0e2839e7",
+      "hash": "1027b01e05dda365",
       "changed": "2026-09-11"
     },
     "/vendor/scan-coverity-com": {
-      "hash": "f128a31429a84791",
+      "hash": "c049ce82101d4dcb",
       "changed": "2026-09-11"
     },
     "/vendor/science-exchange": {
-      "hash": "9167c6708c7fe0d0",
+      "hash": "ce52a9d7f4ad194a",
       "changed": "2026-09-11"
     },
     "/vendor/scraper-s-proxy": {
-      "hash": "ecac4423142646d5",
+      "hash": "0d5d8a7f52d1db71",
       "changed": "2026-09-11"
     },
     "/vendor/scraperapi": {
-      "hash": "95429131d648d365",
+      "hash": "1a29d85c7c55bc0a",
       "changed": "2026-09-11"
     },
     "/vendor/scrapingant": {
-      "hash": "73e4df66e014260d",
+      "hash": "ea28473d52a05111",
       "changed": "2026-09-11"
     },
     "/vendor/scrapingbee": {
-      "hash": "2f6fea29dd0e225f",
+      "hash": "e17dd5246841616d",
       "changed": "2026-09-11"
     },
     "/vendor/screen-sharing-via-browser": {
-      "hash": "73521190fa09b495",
+      "hash": "5e99053fc804df9c",
       "changed": "2026-09-11"
     },
     "/vendor/screenshot-scout": {
-      "hash": "b7cfdde28515167e",
+      "hash": "1ea0c5080a829beb",
       "changed": "2026-09-11"
     },
     "/vendor/screenshotbase-com": {
-      "hash": "5757701f7ec99baf",
+      "hash": "747a36389ca2ad89",
       "changed": "2026-09-11"
     },
     "/vendor/screenshotlayer": {
-      "hash": "f1d8d3e20b3f5944",
+      "hash": "8fb79a3859316aef",
       "changed": "2026-09-11"
     },
     "/vendor/screenshotmachine-com": {
-      "hash": "5733557e5f1abafb",
+      "hash": "eee8ce2d27f43ee6",
       "changed": "2026-09-11"
     },
     "/vendor/scrollbar-app": {
-      "hash": "1a5c6bab533b112f",
+      "hash": "bb3f43428f434131",
       "changed": "2026-09-11"
     },
     "/vendor/scrumfast": {
-      "hash": "77351579d44ce0de",
+      "hash": "49f1fefad57c47a1",
       "changed": "2026-09-11"
     },
     "/vendor/scrutinizer-ci-com": {
-      "hash": "79a1fcb22ccd9070",
+      "hash": "98d4d553150ee4d5",
       "changed": "2026-09-11"
     },
     "/vendor/seafile-com": {
-      "hash": "3b38101259813901",
+      "hash": "4a0b79eeab1a8872",
       "changed": "2026-09-11"
     },
     "/vendor/seatable": {
-      "hash": "112d14ebbb741e1a",
+      "hash": "e2554d85738ae322",
       "changed": "2026-09-11"
     },
     "/vendor/seeqle": {
-      "hash": "80d4126017bccb64",
+      "hash": "7a7483453ccf5d55",
       "changed": "2026-09-11"
     },
     "/vendor/segment": {
-      "hash": "dfb7698515ce9f78",
+      "hash": "49d18582475b9b1f",
       "changed": "2026-09-11"
     },
     "/vendor/selenium-grid": {
-      "hash": "5fdfd2863989b222",
+      "hash": "3d107ed3e6569152",
       "changed": "2026-09-11"
     },
     "/vendor/sellsy": {
-      "hash": "17d4a15d21d422c0",
+      "hash": "a28663ee8219a26b",
       "changed": "2026-09-11"
     },
     "/vendor/semanticdiff-com": {
-      "hash": "6e7ad5282c82db8c",
+      "hash": "21e0f34d6ae666a5",
       "changed": "2026-09-11"
     },
     "/vendor/semaphore-ci": {
-      "hash": "5fd2654004910cdb",
+      "hash": "b6677fd897e04d8b",
       "changed": "2026-09-11"
     },
     "/vendor/semaphr": {
-      "hash": "05fdcfb882fffc16",
+      "hash": "3b1a030d757689f2",
       "changed": "2026-09-11"
     },
     "/vendor/sematext": {
       "daily": true
     },
     "/vendor/semgrep": {
-      "hash": "2facd1eb038ce9c6",
+      "hash": "e70f7f38cbd564e2",
       "changed": "2026-09-11"
     },
     "/vendor/sendbird": {
-      "hash": "b83087daa7341a54",
+      "hash": "dec996b2d5d512a5",
       "changed": "2026-09-11"
     },
     "/vendor/sendgrid": {
       "daily": true
     },
     "/vendor/sendinblue": {
-      "hash": "ff47630aa2d7a144",
+      "hash": "f4128314cc75cf27",
       "changed": "2026-09-11"
     },
     "/vendor/sendpulse": {
-      "hash": "011aed91efdc15e1",
+      "hash": "b15ef5b02a59455a",
       "changed": "2026-09-11"
     },
     "/vendor/sendstreak": {
-      "hash": "3e432308b6d5b8dc",
+      "hash": "d1bcec5d5560b0b8",
       "changed": "2026-09-11"
     },
     "/vendor/sentry": {
       "daily": true
     },
     "/vendor/seotest-me": {
-      "hash": "ba56448409bc98aa",
+      "hash": "c4adb53e1247b72b",
       "changed": "2026-09-11"
     },
     "/vendor/serpapi": {
-      "hash": "94f78bf507b9c4b9",
+      "hash": "c2e0907e0c4eb615",
       "changed": "2026-09-11"
     },
     "/vendor/serv00-com": {
       "daily": true
     },
     "/vendor/serveo": {
-      "hash": "b065e5de68d9d0a5",
+      "hash": "868d4d83ab05891d",
       "changed": "2026-09-11"
     },
     "/vendor/serveravatar-com": {
-      "hash": "f57bc265ae92e14b",
+      "hash": "ddc9c35d203d2ca6",
       "changed": "2026-09-11"
     },
     "/vendor/servervana": {
@@ -8151,47 +8151,47 @@
       "daily": true
     },
     "/vendor/shadcn-space": {
-      "hash": "d3cdb358a51876e2",
+      "hash": "b838c8f582893bf4",
       "changed": "2026-09-11"
     },
     "/vendor/shadcn-studio": {
-      "hash": "ae25913fb0661e9b",
+      "hash": "f9d62b59ab40fb97",
       "changed": "2026-09-11"
     },
     "/vendor/shadcnui": {
-      "hash": "35ee9b0a10693689",
+      "hash": "bbb6beb83dad754c",
       "changed": "2026-09-11"
     },
     "/vendor/shake": {
-      "hash": "3d21f8da4af226a7",
+      "hash": "322750b771fea7f4",
       "changed": "2026-09-11"
     },
     "/vendor/shields-io": {
-      "hash": "9649860c733cc179",
+      "hash": "d648b466102fde90",
       "changed": "2026-09-11"
     },
     "/vendor/shine": {
-      "hash": "bd4742034bd7e33d",
+      "hash": "d547264e52facf5c",
       "changed": "2026-09-11"
     },
     "/vendor/shipfox": {
-      "hash": "a9c10268040f8cde",
+      "hash": "05c1da87f79792f8",
       "changed": "2026-09-11"
     },
     "/vendor/shippo": {
-      "hash": "1e66401153b68ee0",
+      "hash": "8c2c2ab868409bc0",
       "changed": "2026-09-11"
     },
     "/vendor/shortcut": {
-      "hash": "5a5ca284ce703a75",
+      "hash": "efe2a8bdd751f74e",
       "changed": "2026-09-11"
     },
     "/vendor/shotstack-startup-program": {
-      "hash": "460f34fee7bf5a38",
+      "hash": "b7e68d0f5d7d786e",
       "changed": "2026-09-11"
     },
     "/vendor/signal": {
-      "hash": "09a1a6c8bd8f1970",
+      "hash": "1244494c2ec93b5d",
       "changed": "2026-09-11"
     },
     "/vendor/signoz": {
@@ -8207,31 +8207,31 @@
       "daily": true
     },
     "/vendor/simplelocalize": {
-      "hash": "df2fb5f6118c05f3",
+      "hash": "8e0b60690b0f3fe1",
       "changed": "2026-09-11"
     },
     "/vendor/simplelogin": {
-      "hash": "7845adf5acfcf064",
+      "hash": "9ecd477286bd6511",
       "changed": "2026-09-11"
     },
     "/vendor/simplenote": {
-      "hash": "05217b10e55a0a6f",
+      "hash": "c87eb65ffbeb589d",
       "changed": "2026-09-11"
     },
     "/vendor/simplepdf-eu": {
-      "hash": "d678cb468bcc7d35",
+      "hash": "8ceda551969a11cb",
       "changed": "2026-09-11"
     },
     "/vendor/simplescraper": {
-      "hash": "edc8e8a63831960d",
+      "hash": "ddeadf65387b807d",
       "changed": "2026-09-11"
     },
     "/vendor/sirv-com": {
-      "hash": "1711c9febcfa0c25",
+      "hash": "6ca1342c8d007a6c",
       "changed": "2026-09-11"
     },
     "/vendor/sitedots": {
-      "hash": "b4f3aa474b495058",
+      "hash": "6f16cd78f0bac68a",
       "changed": "2026-09-11"
     },
     "/vendor/sitesure-net": {
@@ -8241,198 +8241,198 @@
       "daily": true
     },
     "/vendor/skypack": {
-      "hash": "8f8d154ee20d1459",
+      "hash": "a181dfbc429b72f6",
       "changed": "2026-09-11"
     },
     "/vendor/skyvia-com": {
-      "hash": "0d74a0ff85a8772b",
+      "hash": "9aa4b26dc8fd03b8",
       "changed": "2026-09-11"
     },
     "/vendor/slab": {
-      "hash": "613df939df331f4f",
+      "hash": "e7d49a3ac45d5c93",
       "changed": "2026-09-11"
     },
     "/vendor/slack": {
-      "hash": "f67ed5440b49ba82",
+      "hash": "5078aa6c94ff428e",
       "changed": "2026-09-11"
     },
     "/vendor/slingsite": {
-      "hash": "1982a79b4ffc1aec",
+      "hash": "8a31019bcb29fd63",
       "changed": "2026-09-11"
     },
     "/vendor/slite": {
-      "hash": "d7e3d9536d174d05",
+      "hash": "3ab8f102e5a23f14",
       "changed": "2026-09-11"
     },
     "/vendor/smart-grow-logs": {
-      "hash": "41128cd3c59d9128",
+      "hash": "bbd43f7417cee2c2",
       "changed": "2026-09-11"
     },
     "/vendor/smart-grow-vault": {
-      "hash": "dcf27660fb2a5589",
+      "hash": "1d231d87f24a914c",
       "changed": "2026-09-11"
     },
     "/vendor/smartcar-api": {
-      "hash": "3cbcef0443fba538",
+      "hash": "fcd5e6277317b4b0",
       "changed": "2026-09-11"
     },
     "/vendor/smartforms-dev": {
-      "hash": "1d67c408081e4c73",
+      "hash": "8312e7dfb9fac4a8",
       "changed": "2026-09-11"
     },
     "/vendor/smartlook-com": {
-      "hash": "23847bf624fe66ad",
+      "hash": "6754d019738b9c26",
       "changed": "2026-09-11"
     },
     "/vendor/smartmockups-com": {
-      "hash": "48702740efa626b7",
+      "hash": "5a16992752cc6205",
       "changed": "2026-09-11"
     },
     "/vendor/smartparse": {
-      "hash": "4007fc378e8c3de4",
+      "hash": "8d86de07ac72274a",
       "changed": "2026-09-11"
     },
     "/vendor/smsgate": {
-      "hash": "49185b26af4c4a93",
+      "hash": "6daf9135e8484f9f",
       "changed": "2026-09-11"
     },
     "/vendor/snap": {
-      "hash": "ee3b6a00b7b0cbc8",
+      "hash": "02dca430a7df4c65",
       "changed": "2026-09-11"
     },
     "/vendor/snapapi": {
-      "hash": "ab4fb1370d3640b8",
+      "hash": "c71082e91dcd98f0",
       "changed": "2026-09-11"
     },
     "/vendor/snapcall": {
-      "hash": "65d6128dd36a28c1",
+      "hash": "b4b26a1fae2435fa",
       "changed": "2026-09-11"
     },
     "/vendor/snappify": {
-      "hash": "daa5de1826b3cffd",
+      "hash": "db372f41bfd4d82c",
       "changed": "2026-09-11"
     },
     "/vendor/snippets-uilicious-com": {
-      "hash": "eef2346d18a20e3b",
+      "hash": "35374ec28fbc078f",
       "changed": "2026-09-11"
     },
     "/vendor/snyk": {
-      "hash": "9cd6411ce12efb5d",
+      "hash": "1f82000bf9c1fe25",
       "changed": "2026-09-11"
     },
     "/vendor/social-champ": {
-      "hash": "c2d5e7e3f7fe3e7f",
+      "hash": "718162e8c5c1712a",
       "changed": "2026-09-11"
     },
     "/vendor/socialbee": {
-      "hash": "8c07abd2512c9cbd",
+      "hash": "0559e0f6af156e82",
       "changed": "2026-09-11"
     },
     "/vendor/socket-dev": {
-      "hash": "1bfb40f926c06226",
+      "hash": "96bab1bdf64364a5",
       "changed": "2026-09-11"
     },
     "/vendor/sofodata": {
-      "hash": "232494989592914a",
+      "hash": "69d7286817c9cd17",
       "changed": "2026-09-11"
     },
     "/vendor/solium": {
-      "hash": "24283bddc66c8e92",
+      "hash": "b5a4bf0e53277003",
       "changed": "2026-09-11"
     },
     "/vendor/solo": {
-      "hash": "27cfa713d432d7b3",
+      "hash": "fbf8554ca9ff8a02",
       "changed": "2026-09-11"
     },
     "/vendor/sololearn": {
-      "hash": "7aab5dff08993608",
+      "hash": "f43cd5a4e528e9e3",
       "changed": "2026-09-11"
     },
     "/vendor/sonarqube-cloud": {
       "daily": true
     },
     "/vendor/soos": {
-      "hash": "45be5b1c77317ed4",
+      "hash": "63b5a0ac20d0bfd8",
       "changed": "2026-09-11"
     },
     "/vendor/sourceforge": {
-      "hash": "0d59ebec3deb8aa2",
+      "hash": "128f80f7dc34e574",
       "changed": "2026-09-11"
     },
     "/vendor/spacelift": {
-      "hash": "4bb8241a0fd778f7",
+      "hash": "9b5c1345b6444cf8",
       "changed": "2026-09-11"
     },
     "/vendor/sphinx": {
-      "hash": "fc9f622d25829522",
+      "hash": "a0748a10e035aa2b",
       "changed": "2026-09-11"
     },
     "/vendor/sqlable": {
-      "hash": "e1a7907e8d4c28b1",
+      "hash": "5d2c3c58b2e5ffd0",
       "changed": "2026-09-11"
     },
     "/vendor/squarespace": {
-      "hash": "9c4718a7e2dd6550",
+      "hash": "07e6c929477033a4",
       "changed": "2026-09-11"
     },
     "/vendor/squash-labs": {
-      "hash": "d2fc41c46b663614",
+      "hash": "eb1c1878a5a1e999",
       "changed": "2026-09-11"
     },
     "/vendor/squidex": {
-      "hash": "fc8305b34497dcf2",
+      "hash": "184b1f0eea7b5671",
       "changed": "2026-09-11"
     },
     "/vendor/sslip-io": {
-      "hash": "7962dee62593c5b1",
+      "hash": "15012f276942ed9c",
       "changed": "2026-09-11"
     },
     "/vendor/ssllabs-com": {
-      "hash": "f5d22030fbee513d",
+      "hash": "d3fcbba2c1a7bcbb",
       "changed": "2026-09-11"
     },
     "/vendor/ssr-server-side-rendering-checker": {
-      "hash": "4bea213d6a29aee0",
+      "hash": "9fa66ca9fbee556c",
       "changed": "2026-09-11"
     },
     "/vendor/stack-auth": {
-      "hash": "85da9d19a053f2ae",
+      "hash": "e72f4b975b125424",
       "changed": "2026-09-11"
     },
     "/vendor/stackblitz-com": {
-      "hash": "99935beb07b1fbdf",
+      "hash": "22b9e0fed33ecd3e",
       "changed": "2026-09-11"
     },
     "/vendor/stackby": {
-      "hash": "a913fba393f762dd",
+      "hash": "0f65b0dd05a8cfe6",
       "changed": "2026-09-11"
     },
     "/vendor/stadiamaps-com": {
-      "hash": "a6217eeca0c4cf91",
+      "hash": "af83c5c1eb18086c",
       "changed": "2026-09-11"
     },
     "/vendor/standard-notes": {
-      "hash": "e92ef244c90a90e9",
+      "hash": "1fa3c6017b126d5d",
       "changed": "2026-09-11"
     },
     "/vendor/startup-with-ibm": {
-      "hash": "bb89bf3bac0c0fec",
+      "hash": "4113eb1782785ce9",
       "changed": "2026-09-11"
     },
     "/vendor/statcounter": {
-      "hash": "5a058ac7b199e623",
+      "hash": "e42d5c92c1f0bc9b",
       "changed": "2026-09-11"
     },
     "/vendor/statically": {
-      "hash": "a8d52ccc5b440b6e",
+      "hash": "1a963e1b6e0c3fe1",
       "changed": "2026-09-11"
     },
     "/vendor/staticforms-xyz": {
-      "hash": "29e4b4063dbe3da2",
+      "hash": "b3b8be7cc3f30fd6",
       "changed": "2026-09-11"
     },
     "/vendor/statsig": {
-      "hash": "5a3faa45b94337c6",
+      "hash": "91d908ea2d73cdc1",
       "changed": "2026-09-11"
     },
     "/vendor/statuscake": {
@@ -8445,19 +8445,19 @@
       "daily": true
     },
     "/vendor/stellate": {
-      "hash": "c14c593bfa4c3acf",
+      "hash": "1f23a0ad052676fa",
       "changed": "2026-09-11"
     },
     "/vendor/stickies": {
-      "hash": "74538616aa30aae7",
+      "hash": "329edd107f693b69",
       "changed": "2026-09-11"
     },
     "/vendor/stitch-labs": {
-      "hash": "196264cf9b6c0851",
+      "hash": "9942efbfe1cab9a3",
       "changed": "2026-09-11"
     },
     "/vendor/stoplight": {
-      "hash": "59e90122856ed9cf",
+      "hash": "b7d1281362c3b8e6",
       "changed": "2026-09-11"
     },
     "/vendor/storj": {
@@ -8467,77 +8467,77 @@
       "daily": true
     },
     "/vendor/storyset-com": {
-      "hash": "5f5f9fcfa1ebf205",
+      "hash": "b964e3303e0358dd",
       "changed": "2026-09-11"
     },
     "/vendor/strale": {
-      "hash": "1e91b82d1884d361",
+      "hash": "cc4acdc0d95ed140",
       "changed": "2026-09-11"
     },
     "/vendor/strapi": {
-      "hash": "424e85b643152b72",
+      "hash": "6010f0334df4e6ef",
       "changed": "2026-09-11"
     },
     "/vendor/stream": {
-      "hash": "90d42722779993c1",
+      "hash": "29224d9596fe0061",
       "changed": "2026-09-11"
     },
     "/vendor/streambackdrops": {
-      "hash": "f574976868db8a72",
+      "hash": "da95b24276758c5a",
       "changed": "2026-09-11"
     },
     "/vendor/stripe": {
       "daily": true
     },
     "/vendor/stripe-atlas": {
-      "hash": "06dd0ac0057a10b4",
+      "hash": "e30c0f3c028367a2",
       "changed": "2026-09-11"
     },
     "/vendor/stytch": {
-      "hash": "6b900b7c63e9fcf3",
+      "hash": "ae9c3b4e9dd8394f",
       "changed": "2026-09-11"
     },
     "/vendor/sublime-text": {
-      "hash": "832a24c9e97d987b",
+      "hash": "7cd81f91dba3f5c9",
       "changed": "2026-09-11"
     },
     "/vendor/substack": {
-      "hash": "01ef7236263e6ce8",
+      "hash": "6e7ed7559556f17e",
       "changed": "2026-09-11"
     },
     "/vendor/sucuri-sitecheck": {
-      "hash": "3221a1ae5a0f1581",
+      "hash": "e514e63b95e18201",
       "changed": "2026-09-11"
     },
     "/vendor/sunrise-and-sunset": {
-      "hash": "d085106b1f74dd54",
+      "hash": "8d5f7e297b9f4455",
       "changed": "2026-09-11"
     },
     "/vendor/supabase": {
       "daily": true
     },
     "/vendor/superdesigner": {
-      "hash": "3bb5a6a9d62742db",
+      "hash": "c66d7301030470b9",
       "changed": "2026-09-11"
     },
     "/vendor/superfeedr-com": {
-      "hash": "6c5c291bec80db51",
+      "hash": "72a61f9314aae820",
       "changed": "2026-09-11"
     },
     "/vendor/supermaven": {
-      "hash": "1650d307a047c8ba",
+      "hash": "06d80f13057594f4",
       "changed": "2026-09-11"
     },
     "/vendor/supertokens": {
-      "hash": "d99e8f67b2ef0427",
+      "hash": "ac468f4f1ab14dfa",
       "changed": "2026-09-11"
     },
     "/vendor/supportivekoala": {
-      "hash": "2069bc974bf22daf",
+      "hash": "01c762698a31400a",
       "changed": "2026-09-11"
     },
     "/vendor/suprsend": {
-      "hash": "8b0edddd3ddc87cc",
+      "hash": "4bc2f18aef68fc15",
       "changed": "2026-09-11"
     },
     "/vendor/surge-sh": {
@@ -8547,35 +8547,35 @@
       "daily": true
     },
     "/vendor/surveymonkey-com": {
-      "hash": "8a3f7bb5895cc4d0",
+      "hash": "1d79be7245715cf8",
       "changed": "2026-09-11"
     },
     "/vendor/survicate": {
-      "hash": "9f84e70300bf4fcb",
+      "hash": "d5b4ac6b3f44fb0a",
       "changed": "2026-09-11"
     },
     "/vendor/svb-silicon-valley-bank": {
-      "hash": "f4545d3edbee4bb5",
+      "hash": "aa23c47158e8431e",
       "changed": "2026-09-11"
     },
     "/vendor/svg-converter": {
-      "hash": "781e86b5e02e00a2",
+      "hash": "a3846a341727fe4d",
       "changed": "2026-09-11"
     },
     "/vendor/svix": {
-      "hash": "8346cc65bb2271f9",
+      "hash": "07a05dfa74218dea",
       "changed": "2026-09-11"
     },
     "/vendor/swaggerhub": {
-      "hash": "ba6b0667bfc28dd6",
+      "hash": "c1e195fa4308a1c8",
       "changed": "2026-09-11"
     },
     "/vendor/swaggo-swag": {
-      "hash": "4863b2ae23def7dc",
+      "hash": "80b6293c5eec61b3",
       "changed": "2026-09-11"
     },
     "/vendor/sweego": {
-      "hash": "7427caaeb4262cd1",
+      "hash": "66153039a8221da6",
       "changed": "2026-09-11"
     },
     "/vendor/sweetuptime": {
@@ -8585,295 +8585,295 @@
       "daily": true
     },
     "/vendor/synadia-com": {
-      "hash": "0a3e0e5d4c212491",
+      "hash": "e9eab76ae43432e0",
       "changed": "2026-09-11"
     },
     "/vendor/sync-com": {
-      "hash": "4d14f92a13ea976d",
+      "hash": "cd96a89cbeb4c185",
       "changed": "2026-09-11"
     },
     "/vendor/tabler-icons-io": {
-      "hash": "7ffa8e2a9808151d",
+      "hash": "1441928591b9447b",
       "changed": "2026-09-11"
     },
     "/vendor/taiga-io": {
-      "hash": "2e1f3495da4b246a",
+      "hash": "7b13b4f2727206f1",
       "changed": "2026-09-11"
     },
     "/vendor/tailark": {
-      "hash": "43796d43496bcd44",
+      "hash": "d11e6e8e82b51c86",
       "changed": "2026-09-11"
     },
     "/vendor/tailcolors": {
-      "hash": "ac7c622a150f9886",
+      "hash": "4864ff9cc6b5641b",
       "changed": "2026-09-11"
     },
     "/vendor/tailkits": {
-      "hash": "c942b0a949f489d0",
+      "hash": "bd77ac5992b6e81b",
       "changed": "2026-09-11"
     },
     "/vendor/tailscale": {
-      "hash": "9e3840ffe20ac10c",
+      "hash": "882c991bab712deb",
       "changed": "2026-09-11"
     },
     "/vendor/tailwindadmin": {
-      "hash": "70e481d4b0600cc9",
+      "hash": "8c8142d32f92afd8",
       "changed": "2026-09-11"
     },
     "/vendor/talky-io": {
-      "hash": "de8ded5853370e70",
+      "hash": "eee0531e5009c694",
       "changed": "2026-09-11"
     },
     "/vendor/tally": {
-      "hash": "02d358861559adf1",
+      "hash": "4876c17d622a14f9",
       "changed": "2026-09-11"
     },
     "/vendor/taskade-com": {
-      "hash": "176cbe4164ebcf80",
+      "hash": "60939e2781d1e7c6",
       "changed": "2026-09-11"
     },
     "/vendor/tavily-ai": {
       "daily": true
     },
     "/vendor/tawk-to": {
-      "hash": "6808edc8abe5faf9",
+      "hash": "106cb2cda398e6ea",
       "changed": "2026-09-11"
     },
     "/vendor/teamcamp": {
-      "hash": "a60885e068ec239e",
+      "hash": "5134c2fa20246e93",
       "changed": "2026-09-11"
     },
     "/vendor/teaminal": {
-      "hash": "64c233fdce2d1d89",
+      "hash": "d57967653aa8ebef",
       "changed": "2026-09-11"
     },
     "/vendor/teamplify": {
-      "hash": "745c2089a5594ea7",
+      "hash": "049e88b47a75e043",
       "changed": "2026-09-11"
     },
     "/vendor/teamwork-com": {
-      "hash": "40a76a25c0e801f1",
+      "hash": "b9706ee69b7dcfe7",
       "changed": "2026-09-11"
     },
     "/vendor/telegram": {
-      "hash": "675767eed7a42f64",
+      "hash": "aa36c5530c70d4c4",
       "changed": "2026-09-11"
     },
     "/vendor/teleporthq": {
-      "hash": "d6d659c8fe958817",
+      "hash": "d4c1d80e8c95d14b",
       "changed": "2026-09-11"
     },
     "/vendor/teleretro-com": {
-      "hash": "e632a5c7acfcfc50",
+      "hash": "cc1ed04dcf8a0afd",
       "changed": "2026-09-11"
     },
     "/vendor/temp-mail-io": {
-      "hash": "2712055b509d23e9",
+      "hash": "06d73fcd8850acfc",
       "changed": "2026-09-11"
     },
     "/vendor/tempmaildetector-com": {
-      "hash": "63b385dd40e0506a",
+      "hash": "c0a0d7d66723b26d",
       "changed": "2026-09-11"
     },
     "/vendor/tencent-rtc": {
-      "hash": "360bbd1d45b4c32e",
+      "hash": "3881675973d8d1fc",
       "changed": "2026-09-11"
     },
     "/vendor/tenzu": {
-      "hash": "8131f71f3a32dbf3",
+      "hash": "6cc1fbd51f36449f",
       "changed": "2026-09-11"
     },
     "/vendor/terragrunt-scale": {
       "daily": true
     },
     "/vendor/terramate": {
-      "hash": "d6ab39ee94349f49",
+      "hash": "ca5b49daf75c49cf",
       "changed": "2026-09-11"
     },
     "/vendor/terrateam": {
-      "hash": "c5ed36e6a33e5ea6",
+      "hash": "e72c9691b05c6763",
       "changed": "2026-09-11"
     },
     "/vendor/testcontainers": {
-      "hash": "ba285348c45e22fb",
+      "hash": "080b25c98d43d380",
       "changed": "2026-09-11"
     },
     "/vendor/testingbot-com": {
-      "hash": "a7094cf2f8c527a3",
+      "hash": "4640bf91f4c49aef",
       "changed": "2026-09-11"
     },
     "/vendor/testspace-com": {
-      "hash": "07c98b32d807557d",
+      "hash": "7f405e8cb42ec9ac",
       "changed": "2026-09-11"
     },
     "/vendor/testtls-com": {
-      "hash": "945171d5930610ef",
+      "hash": "67d6b9221a2cef91",
       "changed": "2026-09-11"
     },
     "/vendor/tesults-com": {
-      "hash": "47a55a44d4fea0c1",
+      "hash": "48ff29d94df0ad32",
       "changed": "2026-09-11"
     },
     "/vendor/texterify": {
-      "hash": "8fc40ecca18cf105",
+      "hash": "88766eacc188cfde",
       "changed": "2026-09-11"
     },
     "/vendor/the-gosquared-early-stage-plan": {
-      "hash": "b947bb1234cc0a2f",
+      "hash": "3ec8fe2ff8f9078d",
       "changed": "2026-09-11"
     },
     "/vendor/the-intercom-early-stage-program": {
-      "hash": "5bd47368654c4586",
+      "hash": "f1d6e56cc2dac9d3",
       "changed": "2026-09-11"
     },
     "/vendor/the-ip-api": {
-      "hash": "6e1a8e288328236f",
+      "hash": "a8ba780cda1bccb0",
       "changed": "2026-09-11"
     },
     "/vendor/themecloud": {
-      "hash": "6e13cb51c3a9156f",
+      "hash": "773efb5bf982e7e8",
       "changed": "2026-09-11"
     },
     "/vendor/thumbnail-ws": {
-      "hash": "088bd4ac3a5ca9ab",
+      "hash": "e9860e6016130340",
       "changed": "2026-09-11"
     },
     "/vendor/thunder-client": {
-      "hash": "e6d55484da0f753f",
+      "hash": "08be2ba4d3e2a8f2",
       "changed": "2026-09-11"
     },
     "/vendor/tickgit-com": {
-      "hash": "a1e1de779d8be0fb",
+      "hash": "ab4b3e668e749671",
       "changed": "2026-09-11"
     },
     "/vendor/ticktick": {
-      "hash": "d9f47df71fecb328",
+      "hash": "e3c3831f47a60ca3",
       "changed": "2026-09-11"
     },
     "/vendor/tigris": {
-      "hash": "cd2fd78cabc88e70",
+      "hash": "8908f10aa525a3f5",
       "changed": "2026-09-11"
     },
     "/vendor/tilda-cc": {
       "daily": true
     },
     "/vendor/timecamp": {
-      "hash": "013170adf3aad66e",
+      "hash": "e207e5e2014d1259",
       "changed": "2026-09-11"
     },
     "/vendor/tinacms": {
-      "hash": "76c26de13d0c4ffd",
+      "hash": "056372143f07f221",
       "changed": "2026-09-11"
     },
     "/vendor/tinybird": {
-      "hash": "ad093383d172a946",
+      "hash": "4787923b1ebeb579",
       "changed": "2026-09-11"
     },
     "/vendor/tinymce": {
-      "hash": "1f985e3f00bd7773",
+      "hash": "bdb024394bc05614",
       "changed": "2026-09-11"
     },
     "/vendor/tinypng-com": {
-      "hash": "b70f48bbc29d3ad5",
+      "hash": "121acdbe64c15d96",
       "changed": "2026-09-11"
     },
     "/vendor/titanapps-io": {
-      "hash": "e3b79bb3642b4d5d",
+      "hash": "0af004db00a9e379",
       "changed": "2026-09-11"
     },
     "/vendor/tldraw-com": {
-      "hash": "97df92b14928d06e",
+      "hash": "2ab7a55cd806e362",
       "changed": "2026-09-11"
     },
     "/vendor/todoist": {
-      "hash": "739b71da26d6ed00",
+      "hash": "de1975f1c9c5d9f0",
       "changed": "2026-09-11"
     },
     "/vendor/together-ai": {
       "daily": true
     },
     "/vendor/toggl": {
-      "hash": "5f2d9b273fd65d3b",
+      "hash": "64ac9b5298feab6f",
       "changed": "2026-09-11"
     },
     "/vendor/toggled-dev": {
-      "hash": "358e31db10776bf3",
+      "hash": "a90c95da24952629",
       "changed": "2026-09-11"
     },
     "/vendor/tolgee": {
-      "hash": "fc8a8ee8b731a386",
+      "hash": "dc00ec573aa59c41",
       "changed": "2026-09-11"
     },
     "/vendor/tollbooth": {
-      "hash": "e3059166a657683b",
+      "hash": "544b91d1430d96bb",
       "changed": "2026-09-11"
     },
     "/vendor/tomorrow-io-weather-api": {
-      "hash": "3f0ef0426b916b96",
+      "hash": "b600c9c204497689",
       "changed": "2026-09-11"
     },
     "/vendor/tooljet": {
-      "hash": "05a00df2350898bb",
+      "hash": "f2a2de5c4f967df0",
       "changed": "2026-09-11"
     },
     "/vendor/toranproxy-com": {
-      "hash": "662ad322c32d662c",
+      "hash": "5d5fa779a7b929cb",
       "changed": "2026-09-11"
     },
     "/vendor/tracelog": {
-      "hash": "1d2c42a81256e05f",
+      "hash": "3f132a45bf431c50",
       "changed": "2026-09-11"
     },
     "/vendor/trackingplan": {
-      "hash": "d26ba93500c9afb2",
+      "hash": "35f6892aa4a6a94c",
       "changed": "2026-09-11"
     },
     "/vendor/trackwith-dicloud": {
-      "hash": "7addbfb8dba0fd87",
+      "hash": "98cb72d9452e21e6",
       "changed": "2026-09-11"
     },
     "/vendor/traefik": {
-      "hash": "9aab9e50b9958ab3",
+      "hash": "09d6759cf393ffe6",
       "changed": "2026-09-11"
     },
     "/vendor/transfernow": {
-      "hash": "2bf3f123009e46ec",
+      "hash": "6125d2b69a67c4e0",
       "changed": "2026-09-11"
     },
     "/vendor/transifex-com": {
-      "hash": "ba43724145d8a904",
+      "hash": "d1f2b1db86fdd948",
       "changed": "2026-09-11"
     },
     "/vendor/transloadit-com": {
-      "hash": "621b34a123061fd6",
+      "hash": "bae197ace88ec6ba",
       "changed": "2026-09-11"
     },
     "/vendor/treblle": {
-      "hash": "ceb9be1911a05698",
+      "hash": "8cc9f24acbe4fcf9",
       "changed": "2026-09-11"
     },
     "/vendor/trello": {
-      "hash": "9f2e2932e2ab5e01",
+      "hash": "7ff51e1b57dca7cf",
       "changed": "2026-09-11"
     },
     "/vendor/trigger-dev": {
-      "hash": "e1d0ea2066317999",
+      "hash": "82cadcd463f640c4",
       "changed": "2026-09-11"
     },
     "/vendor/trivy": {
-      "hash": "254ed5524b9896a5",
+      "hash": "89c9029a93a2c4d0",
       "changed": "2026-09-11"
     },
     "/vendor/trufflehog": {
-      "hash": "240d7178712e7375",
+      "hash": "c22095ecb2b09400",
       "changed": "2026-09-11"
     },
     "/vendor/ttl-sh": {
-      "hash": "3df35e2917235659",
+      "hash": "edfa7550280311c3",
       "changed": "2026-09-11"
     },
     "/vendor/tugboat": {
-      "hash": "213d594d96ca8f6c",
+      "hash": "cc59b4681e46aae0",
       "changed": "2026-09-11"
     },
     "/vendor/turbopuffer": {
@@ -8883,110 +8883,110 @@
       "daily": true
     },
     "/vendor/tuta": {
-      "hash": "2bf597cc4b50444a",
+      "hash": "c13dc7bbd58aedbe",
       "changed": "2026-09-11"
     },
     "/vendor/tutanota": {
-      "hash": "77e39b9bc3365958",
+      "hash": "7c03cfb0d9dbe666",
       "changed": "2026-09-11"
     },
     "/vendor/tw-elements": {
-      "hash": "3c3dc55c16eb334c",
+      "hash": "3c720e38dc7195fe",
       "changed": "2026-09-11"
     },
     "/vendor/tweakcn": {
-      "hash": "aac961d069dc022b",
+      "hash": "9fb9ef6a4a941ddb",
       "changed": "2026-09-11"
     },
     "/vendor/tweek": {
-      "hash": "700a937a25f21a29",
+      "hash": "4d0cbd9c62d868b7",
       "changed": "2026-09-11"
     },
     "/vendor/twicpics-com": {
-      "hash": "aaef957b166162af",
+      "hash": "a19b7f4737fb5d4c",
       "changed": "2026-09-11"
     },
     "/vendor/twilio": {
-      "hash": "6fabe9949ae00a88",
+      "hash": "ba3c086b6f1505a4",
       "changed": "2026-09-11"
     },
     "/vendor/twilio-startups-program": {
-      "hash": "a944a647764ebc54",
+      "hash": "646274a281b7ccd9",
       "changed": "2026-09-11"
     },
     "/vendor/twingate": {
-      "hash": "072002003d7bf81b",
+      "hash": "1255d5b3864fd4e6",
       "changed": "2026-09-11"
     },
     "/vendor/twist-com": {
-      "hash": "ecee541912116c27",
+      "hash": "61b5e152f177922f",
       "changed": "2026-09-11"
     },
     "/vendor/tyk": {
-      "hash": "b690efe693005c9f",
+      "hash": "42d2e89c5c2699f0",
       "changed": "2026-09-11"
     },
     "/vendor/typeform-com": {
-      "hash": "0ad57c639453bf19",
+      "hash": "4cc18168c4d91925",
       "changed": "2026-09-11"
     },
     "/vendor/typesense-cloud": {
-      "hash": "c236671c917b103f",
+      "hash": "933a740e9579d252",
       "changed": "2026-09-11"
     },
     "/vendor/ui-avatars": {
-      "hash": "c8e8ce3cf014f202",
+      "hash": "f22831c748a65a23",
       "changed": "2026-09-11"
     },
     "/vendor/ui-bakery": {
-      "hash": "378499d80e2f01c0",
+      "hash": "2ae8d2b34c38782d",
       "changed": "2026-09-11"
     },
     "/vendor/umami": {
-      "hash": "9a17d9efe3beda14",
+      "hash": "97ff33f6c7723164",
       "changed": "2026-09-11"
     },
     "/vendor/umso": {
-      "hash": "e2f9d677d138ab54",
+      "hash": "5b5f1b4d8310f7e8",
       "changed": "2026-09-11"
     },
     "/vendor/undraw": {
-      "hash": "e07c688cb8082f44",
+      "hash": "28f0f596f076523c",
       "changed": "2026-09-11"
     },
     "/vendor/unicorn-platform": {
-      "hash": "d16784edc5e89e23",
+      "hash": "bb92fa4685310a97",
       "changed": "2026-09-11"
     },
     "/vendor/unirateapi": {
-      "hash": "4e0b6b2f75425e97",
+      "hash": "acb55ec23d48b6d9",
       "changed": "2026-09-11"
     },
     "/vendor/unity-devops": {
       "daily": true
     },
     "/vendor/unkey": {
-      "hash": "df9170b0ea43912f",
+      "hash": "67e8aefa595e4e1d",
       "changed": "2026-09-11"
     },
     "/vendor/unpkg": {
-      "hash": "253227e7e5a3240f",
+      "hash": "b85e93db88928be0",
       "changed": "2026-09-11"
     },
     "/vendor/unsplash-com": {
-      "hash": "ffe35f88f2709657",
+      "hash": "ec3fd21ef842728c",
       "changed": "2026-09-11"
     },
     "/vendor/updrafts-app": {
-      "hash": "8ead0b8f8f62966d",
+      "hash": "d56afb386ead8b8e",
       "changed": "2026-09-11"
     },
     "/vendor/uploadcare": {
-      "hash": "86b9d945f6c94e4d",
+      "hash": "ae832fd6e904053e",
       "changed": "2026-09-11"
     },
     "/vendor/upptime": {
-      "hash": "00a635489895f985",
+      "hash": "1a9fe4de67451388",
       "changed": "2026-09-11"
     },
     "/vendor/upstash": {
@@ -9008,336 +9008,336 @@
       "daily": true
     },
     "/vendor/urlscan-io": {
-      "hash": "5ed2eadaa362e1f5",
+      "hash": "2319f8aac42b3dbf",
       "changed": "2026-09-11"
     },
     "/vendor/usercheck": {
-      "hash": "f913fdde2efafb60",
+      "hash": "e24d39384834b6a8",
       "changed": "2026-09-11"
     },
     "/vendor/userforge-com": {
-      "hash": "2e669714a5ad9e74",
+      "hash": "2ac32c7f63ebf6a6",
       "changed": "2026-09-11"
     },
     "/vendor/userguiding": {
-      "hash": "723fdb427f7976d0",
+      "hash": "cb5d339a55eb7901",
       "changed": "2026-09-11"
     },
     "/vendor/usewebhook-com": {
-      "hash": "3b6dc5e902a296a1",
+      "hash": "c087665ae3bbb3bd",
       "changed": "2026-09-11"
     },
     "/vendor/utterances": {
-      "hash": "8c3ab3b3db39ef54",
+      "hash": "7f52f186df4fa54e",
       "changed": "2026-09-11"
     },
     "/vendor/uuid-generator": {
-      "hash": "a31d4f3b2f246aae",
+      "hash": "05098bae4de4deec",
       "changed": "2026-09-11"
     },
     "/vendor/uxtweak-com": {
-      "hash": "819f86fc4ff454bd",
+      "hash": "cfba0d1f83925d52",
       "changed": "2026-09-11"
     },
     "/vendor/v0-dev": {
-      "hash": "b389f1774fd73335",
+      "hash": "93ed1a110bd18612",
       "changed": "2026-09-11"
     },
     "/vendor/vaadin": {
-      "hash": "f22989d1cb743687",
+      "hash": "80394c596a7360ec",
       "changed": "2026-09-11"
     },
     "/vendor/val-town": {
       "daily": true
     },
     "/vendor/vaocherapp-qr-code-generator": {
-      "hash": "52a20a695b58a402",
+      "hash": "6915fdd7be165142",
       "changed": "2026-09-11"
     },
     "/vendor/vast-ai": {
-      "hash": "c31b665ebb276fa5",
+      "hash": "f4ac94c0cd327de0",
       "changed": "2026-09-11"
     },
     "/vendor/vatcheckapi-com": {
-      "hash": "476ad0fa4002d054",
+      "hash": "eb5ad3faf4304179",
       "changed": "2026-09-11"
     },
     "/vendor/vatlayer": {
-      "hash": "4adfa968dc2077b2",
+      "hash": "9b1be441537f4ff5",
       "changed": "2026-09-11"
     },
     "/vendor/vector-express": {
-      "hash": "79ab80b49fda6793",
+      "hash": "93b30d9bef75aafd",
       "changed": "2026-09-11"
     },
     "/vendor/vectr-com": {
-      "hash": "7c6aab8b7bc81c35",
+      "hash": "7aef78e2d8a2e82e",
       "changed": "2026-09-11"
     },
     "/vendor/vera-aws": {
-      "hash": "5298c6d8f7bf503a",
+      "hash": "1949c3d89c70bf41",
       "changed": "2026-09-11"
     },
     "/vendor/vercel": {
       "daily": true
     },
     "/vendor/verifalia": {
-      "hash": "7e5fee85310a5441",
+      "hash": "f9791d396fdcb704",
       "changed": "2026-09-11"
     },
     "/vendor/verimail-io": {
-      "hash": "b761c6dd96ae0036",
+      "hash": "1d3474a2e96f1766",
       "changed": "2026-09-11"
     },
     "/vendor/veriphone": {
-      "hash": "145e2630e813e122",
+      "hash": "cb086a6ccf55432f",
       "changed": "2026-09-11"
     },
     "/vendor/versionfeeds": {
-      "hash": "71caeaf4629d36f3",
+      "hash": "45095bae65a9de1d",
       "changed": "2026-09-11"
     },
     "/vendor/versoly": {
       "daily": true
     },
     "/vendor/vertopal": {
-      "hash": "b1b63e365353c7c4",
+      "hash": "51ce2d63edbe7538",
       "changed": "2026-09-11"
     },
     "/vendor/videoinu": {
-      "hash": "64da378fabe9063d",
+      "hash": "2d41ec32b52ffd88",
       "changed": "2026-09-11"
     },
     "/vendor/vidhook": {
-      "hash": "706e546255c8de4e",
+      "hash": "cf9a7405f97d2263",
       "changed": "2026-09-11"
     },
     "/vendor/virgil-security": {
-      "hash": "13fe0727fae7788a",
+      "hash": "490fc84ee340e323",
       "changed": "2026-09-11"
     },
     "/vendor/virustotal": {
-      "hash": "47ac3818ddbff47b",
+      "hash": "be684eaa0c8c8126",
       "changed": "2026-09-11"
     },
     "/vendor/visual-debug": {
-      "hash": "010a81a852636d98",
+      "hash": "afcd9f5012ebc11d",
       "changed": "2026-09-11"
     },
     "/vendor/visual-studio-code": {
-      "hash": "5cccca7cee12f35d",
+      "hash": "c8d402fdddd1f60e",
       "changed": "2026-09-11"
     },
     "/vendor/visual-studio-community": {
-      "hash": "2d5c5587883b46a8",
+      "hash": "b536e2e316027ba2",
       "changed": "2026-09-11"
     },
     "/vendor/vitepress": {
-      "hash": "2f2f3ca361b8c4bb",
+      "hash": "270f2ccf3949c3a2",
       "changed": "2026-09-11"
     },
     "/vendor/volaryddns": {
-      "hash": "de09b06c72940ed1",
+      "hash": "b818d1c6b3f74364",
       "changed": "2026-09-11"
     },
     "/vendor/volume": {
-      "hash": "0a83ce759a1e3af4",
+      "hash": "182b2642bfbaed5b",
       "changed": "2026-09-11"
     },
     "/vendor/volume-shader-bm": {
-      "hash": "9236b43e7586a8cb",
+      "hash": "4845c13c3bab5747",
       "changed": "2026-09-11"
     },
     "/vendor/vscodium": {
-      "hash": "9064f810a185130a",
+      "hash": "1ea906b8faca07fe",
       "changed": "2026-09-11"
     },
     "/vendor/vultr-dns": {
-      "hash": "e8cd11adf9d30458",
+      "hash": "afd672c7261dd790",
       "changed": "2026-09-11"
     },
     "/vendor/wachete": {
       "daily": true
     },
     "/vendor/waitlio": {
-      "hash": "d376a5fa89ab4fd6",
+      "hash": "a24ec539cbee2184",
       "changed": "2026-09-11"
     },
     "/vendor/waiverstevie-com": {
-      "hash": "297b231f7b97db5e",
+      "hash": "62459f84be257df9",
       "changed": "2026-09-11"
     },
     "/vendor/wakatime-com": {
-      "hash": "e127310e1864ec4b",
+      "hash": "f1684c4d4694c2b6",
       "changed": "2026-09-11"
     },
     "/vendor/wave-terminal": {
-      "hash": "ac204a2ad98d77bb",
+      "hash": "6c71b3454fe566a1",
       "changed": "2026-09-11"
     },
     "/vendor/wdrfree-svg": {
-      "hash": "a13f9d13c94624ac",
+      "hash": "164b9c39f3d5880c",
       "changed": "2026-09-11"
     },
     "/vendor/we-team": {
-      "hash": "55dc39500e2a1552",
+      "hash": "e29967b694a3be18",
       "changed": "2026-09-11"
     },
     "/vendor/weatherxu": {
-      "hash": "c07f3cb37bee5391",
+      "hash": "9f120d0c2e5bc896",
       "changed": "2026-09-11"
     },
     "/vendor/weaviate": {
       "daily": true
     },
     "/vendor/web3forms": {
-      "hash": "f54195fe4a0eb1eb",
+      "hash": "245196e5bde25aae",
       "changed": "2026-09-11"
     },
     "/vendor/webacus": {
-      "hash": "0ad780fb4ba2e739",
+      "hash": "e474aa1f673477d8",
       "changed": "2026-09-11"
     },
     "/vendor/webcomponents-dev": {
-      "hash": "21769d6d9aa17be4",
+      "hash": "ef65d321389f840e",
       "changed": "2026-09-11"
     },
     "/vendor/webex": {
-      "hash": "827967d4ac3e98e9",
+      "hash": "5023260a4283b1aa",
       "changed": "2026-09-11"
     },
     "/vendor/webflow": {
-      "hash": "0343f9bceb785301",
+      "hash": "40dde6ab86bbe952",
       "changed": "2026-09-11"
     },
     "/vendor/webhook-site": {
-      "hash": "ab33e5660dcfe087",
+      "hash": "f448ec3c735e3f2a",
       "changed": "2026-09-11"
     },
     "/vendor/webhookrelay-com": {
-      "hash": "7b4586a3037f5bba",
+      "hash": "a7bd4a2aaffc8abe",
       "changed": "2026-09-11"
     },
     "/vendor/webpushr": {
-      "hash": "84d51a438824aba7",
+      "hash": "c40b71b8ebb85cf4",
       "changed": "2026-09-11"
     },
     "/vendor/webscraping-ai": {
-      "hash": "a111ae3d111a6169",
+      "hash": "0249f39ceacf5c0d",
       "changed": "2026-09-11"
     },
     "/vendor/websitepulse-com": {
-      "hash": "835406496fb59a22",
+      "hash": "b1177e69ed5b4140",
       "changed": "2026-09-11"
     },
     "/vendor/webstudio": {
-      "hash": "ed14efb17ad46259",
+      "hash": "a4630238d0849e16",
       "changed": "2026-09-11"
     },
     "/vendor/webvizio": {
-      "hash": "cc34f86b26d92327",
+      "hash": "41672b007fac9c8d",
       "changed": "2026-09-11"
     },
     "/vendor/weglot": {
-      "hash": "ebd754ba0fba0f3e",
+      "hash": "f66b7533347e95e8",
       "changed": "2026-09-11"
     },
     "/vendor/weights-biases": {
       "daily": true
     },
     "/vendor/weserv": {
-      "hash": "30a47c0779de2c39",
+      "hash": "28851605576266b9",
       "changed": "2026-09-11"
     },
     "/vendor/wework": {
-      "hash": "2d47f3b40f2f6b2b",
+      "hash": "00b1f85ec23b19ce",
       "changed": "2026-09-11"
     },
     "/vendor/what-the-diff": {
-      "hash": "db3742c1087b17b5",
+      "hash": "1f5f74168b6d39a4",
       "changed": "2026-09-11"
     },
     "/vendor/whatsapp": {
-      "hash": "32d52a4e36133ef8",
+      "hash": "fc73747007cb3b10",
       "changed": "2026-09-11"
     },
     "/vendor/whereby": {
-      "hash": "c8a5397dff4a0dea",
+      "hash": "14965bf4c5947ea8",
       "changed": "2026-09-11"
     },
     "/vendor/whimsical-com": {
-      "hash": "337f0ac756227e8f",
+      "hash": "4c0608391c490b33",
       "changed": "2026-09-11"
     },
     "/vendor/whitespace": {
-      "hash": "76c3888144799f0a",
+      "hash": "e6ccb39c1b8dbb4e",
       "changed": "2026-09-11"
     },
     "/vendor/windmill-dev": {
-      "hash": "f5147c5433f80fde",
+      "hash": "575dc14800a3453c",
       "changed": "2026-09-11"
     },
     "/vendor/windscribe": {
-      "hash": "8f36702b04dff8ca",
+      "hash": "3c5db332c05c8895",
       "changed": "2026-09-11"
     },
     "/vendor/windsurf": {
       "daily": true
     },
     "/vendor/wisepops": {
-      "hash": "e2daa211d3f89053",
+      "hash": "3fb122899f047d44",
       "changed": "2026-09-11"
     },
     "/vendor/wistia-com": {
-      "hash": "cd300240c23347ff",
+      "hash": "75fdff7faa1f1161",
       "changed": "2026-09-11"
     },
     "/vendor/wizishop": {
-      "hash": "5b72784605950ffe",
+      "hash": "d7d54e180437b81a",
       "changed": "2026-09-11"
     },
     "/vendor/woodpecker-ci": {
-      "hash": "5947f72c13d99006",
+      "hash": "8fc5452113cf7b36",
       "changed": "2026-09-11"
     },
     "/vendor/workos": {
-      "hash": "0996a8cb52b9dd25",
+      "hash": "73c62f3d9dd700ec",
       "changed": "2026-09-11"
     },
     "/vendor/wormhol-org": {
-      "hash": "108482cd8b0b883f",
+      "hash": "868bf5f8b1979be2",
       "changed": "2026-09-11"
     },
     "/vendor/wormhole": {
-      "hash": "af46ed3494a74bdb",
+      "hash": "60c92857c1d662d7",
       "changed": "2026-09-11"
     },
     "/vendor/wp-engine": {
-      "hash": "5f413f0adacedcbc",
+      "hash": "3c4d4e479eb50ed8",
       "changed": "2026-09-11"
     },
     "/vendor/wpjack": {
-      "hash": "e1a89a75439d3034",
+      "hash": "adaaf19db83d2c88",
       "changed": "2026-09-11"
     },
     "/vendor/wrapapi-com": {
-      "hash": "c91bcd77dcfb65e8",
+      "hash": "553953fd73526338",
       "changed": "2026-09-11"
     },
     "/vendor/wraps": {
-      "hash": "3babd8d3bd1b8e79",
+      "hash": "6a520d95839ebf2e",
       "changed": "2026-09-11"
     },
     "/vendor/wufoo": {
-      "hash": "f9c6c8e7088d8d3c",
+      "hash": "59f1a24b79dc61ce",
       "changed": "2026-09-11"
     },
     "/vendor/wundergraph": {
-      "hash": "51f79c5cf3540734",
+      "hash": "d7f71f3acfe3a319",
       "changed": "2026-09-11"
     },
     "/vendor/x-twitter": {
-      "hash": "ac7a8eea7c2012c2",
+      "hash": "bc5499d8d98e933c",
       "changed": "2026-09-11"
     },
     "/vendor/xai": {
@@ -9347,66 +9347,66 @@
       "daily": true
     },
     "/vendor/xcloud-host": {
-      "hash": "1fefbf868f98ab40",
+      "hash": "68b9639bdbbfc6e9",
       "changed": "2026-09-11"
     },
     "/vendor/xirsys": {
-      "hash": "2e7d6029e3c41066",
+      "hash": "804a6c7482c07554",
       "changed": "2026-09-11"
     },
     "/vendor/xitoring-com": {
       "daily": true
     },
     "/vendor/xkit": {
-      "hash": "389facd2146f4a0f",
+      "hash": "2175dc7f84fca423",
       "changed": "2026-09-11"
     },
     "/vendor/yepcode": {
-      "hash": "46bba819133095de",
+      "hash": "75dbc9b42d1b6791",
       "changed": "2026-09-11"
     },
     "/vendor/yodiz": {
-      "hash": "cb59f29ff7b2cf23",
+      "hash": "5efff0336b4501fe",
       "changed": "2026-09-11"
     },
     "/vendor/yousign": {
-      "hash": "a1dbc9702b257af9",
+      "hash": "138bd7b1cc12be12",
       "changed": "2026-09-11"
     },
     "/vendor/zapier": {
-      "hash": "37b216f07c4d1a3a",
+      "hash": "f7474783dedbca3d",
       "changed": "2026-09-11"
     },
     "/vendor/zed": {
-      "hash": "f07a0d53e0bc06ad",
+      "hash": "7691ac13d59dc138",
       "changed": "2026-09-11"
     },
     "/vendor/zenable": {
-      "hash": "b4d397cc214c643a",
+      "hash": "810fa9d0676c40b9",
       "changed": "2026-09-11"
     },
     "/vendor/zendesk-for-startups": {
-      "hash": "ec77b89ee8b343eb",
+      "hash": "c5de571e2be3a604",
       "changed": "2026-09-11"
     },
     "/vendor/zenhub-com": {
-      "hash": "469fba59ad6a3fc2",
+      "hash": "03fe966fc5376527",
       "changed": "2026-09-11"
     },
     "/vendor/zenscrape": {
-      "hash": "e9a22d7398213f82",
+      "hash": "8558613f6f51d2b1",
       "changed": "2026-09-11"
     },
     "/vendor/zentail": {
-      "hash": "8ef4447aef8eb65c",
+      "hash": "4fdc8f97c4d749d4",
       "changed": "2026-09-11"
     },
     "/vendor/zeplin": {
-      "hash": "00f80391de6be372",
+      "hash": "06ad2711cc50b6f0",
       "changed": "2026-09-11"
     },
     "/vendor/zerotier": {
-      "hash": "86dfb31f386581b6",
+      "hash": "2d14a7f54bf7e9f5",
       "changed": "2026-09-11"
     },
     "/vendor/zhipu-ai": {
@@ -9416,119 +9416,119 @@
       "daily": true
     },
     "/vendor/zilore-com": {
-      "hash": "b0c3b05c624b3c41",
+      "hash": "3c1444cb253ecafb",
       "changed": "2026-09-11"
     },
     "/vendor/zipcodebase": {
-      "hash": "feffa912073f07d2",
+      "hash": "e5a3f6552a0e0a76",
       "changed": "2026-09-11"
     },
     "/vendor/zipcodestack": {
-      "hash": "948c79341e6332b8",
+      "hash": "dec58bc98f94c12d",
       "changed": "2026-09-11"
     },
     "/vendor/zitadel-cloud": {
-      "hash": "1e53dd076502d5c3",
+      "hash": "e4daa16b117a49c0",
       "changed": "2026-09-11"
     },
     "/vendor/zoho": {
-      "hash": "7ccd4d154e85cbfc",
+      "hash": "32efcc0afe23a892",
       "changed": "2026-09-11"
     },
     "/vendor/zoho-assist": {
-      "hash": "ae274a7c06244916",
+      "hash": "15eaae03df8c6b0d",
       "changed": "2026-09-11"
     },
     "/vendor/zoho-bookings": {
-      "hash": "191430aa6067a210",
+      "hash": "ff324a4ff0dbf476",
       "changed": "2026-09-11"
     },
     "/vendor/zoho-campaigns": {
-      "hash": "df35674976c0abbf",
+      "hash": "a663f6119306f976",
       "changed": "2026-09-11"
     },
     "/vendor/zoho-checkout": {
-      "hash": "267d1ea0b0a0aa4b",
+      "hash": "08c89120ed4b6e49",
       "changed": "2026-09-11"
     },
     "/vendor/zoho-cliq": {
-      "hash": "868fac806b1d67c4",
+      "hash": "7e34a51f1dbcd7ad",
       "changed": "2026-09-11"
     },
     "/vendor/zoho-connect": {
-      "hash": "c44aaec42f5d827b",
+      "hash": "ef74268f96d9af11",
       "changed": "2026-09-11"
     },
     "/vendor/zoho-desk": {
-      "hash": "c9234bbaddd4f07a",
+      "hash": "df97d1e8dccea5c6",
       "changed": "2026-09-11"
     },
     "/vendor/zoho-docs": {
-      "hash": "413a49d433d67b02",
+      "hash": "7cccb0dcf79e94bf",
       "changed": "2026-09-11"
     },
     "/vendor/zoho-forms": {
-      "hash": "d473e07d7ff9f74d",
+      "hash": "8c27dacf93bea8e2",
       "changed": "2026-09-11"
     },
     "/vendor/zoho-meeting": {
-      "hash": "86e05e561aa4c533",
+      "hash": "cb4b076fa5cab46f",
       "changed": "2026-09-11"
     },
     "/vendor/zoho-notebook": {
-      "hash": "12717bfe33d2dd3a",
+      "hash": "1313e99d14e94db6",
       "changed": "2026-09-11"
     },
     "/vendor/zoho-projects": {
-      "hash": "cf0cf188d0412203",
+      "hash": "388e1028b5494adc",
       "changed": "2026-09-11"
     },
     "/vendor/zoho-showtime": {
-      "hash": "fcbddefc48d9b233",
+      "hash": "d4dc2cc04593b6e4",
       "changed": "2026-09-11"
     },
     "/vendor/zoho-sign": {
-      "hash": "84a1bdf482500dc1",
+      "hash": "a093101c12a631ac",
       "changed": "2026-09-11"
     },
     "/vendor/zoho-survey": {
-      "hash": "8f96a24bf691c029",
+      "hash": "e38a7dd7976c63c0",
       "changed": "2026-09-11"
     },
     "/vendor/zoho-vault": {
-      "hash": "ce4138f5bfdea233",
+      "hash": "9e8e61c337806308",
       "changed": "2026-09-11"
     },
     "/vendor/zoho-wiki": {
-      "hash": "5c441e8768a1c836",
+      "hash": "f89dff602834548f",
       "changed": "2026-09-11"
     },
     "/vendor/zoneedit-com": {
-      "hash": "4e7bd080e14cf9d7",
+      "hash": "72f9a91fd6090bde",
       "changed": "2026-09-11"
     },
     "/vendor/zonomi": {
-      "hash": "a1641698be9ec5e9",
+      "hash": "18ccd63b768d5bf5",
       "changed": "2026-09-11"
     },
     "/vendor/zoom": {
-      "hash": "0aefed46516f0f67",
+      "hash": "6b4d3ff58161c5e5",
       "changed": "2026-09-11"
     },
     "/vendor/zoom-us": {
-      "hash": "70238fe8cbbc3d84",
+      "hash": "a5b273c8949e2c9f",
       "changed": "2026-09-11"
     },
     "/vendor/zube": {
-      "hash": "a3b547e62ac45c58",
+      "hash": "9f7323702f93e648",
       "changed": "2026-09-11"
     },
     "/vendor/zulip": {
-      "hash": "2b248c3eb70ebd7e",
+      "hash": "7d392d12ab05b7fa",
       "changed": "2026-09-11"
     },
     "/vendor/zuplo": {
-      "hash": "78d211148634877c",
+      "hash": "f3405872f2b61c2b",
       "changed": "2026-09-11"
     },
     "/vercel-alternatives": {

--- a/scripts/subset-churn-census.mjs
+++ b/scripts/subset-churn-census.mjs
@@ -1,0 +1,273 @@
+import { spawn } from "node:child_process";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const REPO = join(dirname(fileURLToPath(import.meta.url)), "..");
+const ORIGIN = "http://localhost";
+const A_DAY_IN_MS = 86400000;
+
+const HELP = `Report which surfaces name a different set of vendors tomorrow.
+
+Every page is rendered twice, the second time against a server whose clock is a day ahead, and
+the names each surface publishes are compared as sets. A tied set listed in a rotating order is
+the same set both times; a slice of that order is not, and this is what finds the slices.
+
+Regions are read from each page's own headings rather than from a list of surfaces, so a surface
+added later is measured without being registered here.
+
+Usage: node scripts/subset-churn-census.mjs [--all]
+
+  --all    Read every published URL rather than only the pages data/page-lastmod.json calls daily
+  --help   This text
+`;
+
+function startServer(inventoryOut, clockShiftMs = 0) {
+  return new Promise((resolve, reject) => {
+    const args = clockShiftMs ? ["--import", join(REPO, "scripts", "shifted-clock.mjs")] : [];
+    const proc = spawn("node", [...args, join(REPO, "dist", "serve.js")], {
+      stdio: ["pipe", "pipe", "pipe"],
+      env: {
+        ...process.env,
+        TZ: "UTC",
+        PORT: "0",
+        BASE_URL: ORIGIN,
+        AGENTDEALS_PAGE_INVENTORY_OUT: inventoryOut,
+        AGENTDEALS_CLOCK_SHIFT_MS: String(clockShiftMs),
+      },
+    });
+    const timeout = setTimeout(() => { proc.kill(); reject(new Error("no port in 60s")); }, 60000);
+    proc.stderr.on("data", chunk => {
+      const match = chunk.toString().match(/running on http:\/\/localhost:(\d+)/);
+      if (match) { clearTimeout(timeout); resolve({ proc, base: `${ORIGIN}:${match[1]}` }); }
+    });
+    proc.on("error", err => { clearTimeout(timeout); reject(err); });
+    proc.on("exit", code => { clearTimeout(timeout); reject(new Error(`exit ${code} before port`)); });
+  });
+}
+
+function metaDescription(body) {
+  const m = body.match(/<meta name="description" content="([^"]*)"/);
+  return m ? m[1] : null;
+}
+
+function jsonLdBlocks(body) {
+  const out = [];
+  const re = /<script type="application\/ld\+json">([\s\S]*?)<\/script>/g;
+  let m;
+  while ((m = re.exec(body))) {
+    try { out.push(JSON.parse(m[1])); } catch { out.push({ unparseable: m[1] }); }
+  }
+  return out;
+}
+
+function itemListNames(body) {
+  const names = [];
+  const walk = node => {
+    if (Array.isArray(node)) { node.forEach(walk); return; }
+    if (!node || typeof node !== "object") return;
+    if (node["@type"] === "ItemList" && Array.isArray(node.itemListElement)) {
+      for (const el of node.itemListElement) {
+        const name = el?.item?.name ?? el?.name;
+        if (typeof name === "string") names.push(name);
+      }
+    }
+    for (const value of Object.values(node)) walk(value);
+  };
+  jsonLdBlocks(body).forEach(walk);
+  return names;
+}
+
+function compareTableNames(body) {
+  const section = body.match(/<table class="mini-compare-table">([\s\S]*?)<\/table>/);
+  if (!section) return null;
+  const names = [...section[1].matchAll(/<a href="\/vendor\/[^"]*">([^<]*)<\/a>/g)].map(m => m[1]);
+  return names;
+}
+
+function growthConsideration(body) {
+  const m = body.match(/At that point, consider <a href="\/vendor\/([^"]*)"/);
+  return m ? m[1] : null;
+}
+
+function faqOtherVendors(body) {
+  const m = body.match(/Other vendors in [^.]*? include ([^.]*)\./);
+  return m ? m[1] : null;
+}
+
+function linkedVendorSlugs(body) {
+  return [...new Set([...body.matchAll(/href="\/vendor\/([a-z0-9-]+)"/g)].map(m => m[1]))];
+}
+
+function stripTags(html) {
+  return html.replace(/<[^>]*>/g, "").replace(/\s+/g, " ").trim();
+}
+
+function vendorsByRegion(body) {
+  const regions = new Map();
+  const add = (region, slug) => {
+    if (!regions.has(region)) regions.set(region, new Set());
+    regions.get(region).add(slug);
+  };
+  const headingAt = [...body.matchAll(/<h[1-4][^>]*>([\s\S]*?)<\/h[1-4]>/g)].map(m => ({ at: m.index, text: stripTags(m[1]) }));
+  const headingFor = index => {
+    let current = "(before the first heading)";
+    for (const heading of headingAt) {
+      if (heading.at > index) break;
+      current = heading.text;
+    }
+    return current;
+  };
+  for (const match of body.matchAll(/href="\/vendor\/([a-z0-9-]+)"/g)) {
+    add(headingFor(match.index), match[1]);
+  }
+  return Object.fromEntries([...regions].map(([k, v]) => [k, [...v].sort()]));
+}
+
+function faqAnswers(body) {
+  const out = [];
+  const walk = node => {
+    if (Array.isArray(node)) { node.forEach(walk); return; }
+    if (!node || typeof node !== "object") return;
+    if (node["@type"] === "Question" && typeof node.acceptedAnswer?.text === "string") {
+      out.push(`${node.name} :: ${node.acceptedAnswer.text}`);
+    }
+    for (const value of Object.values(node)) walk(value);
+  };
+  jsonLdBlocks(body).forEach(walk);
+  return out.sort();
+}
+
+function surfacesOf(body) {
+  return {
+    regions: vendorsByRegion(body),
+    faq_answers: faqAnswers(body),
+    every_vendor_named: linkedVendorSlugs(body),
+    meta_description: metaDescription(body),
+    item_list_names: itemListNames(body),
+    compare_table: compareTableNames(body),
+    growth_consideration: growthConsideration(body),
+    faq_other_vendors: faqOtherVendors(body),
+  };
+}
+
+function sameSet(a, b) {
+  if (a === null || b === null) return a === b;
+  if (Array.isArray(a) && Array.isArray(b)) {
+    const sa = [...a].sort().join(" ");
+    const sb = [...b].sort().join(" ");
+    return sa === sb;
+  }
+  return a === b;
+}
+
+function sameSequence(a, b) {
+  if (Array.isArray(a) && Array.isArray(b)) return a.join(" ") === b.join(" ");
+  return a === b;
+}
+
+async function readEveryPage(base, paths) {
+  const out = new Map();
+  for (const pagePath of paths) {
+    const response = await fetch(base + pagePath);
+    const body = await response.text();
+    if (response.status !== 200) throw new Error(`${pagePath} answered ${response.status}`);
+    out.set(pagePath, surfacesOf(body));
+  }
+  return out;
+}
+
+function pageClass(pagePath) {
+  const first = pagePath.split("/")[1] ?? "";
+  if (["alternative-to", "vendor", "best", "category", "compare", "trends"].includes(first)) return `/${first}/*`;
+  return pagePath;
+}
+
+async function main() {
+  if (process.argv.includes("--help") || process.argv.includes("-h")) {
+    console.log(HELP);
+    return 0;
+  }
+  const onlyDaily = !process.argv.includes("--all");
+  const scratch = mkdtempSync(join(tmpdir(), "subset-churn-"));
+  let today;
+  let tomorrow;
+  try {
+    const startedAt = Date.now();
+    const inventoryOut = join(scratch, "inventory.json");
+    today = await startServer(inventoryOut);
+    let paths = JSON.parse(readFileSync(inventoryOut, "utf-8"));
+    if (onlyDaily) {
+      const ledger = JSON.parse(readFileSync(join(REPO, "data", "page-lastmod.json"), "utf-8"));
+      const daily = new Set(Object.entries(ledger.pages).filter(([, v]) => v.daily).map(([k]) => k));
+      paths = paths.filter(p => daily.has(p));
+    }
+    const todaySurfaces = await readEveryPage(today.base, paths);
+    today.proc.kill();
+    today = null;
+
+    tomorrow = await startServer(join(scratch, "inventory-tomorrow.json"), A_DAY_IN_MS);
+    const tomorrowSurfaces = await readEveryPage(tomorrow.base, paths);
+    tomorrow.proc.kill();
+    tomorrow = null;
+
+    const surfaceNames = ["faq_answers", "every_vendor_named", "meta_description", "item_list_names", "compare_table", "growth_consideration", "faq_other_vendors"];
+    const membershipMoved = {};
+    const orderOnlyMoved = {};
+    const byClass = {};
+    const examples = {};
+    const regionChurn = {};
+    for (const name of surfaceNames) { membershipMoved[name] = []; orderOnlyMoved[name] = []; }
+
+    for (const pagePath of paths) {
+      const a = todaySurfaces.get(pagePath);
+      const b = tomorrowSurfaces.get(pagePath);
+      const regionsToday = a.regions;
+      const regionsTomorrow = b.regions;
+      for (const region of new Set([...Object.keys(regionsToday), ...Object.keys(regionsTomorrow)])) {
+        if (sameSet(regionsToday[region] ?? [], regionsTomorrow[region] ?? [])) continue;
+        regionChurn[region] ??= { pages: 0, example: null };
+        regionChurn[region].pages++;
+        regionChurn[region].example ??= { path: pagePath, today: regionsToday[region], tomorrow: regionsTomorrow[region] };
+      }
+      for (const name of surfaceNames) {
+        const same = sameSet(a[name], b[name]);
+        if (!same) {
+          membershipMoved[name].push(pagePath);
+          const cls = pageClass(pagePath);
+          byClass[name] ??= {};
+          byClass[name][cls] = (byClass[name][cls] ?? 0) + 1;
+          examples[name] ??= { path: pagePath, today: a[name], tomorrow: b[name] };
+        } else if (!sameSequence(a[name], b[name])) {
+          orderOnlyMoved[name].push(pagePath);
+        }
+      }
+    }
+
+    const report = {
+      pages_read: paths.length,
+      seconds: Number(((Date.now() - startedAt) / 1000).toFixed(1)),
+      membership_changes: Object.fromEntries(surfaceNames.map(n => [n, membershipMoved[n].length])),
+      order_only_changes: Object.fromEntries(surfaceNames.map(n => [n, orderOnlyMoved[n].length])),
+      by_class: byClass,
+      region_churn: Object.fromEntries(
+        Object.entries(regionChurn).sort((x, y) => y[1].pages - x[1].pages).map(([k, v]) => [k, v.pages]),
+      ),
+      region_examples: regionChurn,
+      examples,
+      paths: Object.fromEntries(surfaceNames.map(n => [n, membershipMoved[n]])),
+    };
+    const out = join(scratch, "..", "subset-churn-census.json");
+    writeFileSync(out, JSON.stringify(report, null, 2));
+    console.log(JSON.stringify({ ...report, paths: undefined, examples: undefined, region_examples: undefined }, null, 2));
+    console.error(`Full report: ${out}`);
+    return 0;
+  } finally {
+    if (today) today.proc.kill();
+    if (tomorrow) tomorrow.proc.kill();
+    rmSync(scratch, { recursive: true, force: true });
+  }
+}
+
+main().then(code => process.exit(code), err => { console.error(err.stack); process.exit(1); });

--- a/src/ranking.ts
+++ b/src/ranking.ts
@@ -13,6 +13,12 @@ export const DEMOTE_ONLY_POLICY =
 export const NOT_MODELLED_NOTICE =
   "We rank on offer terms, verification recency and recorded adverse changes. We do NOT model technical fit between a product and a role — the caller must apply that.";
 
+export const NAMED_SUBSET_RULE =
+  "A surface with room for every member of a tied set may rotate their order. A surface with room for only some of them names none of them, because which ones it named would be the claim, and a claim seeded on the date is not the one we serve tomorrow.";
+
+export const NAMED_SUBSET_FIELD_RULE =
+  "No field picks a few members out of a tied set, because being tied is the absence of one. verifiedDate is the nearest candidate, and every date we hold is like it: they record when we last looked at a record rather than anything about the vendor, so ordering a list by one publishes our own re-read queue as though it were a recommendation. It would also still move — that queue confirms about a hundred records a day, so the three names would be different ones next week for a reason no reader of the claim can see. A record's name, slug, id and position in our file are inputs the tie-break promises never to use, and we hold no date for when we first indexed one.";
+
 const DAY_MS = 24 * 60 * 60 * 1000;
 const STALE_VERIFICATION_DAYS = 90;
 const VERIFICATION_LAPSED_DAYS = 180;

--- a/src/serve.ts
+++ b/src/serve.ts
@@ -72,7 +72,7 @@ import { statedFreeTierBasis, unrankedBestAnswer, unrankedListingBasis } from ".
 import { SSE_KEEPALIVE_FRAME, keepaliveIntervalMs, sessionRecoveryBody } from "./mcp-stream.js";
 import { ASSISTANTS_API_SHUTDOWN } from "./assistants-shutdown.js";
 import { discontinuedOnOrBefore, PRODUCT_DEPRECATED } from "./product-deprecation.js";
-import { rankOffers, rankForListing, rotateListing, utcDate, gateFor, notAFreeOfferGateFor, descriptionDeniesFreeTier, classifyTier, CRITERIA_PATH, DEMOTE_ONLY_POLICY, DISCLOSURE_RATIONALE, TIE_BREAK_ALGORITHM, GATE_TABLE, DEMERIT_TABLE, NOT_FREE_TIER_RULES, TIME_LIMITED_TIER_RULES, type TieBreak, type Gate, type GateCode } from "./ranking.js";
+import { rankOffers, rankForListing, rotateListing, utcDate, gateFor, notAFreeOfferGateFor, descriptionDeniesFreeTier, classifyTier, CRITERIA_PATH, DEMOTE_ONLY_POLICY, DISCLOSURE_RATIONALE, TIE_BREAK_ALGORITHM, NAMED_SUBSET_RULE, NAMED_SUBSET_FIELD_RULE, GATE_TABLE, DEMERIT_TABLE, NOT_FREE_TIER_RULES, TIME_LIMITED_TIER_RULES, type TieBreak, type Gate, type GateCode } from "./ranking.js";
 import type { RankedEntry, RankingResult } from "./ranking.js";
 import { eligibilityGateAsPublished, gatedShareDescriptionClause, gatedShareLede, publishableEligibilityConditions } from "./eligibility.js";
 import { gateDisclosureFor } from "./gate-disclosure.js";
@@ -2327,9 +2327,9 @@ function auditBlockCss(): string {
 @media(max-width:768px){.audit-block dl{grid-template-columns:1fr}}`;
 }
 
-function renderAuditBlock(tie: TieBreak, listed?: { shown: number; total: number }): string {
-  const truncationNote = listed && listed.shown < listed.total
-    ? ` The list above is the first ${listed.shown} of ${listed.total} entries in that order.`
+function renderAuditBlock(tie: TieBreak, listed?: { total: number }): string {
+  const truncationNote = listed
+    ? ` The list above is every one of the ${listed.total} entries in that order, not a prefix of it.`
     : "";
   return `  <div class="audit-block">
     <strong style="color:var(--text)">Recompute today's order yourself.</strong> The order above is a permutation seeded only on the UTC date and the query key &mdash; no vendor name, slug, id or offer field is an input.${truncationNote} <a href="${CRITERIA_PATH}">The algorithm is published</a>, so anyone can reproduce this page's order without asking us.
@@ -2908,6 +2908,12 @@ ${demeritRows}
   <p>Tied offers are ordered by a permutation seeded on the UTC date and the query key, and nothing else. No vendor name, slug, id, index or offer field is an input, so an offer's position is uniform regardless of what it is called or where it sits in our file. The order rotates daily; the membership of the list does not.</p>
   <pre>${escHtmlServer(TIE_BREAK_ALGORITHM)}</pre>
   <p>Every ranked page publishes the <code>date</code>, <code>query_key</code>, <code>seed</code> and <code>tie_count</code> it used, and the JSON APIs return the same block. <strong style="color:var(--text)">You can recompute today's order yourself and check it against what we served, without asking us.</strong> That is the point: not for sale should be auditable, not merely asserted.</p>
+
+  <h3 id="subsets">Surfaces with room for only a few of them</h3>
+  <p><strong style="color:var(--text)">${escHtmlServer(NAMED_SUBSET_RULE)}</strong></p>
+  <p>Rotating a complete list costs a reader nothing: every member is on the page whichever day you read it, and the order is recomputable from the seed above. Rotating a <em>truncated</em> list is a different thing, because a vendor is either named or it is not, and being named is what a reader and an extractor take away. A search snippet that named three of forty alternatives would name three others tomorrow, so anyone quoting it would be quoting a sentence we are no longer serving &mdash; and the whole point of publishing the date we read every record and the page we read it from is that a claim about us can be checked.</p>
+  <p>So a page that can carry the whole tied set carries it: a vendor page lists every alternative we hold for it, not a sample. Where there is no room &mdash; a <code>&lt;meta&gt;</code> description, a one-line answer &mdash; we describe the set and name none of it.</p>
+  <p>The obvious alternative would be to pick a few by some field and say which. ${escHtmlServer(NAMED_SUBSET_FIELD_RULE)} Any of those would manufacture the permanent top slot that section 3 exists to deny, so there is none to manufacture.</p>
 
   <h2>4. What we do not model</h2>
   <p>We rank on offer terms, verification recency and recorded adverse changes. <strong style="color:var(--text)">We do not model technical fit</strong> &mdash; whether a particular product suits a particular role in your architecture. A vector database and a relational database sit in the same category here. If you are asking us which of two products fits your app, we are the wrong source; if you are asking whose free tier we could confirm this week and whose was withdrawn in March, that is exactly what this is for.</p>
@@ -4721,7 +4727,7 @@ function buildVendorPage(slug: string): string | null {
     alternativesMembership.kept,
     { queryKey: `alternatives:${primary.category}:${vendorName}`, changes: dealChanges },
   );
-  const alternatives = alternativesRanking.entries.slice(0, 12).map(e => e.offer);
+  const alternatives = alternativesRanking.entries.map(e => e.offer);
 
   const curatedVendorRanking = (() => {
     const kept = curatedAlternativesFor(vendorName, dealChanges, offers, vendorOffers).kept;
@@ -4801,8 +4807,7 @@ function buildVendorPage(slug: string): string | null {
     growthBullets.push(`When your usage exceeds the free tier limits, you'll need to upgrade.`);
   }
   if (alternatives.length > 2 && !termsSuperseded) {
-    const topAlt = alternatives[0];
-    growthBullets.push(`At that point, consider <a href="/vendor/${toSlug(topAlt.vendor)}">${escHtmlServer(topAlt.vendor)}</a> which offers ${escHtmlServer(topAlt.tier)} in the same category.`);
+    growthBullets.push(`At that point, the <a href="#alternatives">${alternatives.length} alternatives in ${escHtmlServer(primary.category)}</a> are each listed with the free tier they offer, so you can compare what they give you against what you have outgrown.`);
   }
   const growthPathHtml = growthBullets.length > 0 && !discontinuedOn && !primaryGate ? `
   <div class="section growth-section">
@@ -4812,37 +4817,7 @@ function buildVendorPage(slug: string): string | null {
     </ul>
   </div>` : "";
 
-  const enrichedAlts = enrichOffers(alternatives.slice(0, 3));
-  const compareTableHtml = enrichedAlts.length > 0 ? `
-  <div class="section compare-table-section">
-    <h2>How ${escHtmlServer(vendorName)} Compares</h2>
-    <div class="mini-compare-table-wrap">
-      <table class="mini-compare-table">
-        <thead>
-          <tr>
-            <th>Service</th>
-            <th>Free Tier</th>
-            <th>Stability</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr class="current-vendor-row">
-            <td><strong>${escHtmlServer(vendorName)}</strong></td>
-            <td>${escHtmlServer(primary.tier)}</td>
-            <td>${stabilityCellHtml(enriched.risk_level, riskCause, linkUnreachable, primary, primaryGate, enriched.rating_withheld)}</td>
-          </tr>
-${enrichedAlts.map(a => {
-  return `          <tr>
-            <td><a href="/vendor/${toSlug(a.vendor)}">${escHtmlServer(a.vendor)}</a></td>
-            <td>${escHtmlServer(a.tier)}</td>
-            <td>${stabilityCellHtml(a.risk_level, a.risk_cause, a.link_unreachable, a, null, a.rating_withheld)}</td>
-          </tr>`;
-}).join("\n")}
-        </tbody>
-      </table>
-    </div>
-    ${catMapping?.comparison ? `<p class="compare-more"><a href="${catMapping.comparison}">See full comparison &rarr;</a></p>` : catMapping?.hub ? `<p class="compare-more"><a href="${catMapping.hub}">See all ${escHtmlServer(primary.category)} options &rarr;</a></p>` : ""}
-  </div>` : "";
+  const enrichedAlts = enrichOffers(alternatives);
 
   const changesHtml = vendorChanges.length > 0 ? vendorChanges.map(c => {
     const badge = changeTypeBadge[c.change_type] ?? { label: c.change_type, color: "#8b949e" };
@@ -4921,18 +4896,39 @@ ${curatedVendorAlts.map(a => `      <a href="/vendor/${toSlug(a.vendor)}" class=
         <span class="alt-tier">${escHtmlServer(a.tier)}</span>
       </a>`).join("\n")}
     </div>
-${renderAuditBlock(curatedVendorRanking.tie_break, { shown: curatedVendorAlts.length, total: curatedVendorRanking.entries.length })}
+${renderAuditBlock(curatedVendorRanking.tie_break, { total: curatedVendorRanking.entries.length })}
   </div>` : "";
-  const alternativesHtml = alternatives.length > 0 ? `
-  <div class="section">
-    <h2>Alternatives in ${escHtmlServer(primary.category)}</h2>
-    <div class="alt-grid">
-${alternatives.map(a => `      <a href="/vendor/${toSlug(a.vendor)}" class="alt-card">
-        <span class="alt-name">${escHtmlServer(a.vendor)}</span>
-        <span class="alt-tier">${escHtmlServer(a.tier)}</span>
-      </a>`).join("\n")}
+  const alternativesHtml = enrichedAlts.length > 0 ? `
+  <div class="section compare-table-section">
+    <h2 id="alternatives">Alternatives in ${escHtmlServer(primary.category)}</h2>
+    <p class="section-note" style="margin:0 0 1rem;font-size:.85rem;color:var(--text-muted)">How ${escHtmlServer(vendorName)} compares against every one of the ${enrichedAlts.length} we list, not against a selection of them. ${escHtmlServer(NAMED_SUBSET_RULE)} <a href="${CRITERIA_PATH}#subsets">How we decide this</a>.</p>
+    <div class="mini-compare-table-wrap">
+      <table class="mini-compare-table">
+        <thead>
+          <tr>
+            <th>Service</th>
+            <th>Free Tier</th>
+            <th>Stability</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr class="current-vendor-row">
+            <td><strong>${escHtmlServer(vendorName)}</strong></td>
+            <td>${escHtmlServer(primary.tier)}</td>
+            <td>${stabilityCellHtml(enriched.risk_level, riskCause, linkUnreachable, primary, primaryGate, enriched.rating_withheld)}</td>
+          </tr>
+${enrichedAlts.map(a => {
+  return `          <tr>
+            <td><a href="/vendor/${toSlug(a.vendor)}">${escHtmlServer(a.vendor)}</a></td>
+            <td>${escHtmlServer(a.tier)}</td>
+            <td>${stabilityCellHtml(a.risk_level, a.risk_cause, a.link_unreachable, a, null, a.rating_withheld)}</td>
+          </tr>`;
+}).join("\n")}
+        </tbody>
+      </table>
     </div>${membershipExclusionsHtml}
-${renderAuditBlock(alternativesRanking.tie_break, { shown: alternatives.length, total: alternativesRanking.entries.length })}
+    ${catMapping?.comparison ? `<p class="compare-more"><a href="${catMapping.comparison}">See full comparison &rarr;</a></p>` : catMapping?.hub ? `<p class="compare-more"><a href="${catMapping.hub}">See all ${escHtmlServer(primary.category)} options &rarr;</a></p>` : ""}
+${renderAuditBlock(alternativesRanking.tie_break, { total: alternativesRanking.entries.length })}
   </div>` : "";
 
   const vendorVsPages = vsPageByVendor.get(vendorName.toLowerCase()) ?? [];
@@ -5101,7 +5097,7 @@ ${allCompareLinks.join("\n")}
     : riskLevel === "caution"
     ? `${vendorName}'s free tier requires caution because of one specific recorded change${riskCause ? `, ${changeDateClause(riskCause)}: ${changeSummaryText(riskCause)}` : "."}`
     : `${vendorName}'s free tier is considered risky because of one specific recorded change${riskCause ? `, ${changeDateClause(riskCause)}: ${changeSummaryText(riskCause)}` : "."} Consider alternatives.`;
-  const faqCategoryAnswer = `${vendorName} is categorized under ${allCategories.join(", ")} on AgentDeals.${alternatives.length > 0 ? ` Other vendors in ${primary.category} include ${alternatives.slice(0, 5).map(a => a.vendor).join(", ")}.` : ""}`;
+  const faqCategoryAnswer = `${vendorName} is categorized under ${allCategories.join(", ")} on AgentDeals.${alternatives.length > 0 ? ` We list ${alternatives.length} other ${primary.category} services alongside it, every one of them on this page with its free tier and the stability we publish for it.` : ""}`;
 
   const faqProductionAnswer = productionGate
     ? `${productionGate.reason} ${NO_FREE_TIER_FOR_PRODUCTION}`
@@ -5298,7 +5294,6 @@ ${referralCalloutHtml}
       ? `<p class="terms-superseded-text"><strong>${SUPERSEDED_TERMS_LABEL}:</strong> ${supersededTermsNoticeHtml(vendorName, termsSuperseded, escHtmlServer)} <a href="#changes">Read what we recorded &darr;</a></p>`
       : `<p class="desc-text">${escHtmlServer(primary.description)}</p>`}${freeTierSourceLine}
   </div>
-${compareTableHtml}
 ${growthPathHtml}
 
   <div class="section">
@@ -5401,7 +5396,7 @@ function buildAlternativesPage(slug: string): string | null {
 
   const curatedAlts = enrichedAlts.filter(a => curatedAltNames.has(a.vendor));
   const listedCategories = [...vendorCategories];
-  for (const a of enrichedAlts) {
+  for (const a of [...enrichedAlts].sort((x, y) => x.category.localeCompare(y.category))) {
     if (!listedCategories.includes(a.category)) listedCategories.push(a.category);
   }
 
@@ -5412,9 +5407,8 @@ function buildAlternativesPage(slug: string): string | null {
   const title = publishesSubstitutes
     ? `Best ${vendorName} Alternatives with Free Tiers (${currentYear}) | AgentDeals`
     : `${heading} — none listed yet | AgentDeals`;
-  const topAlts = enrichedAlts.slice(0, 3).map(a => a.vendor).join(", ");
   const metaDesc = publishesSubstitutes
-    ? `Compare ${enrichedAlts.length} free alternatives to ${vendorName} for ${homeCategory}. ${topAlts ? `Side-by-side free tier limits for ${topAlts}.` : "Find stable, verified free-tier tools."}`
+    ? `Compare ${enrichedAlts.length} free alternatives to ${vendorName} for ${homeCategory}. Every one of their free tier limits side by side, each with the date we last verified it.`
     : `We publish no substitute list for ${vendorName} yet. See the ${homeCategory} category for every offer we track alongside it.`;
   const subjectSaysWhatItIs = vendorOffers.some(o => (o.product_subtypes?.labels.length ?? 0) > 0);
   const noSubstitutesReason = subjectSaysWhatItIs

--- a/test/alternatives-membership.test.ts
+++ b/test/alternatives-membership.test.ts
@@ -109,8 +109,8 @@ describe("#1032 the vendor page the issue was filed about", () => {
   it("still offers alternatives, so the gates did not empty the list", async () => {
     const { body } = await get(`/vendor/${slugOf(SUBJECT)}`);
     const grid = sectionAfter(body, "Alternatives in");
-    const cards = grid.match(/class="alt-name"/g) ?? [];
-    assert.ok(cards.length >= 5, `the alternatives grid must still carry a useful list, found ${cards.length}`);
+    const listed = grid.match(/<td><a href="\/vendor\/[a-z0-9-]+">/g) ?? [];
+    assert.ok(listed.length >= 5, `the alternatives list must still carry a useful list, found ${listed.length}`);
   });
 
   it("does not list a connection pool or a downloadable emulator among them", async () => {
@@ -387,16 +387,16 @@ describe("#1032 a classification must not contradict what we already publish", (
         `${name} must be subtype-gated against ${subject} for this test to mean anything`
       );
     }
-    const cardName: Record<string, string> = {
-      "/vendor/pythonanywhere": "alt-name",
-      "/alternative-to/pythonanywhere": "alt-vendor-name",
+    const namedBy: Record<string, RegExp[]> = {
+      "/vendor/pythonanywhere": [/class="alt-name">([^<]+)</g, /<td><a href="\/vendor\/[a-z0-9-]+">([^<]+)<\/a><\/td>/g],
+      "/alternative-to/pythonanywhere": [/class="alt-vendor-name">([^<]+)</g],
     };
-    for (const [url, cls] of Object.entries(cardName)) {
+    for (const [url, patterns] of Object.entries(namedBy)) {
       const { body } = await get(url);
-      const listed = [...body.matchAll(new RegExp(`class="${cls}">([^<]+)<`, "g"))].map(m => m[1]);
-      assert.ok(listed.length > 3, `${url} rendered no alternatives cards, so this test proves nothing`);
+      const listed = patterns.flatMap(pattern => [...body.matchAll(pattern)].map(m => m[1]));
+      assert.ok(listed.length > 3, `${url} named no alternatives, so this test proves nothing`);
       for (const name of crossing) {
-        assert.ok(listed.includes(name), `${url} drops the curated name ${name} from its cards`);
+        assert.ok(listed.includes(name), `${url} drops the curated name ${name} from the alternatives it names`);
       }
     }
   });

--- a/test/curated-alternatives.test.ts
+++ b/test/curated-alternatives.test.ts
@@ -427,7 +427,7 @@ describe("curated alternatives on the published pages", () => {
   });
 
   it("leaves the category heading on the vendor page describing the category list", async () => {
-    const heading = "<h2>Alternatives in Databases</h2>";
+    const heading = '<h2 id="alternatives">Alternatives in Databases</h2>';
     const res = await get("/vendor/firebase");
     assert.ok(res.body.includes(heading), "the subject must render a category list for the assertion to mean anything");
     const categoryList = res.body.slice(res.body.indexOf(heading));

--- a/test/named-subsets.test.ts
+++ b/test/named-subsets.test.ts
@@ -1,0 +1,243 @@
+import { describe, it, before, after } from "node:test";
+import assert from "node:assert";
+import { spawn, type ChildProcess } from "node:child_process";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { assertCoversPopulation, vendorsInTheCatalogue } from "./population-floor.ts";
+import { NAMED_SUBSET_RULE, NAMED_SUBSET_FIELD_RULE } from "../dist/ranking.js";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO = path.join(__dirname, "..");
+const A_DAY_IN_MS = 86400000;
+
+interface Surfaces {
+  regions: Record<string, string[]>;
+  vendorSequence: string[];
+  metaDescription: string | null;
+  itemListNames: string[];
+  faqAnswers: string[];
+}
+
+function startServer(inventoryOut: string, clockShiftMs: number): Promise<{ proc: ChildProcess; base: string }> {
+  return new Promise((resolve, reject) => {
+    const args = clockShiftMs ? ["--import", path.join(REPO, "scripts", "shifted-clock.mjs")] : [];
+    const proc = spawn("node", [...args, path.join(REPO, "dist", "serve.js")], {
+      stdio: ["pipe", "pipe", "pipe"],
+      env: {
+        ...process.env,
+        TZ: "UTC",
+        PORT: "0",
+        BASE_URL: "http://localhost",
+        AGENTDEALS_PAGE_INVENTORY_OUT: inventoryOut,
+        AGENTDEALS_CLOCK_SHIFT_MS: String(clockShiftMs),
+      },
+    });
+    const timeout = setTimeout(() => {
+      proc.kill();
+      reject(new Error("Server startup timeout"));
+    }, 60000);
+    proc.stderr!.on("data", (data: Buffer) => {
+      const match = data.toString().match(/running on http:\/\/localhost:(\d+)/);
+      if (match) {
+        clearTimeout(timeout);
+        resolve({ proc, base: `http://localhost:${match[1]}` });
+      }
+    });
+    proc.on("error", err => {
+      clearTimeout(timeout);
+      reject(err);
+    });
+    proc.on("exit", code => {
+      clearTimeout(timeout);
+      reject(new Error(`The server exited with status ${code} before reporting a port`));
+    });
+  });
+}
+
+function stripTags(html: string): string {
+  return html.replace(/<[^>]*>/g, "").replace(/\s+/g, " ").trim();
+}
+
+function jsonLdBlocks(body: string): unknown[] {
+  const out: unknown[] = [];
+  const re = /<script type="application\/ld\+json">([\s\S]*?)<\/script>/g;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(body))) {
+    try {
+      out.push(JSON.parse(m[1]!));
+    } catch {
+      out.push({ unparseable: m[1] });
+    }
+  }
+  return out;
+}
+
+function walkJsonLd(body: string, visit: (node: Record<string, unknown>) => void): void {
+  const walk = (node: unknown): void => {
+    if (Array.isArray(node)) {
+      node.forEach(walk);
+      return;
+    }
+    if (!node || typeof node !== "object") return;
+    visit(node as Record<string, unknown>);
+    for (const value of Object.values(node)) walk(value);
+  };
+  jsonLdBlocks(body).forEach(walk);
+}
+
+export function vendorsByRegion(body: string): Record<string, string[]> {
+  const regions = new Map<string, Set<string>>();
+  const headings = [...body.matchAll(/<h[1-4][^>]*>([\s\S]*?)<\/h[1-4]>/g)]
+    .map(m => ({ at: m.index!, text: stripTags(m[1]!) }));
+  const headingFor = (index: number): string => {
+    let current = "(above the first heading)";
+    for (const heading of headings) {
+      if (heading.at > index) break;
+      current = heading.text;
+    }
+    return current;
+  };
+  for (const match of body.matchAll(/href="\/vendor\/([a-z0-9-]+)"/g)) {
+    const region = headingFor(match.index!);
+    if (!regions.has(region)) regions.set(region, new Set());
+    regions.get(region)!.add(match[1]!);
+  }
+  return Object.fromEntries([...regions].map(([k, v]) => [k, [...v].sort()]));
+}
+
+function surfacesOf(body: string): Surfaces {
+  const itemListNames: string[] = [];
+  const faqAnswers: string[] = [];
+  walkJsonLd(body, node => {
+    if (node["@type"] === "ItemList" && Array.isArray(node.itemListElement)) {
+      for (const el of node.itemListElement as Array<Record<string, any>>) {
+        const name = el?.item?.name ?? el?.name;
+        if (typeof name === "string") itemListNames.push(name);
+      }
+    }
+    if (node["@type"] === "Question" && typeof (node.acceptedAnswer as any)?.text === "string") {
+      faqAnswers.push(`${node.name} :: ${(node.acceptedAnswer as any).text}`);
+    }
+  });
+  const meta = body.match(/<meta name="description" content="([^"]*)"/);
+  return {
+    regions: vendorsByRegion(body),
+    vendorSequence: [...body.matchAll(/href="\/vendor\/([a-z0-9-]+)"/g)].map(m => m[1]!),
+    metaDescription: meta ? meta[1]! : null,
+    itemListNames: itemListNames.sort(),
+    faqAnswers: faqAnswers.sort(),
+  };
+}
+
+async function readEveryPage(base: string, paths: string[]): Promise<Map<string, Surfaces>> {
+  const out = new Map<string, Surfaces>();
+  for (const pagePath of paths) {
+    const response = await fetch(base + pagePath);
+    const body = await response.text();
+    assert.equal(response.status, 200, `${pagePath} answered ${response.status}, so what it names cannot be compared`);
+    out.set(pagePath, surfacesOf(body));
+  }
+  return out;
+}
+
+describe("what a page names does not depend on the day it is served", () => {
+  let inventory: string[] = [];
+  let today: Map<string, Surfaces>;
+  let tomorrow: Map<string, Surfaces>;
+  let scratch = "";
+
+  before(async () => {
+    scratch = mkdtempSync(path.join(tmpdir(), "named-subsets-"));
+    const inventoryOut = path.join(scratch, "inventory.json");
+    const first = await startServer(inventoryOut, 0);
+    inventory = JSON.parse(readFileSync(inventoryOut, "utf-8"));
+    today = await readEveryPage(first.base, inventory);
+    first.proc.kill();
+
+    const ahead = await startServer(path.join(scratch, "inventory-ahead.json"), A_DAY_IN_MS);
+    tomorrow = await readEveryPage(ahead.base, inventory);
+    ahead.proc.kill();
+  });
+
+  after(() => {
+    if (scratch) rmSync(scratch, { recursive: true, force: true });
+  });
+
+  it("reads every page this server publishes, not a sample of them", () => {
+    const vendorPages = inventory.filter(p => p.startsWith("/vendor/"));
+    assertCoversPopulation(vendorPages.length, vendorsInTheCatalogue(), "vendor pages read against a clock a day ahead");
+  });
+
+  it("reads a server whose clock really is a day ahead", () => {
+    const inADifferentOrder = inventory.filter(pagePath => {
+      const before = today.get(pagePath)!.vendorSequence;
+      const after = tomorrow.get(pagePath)!.vendorSequence;
+      return before.length > 1 && before.join("|") !== after.join("|");
+    });
+    assert.ok(
+      inADifferentOrder.length > 0,
+      "no page lists its vendors in a different order tomorrow, so the second server is not a day ahead and every comparison here passes for the wrong reason",
+    );
+  });
+
+  it("names the same vendors under every heading it serves them under", () => {
+    const moved: string[] = [];
+    for (const pagePath of inventory) {
+      const before = today.get(pagePath)!.regions;
+      const after = tomorrow.get(pagePath)!.regions;
+      for (const region of new Set([...Object.keys(before), ...Object.keys(after)])) {
+        const named = (before[region] ?? []).join(", ");
+        const namedTomorrow = (after[region] ?? []).join(", ");
+        if (named !== namedTomorrow) moved.push(`${pagePath} under "${region}": ${named} becomes ${namedTomorrow}`);
+      }
+    }
+    assert.deepEqual(moved.slice(0, 8), [], `${moved.length} of ${inventory.length} pages name a different set of vendors tomorrow`);
+  });
+
+  it("serves the same meta description tomorrow", () => {
+    const moved = inventory.filter(p => today.get(p)!.metaDescription !== tomorrow.get(p)!.metaDescription);
+    assert.deepEqual(
+      moved.slice(0, 8).map(p => `${p}: ${today.get(p)!.metaDescription} becomes ${tomorrow.get(p)!.metaDescription}`),
+      [],
+      `${moved.length} of ${inventory.length} meta descriptions are a function of the day they are served`,
+    );
+  });
+
+  it("puts the same names in its structured data tomorrow, whatever order it lists them in", () => {
+    const moved = inventory.filter(p =>
+      today.get(p)!.itemListNames.join("|") !== tomorrow.get(p)!.itemListNames.join("|"));
+    assert.deepEqual(moved.slice(0, 8), [], `${moved.length} of ${inventory.length} pages publish an ItemList naming different members tomorrow`);
+  });
+
+  it("answers its own questions with the same words tomorrow", () => {
+    const moved: string[] = [];
+    for (const pagePath of inventory) {
+      const before = today.get(pagePath)!.faqAnswers;
+      const after = tomorrow.get(pagePath)!.faqAnswers;
+      if (before.join("\n") === after.join("\n")) continue;
+      const first = before.find((answer, i) => answer !== after[i]) ?? before[0];
+      moved.push(`${pagePath}: ${first}`);
+    }
+    assert.deepEqual(moved.slice(0, 8), [], `${moved.length} of ${inventory.length} pages answer a question differently tomorrow`);
+  });
+
+});
+
+describe("the rule that decides it is published where a reader can find it", () => {
+  it("states the rule and the reason no field replaces it on /criteria", async () => {
+    const scratch = mkdtempSync(path.join(tmpdir(), "named-subsets-criteria-"));
+    const { proc, base } = await startServer(path.join(scratch, "inventory.json"), 0);
+    try {
+      const body = await (await fetch(`${base}/criteria`)).text();
+      const text = stripTags(body).replace(/&mdash;/g, "—").replace(/&lt;/g, "<").replace(/&gt;/g, ">");
+      assert.ok(text.includes(NAMED_SUBSET_RULE), "/criteria does not state the rule the pages follow");
+      assert.ok(text.includes(NAMED_SUBSET_FIELD_RULE), "/criteria does not say why no field picks the members instead");
+      assert.ok(body.includes('id="subsets"'), "nothing on a page can link to the rule it says it follows");
+    } finally {
+      proc.kill();
+      rmSync(scratch, { recursive: true, force: true });
+    }
+  });
+});

--- a/test/ranked-surfaces.test.ts
+++ b/test/ranked-surfaces.test.ts
@@ -349,10 +349,23 @@ describe("every ranked surface publishes the seed that ordered it", () => {
     assert.match(llms, new RegExp(`${uniqueTop} of the ${slugs.length} product functions with a best-of page`), "llms.txt must carry the same figure and the same scope");
   });
 
-  it("the vendor page says how much of the ranked order it is showing", async () => {
-    const { text: truncated } = await get("/vendor/supabase");
-    assert.match(truncated, /The list above is the first \d+ of \d+ entries in that order\./);
-    const { text: whole } = await get("/vendor/doppler");
-    assert.ok(!/The list above is the first/.test(whole), "a list that shows every entry must not claim to be a prefix");
+  it("the vendor page says the ranked order it shows is the whole of it", async () => {
+    for (const slug of ["supabase", "vercel"]) {
+      const { text } = await get(`/vendor/${slug}`);
+      const at = text.indexOf('<h2 id="alternatives">');
+      assert.notEqual(at, -1, `/vendor/${slug} publishes no alternatives, so it cannot say how many it shows`);
+      const section = text.slice(at);
+      const claim = section.match(/The list above is every one of the (\d+) entries in that order, not a prefix of it\./);
+      assert.ok(claim, `/vendor/${slug} does not say how much of the ranked order it is showing`);
+      const listed = [...section.matchAll(/<td><a href="\/vendor\/[a-z0-9-]+">/g)].length;
+      assert.equal(listed, Number(claim[1]), `/vendor/${slug} lists ${listed} alternatives under a claim of ${claim[1]}`);
+      assert.ok(!/The list above is the first/.test(text), "a list that shows every entry must not claim to be a prefix");
+    }
+  });
+
+  it("a vendor page with no alternatives claims nothing about a list it does not publish", async () => {
+    const { text } = await get("/vendor/doppler");
+    assert.equal(text.indexOf('<h2 id="alternatives">'), -1, "this test needs a page that publishes no alternatives");
+    assert.ok(!/The list above is/.test(text), "a page with no ranked list published a claim about one");
   });
 });


### PR DESCRIPTION
Refs #1541.

`/criteria` has said for months that "the order rotates daily; the membership of the list does not". Five surfaces did not do that: they took a slice of a list whose order is seeded on the UTC date, so what rotated was which vendors they named.

## What was rotating

Measured by rendering all 2,519 published URLs against two servers whose clocks are a day apart, and comparing the set of names each surface publishes. `scripts/subset-churn-census.mjs` reproduces it.

| surface | pages | named |
|---|---:|---|
| `/alternative-to/*` `<meta name="description">` | 187 | 3 of N |
| `/vendor/*` FAQ "Other vendors in C include …" | 159 | 5 of N |
| `/vendor/*` "How X Compares" table | 140 | 3 of N |
| `/vendor/*` "When You'll Outgrow …" bullet | 124 | 1 of N |
| `/vendor/*` "Alternatives in C" grid | 112 | 12 of N |

722 surface instances across 327 pages. `/vendor/vercel` said "consider Deno Deploy" today and "consider Cloudflare Pages" tomorrow.

The JSON-LD `ItemList` is not among them. 264 pages list their `ItemList` names in a different order tomorrow and **0 of them list different names** — it is a complete list being rotated, which is the case the tie-break is for.

Three of the five are not in the issue. The grid is the one worth naming: the twelve it showed rotate inside a set the same page names in full lower down, so the page-wide set of vendors is unchanged and only a per-region comparison sees it.

## The rule

> A surface with room for every member of a tied set may rotate their order. A surface with room for only some of them names none of them.

Published at `/criteria#subsets` with the reason no field replaces it: being tied is the absence of one. Every date we hold records when *we* last looked at a record rather than anything about the vendor, so ordering by one publishes our own re-read queue as though it were a recommendation — and that queue confirms about a hundred records a day, so the three names would be different ones next week for a reason no reader of the claim can see. A record's name, slug, id and position in the file are inputs the tie-break promises never to use.

## What changed

**Room for all → carry all.** The vendor page had the same set twice, truncated both times: a three-row "How X Compares" table near the top and a twelve-card grid near the bottom. They are now one table of every alternative with its free tier and the stability we publish for it — the grid's columns were a subset of the table's, so nothing is lost. Largest is 44 rows, median 25.

**No room → name none.** The `/alternative-to/*` meta description and the two `/vendor/*` sentences describe the set instead:

- was: `Compare 41 free alternatives to 360 Monitoring for Monitoring. Side-by-side free tier limits for pingbreak.com, syagent.com, Jaeger.`
- now: `Compare 41 free alternatives to 360 Monitoring for Monitoring. Every one of their free tier limits side by side, each with the date we last verified it.`

Three things fell out of removing the cap:

- `alternatives` was capped at 12 and six count claims read off it, so 113 vendor pages advertised "Compare with 12 alternatives in Databases" while the same page's FAQ sized the same set at 25. All six are the true count now.
- `renderAuditBlock`'s "the first N of M entries" branch is unreachable once nothing truncates. It states the list is complete instead, and `test/ranked-surfaces.test.ts` checks that claim against the row count rather than trusting it.
- `/alternative-to/aws` listed its categories in whatever order the rotated alternatives put them in — "Cloud IaaS, Infrastructure, Cloud Hosting" today, the same three reordered tomorrow. Same members, so not what this issue is about, but the same accident.

## The test

`test/named-subsets.test.ts` renders every page the server publishes against a clock a day ahead and asserts the same names come back: under every heading the page serves vendors under, in the meta description, in the `ItemList`, and in the answers to its own questions. The regions are read from the page's own headings rather than from a list of surfaces someone has to keep, so a surface added later is covered without being registered.

Two controls: the sweep must cover every vendor in the catalogue, and at least one page must list its vendors in a *different* order tomorrow — otherwise the second server is not a day ahead and every comparison passes for the wrong reason. 448 pages do.

Both guards were checked against the defect they exist for: putting the meta description back fails at 187 of 2,519, putting the growth bullet back fails at 124.

## What it costs

The whole crawl space grows 645,212 bytes, from 98,277,776 to 98,922,988 — 0.7%. Vendor pages carry all of it, about 405 bytes each, because the complete table replaces a twelve-card grid and a three-row table rather than being added to them.

## What this does not change

`data/page-lastmod.json` still records the same 535 pages as daily — not one stops. The flag is set by the body differing between two clocks, and the order of a complete list still rotates, which is deliberate. So none of the 535 becomes able to answer a conditional request, and the crawl-footprint half of the issue's priority argument is unaffected by this change.
