### PR TITLE
Cite the whole catalogue on every answer drawn from it

### DIFF
--- a/scripts/mutate-1546.mjs
+++ b/scripts/mutate-1546.mjs
@@ -1,0 +1,117 @@
+import { readFileSync, writeFileSync } from "node:fs";
+import { execFileSync } from "node:child_process";
+
+const SUITE = [
+  "test/catalogue-wide-route-citation.test.ts",
+  "test/response-provenance.test.ts",
+  "test/documented-route-citation.test.ts",
+];
+const PROVENANCE = "src/provenance.ts";
+const SERVER = "src/serve.ts";
+const MCP = "src/server.ts";
+
+const STATED = '  const path = options.path ?? (derived === "/" ? options.listingPath ?? "/" : derived);';
+
+const MUTANTS = [
+  ["the-records-outrank-the-stated-page", PROVENANCE,
+    STATED,
+    '  const path = derived === "/" ? options.listingPath ?? "/" : derived;'],
+
+  ["a-listing-page-outranks-the-stated-page", PROVENANCE,
+    STATED,
+    '  const path = derived === "/" ? options.listingPath ?? options.path ?? "/" : options.path ?? derived;'],
+
+  ["the-stated-page-is-taken-only-where-the-records-agree", PROVENANCE,
+    STATED,
+    '  const path = derived === "/" ? options.path ?? options.listingPath ?? "/" : derived;'],
+
+  ["the-whole-index-is-one-category", SERVER,
+    'const THE_WHOLE_INDEX = "/";',
+    'const THE_WHOLE_INDEX = "/changes";'],
+
+  ["a-catalogue-wide-answer-is-dated-from-its-records-again", SERVER,
+    "function citedAcrossTheWholeIndex<T extends object>(payload: T): T & { _provenance: Record<string, unknown> } {\n  return citedAt(payload, THE_WHOLE_INDEX);\n}",
+    "function citedAcrossTheWholeIndex<T extends object>(payload: T): T & { _provenance: Record<string, unknown> } {\n  return cited(payload);\n}"],
+
+  ["the-agent-block-drops-the-page-it-was-given", SERVER,
+    "      ...(citePath ? { path: citePath } : {}),",
+    "      ...(citePath ? {} : {}),"],
+
+  ["the-new-offers-cite-their-records", SERVER,
+    'endpoint: "/api/new", params: { days }, user_agent: req.headers["user-agent"] ?? "unknown", result_count: result.offers.length });\n    res.writeHead(200, { "Content-Type": "application/json", "Access-Control-Allow-Origin": "*" });\n    res.end(JSON.stringify(citedAcrossTheWholeIndex(result)));',
+    'endpoint: "/api/new", params: { days }, user_agent: req.headers["user-agent"] ?? "unknown", result_count: result.offers.length });\n    res.writeHead(200, { "Content-Type": "application/json", "Access-Control-Allow-Origin": "*" });\n    res.end(JSON.stringify(cited(result)));'],
+
+  ["the-newest-offers-cite-their-records", SERVER,
+    "    res.end(JSON.stringify(citedAcrossTheWholeIndex(dealsWithCodes)));",
+    "    res.end(JSON.stringify(cited(dealsWithCodes)));"],
+
+  ["the-stack-audit-cites-its-records", SERVER,
+    "    res.end(JSON.stringify(citedAcrossTheWholeIndex(auditResult)));",
+    "    res.end(JSON.stringify(cited(auditResult)));"],
+
+  ["the-stack-recommendation-cites-its-records", SERVER,
+    "    res.end(JSON.stringify(withAgentBlock(result, null, THE_WHOLE_INDEX)));",
+    "    res.end(JSON.stringify(withAgentBlock(result)));"],
+
+  ["the-cost-estimate-cites-its-records", SERVER,
+    'endpoint: "/api/costs", params: { services, scale }, user_agent: req.headers["user-agent"] ?? "unknown", result_count: result.services.length });\n    res.writeHead(200, { "Content-Type": "application/json", "Access-Control-Allow-Origin": "*" });\n    res.end(JSON.stringify(citedAcrossTheWholeIndex(result)));',
+    'endpoint: "/api/costs", params: { services, scale }, user_agent: req.headers["user-agent"] ?? "unknown", result_count: result.services.length });\n    res.writeHead(200, { "Content-Type": "application/json", "Access-Control-Allow-Origin": "*" });\n    res.end(JSON.stringify(cited(result)));'],
+
+  ["the-tool-answers-are-dated-from-their-records-again", MCP,
+    "  return JSON.stringify(\n    withProvenance(BASE_URL, payload, { dateForSlug: oldestVerifiedDateForSlug, path: THE_WHOLE_INDEX }),",
+    "  return JSON.stringify(\n    withProvenance(BASE_URL, payload, { dateForSlug: oldestVerifiedDateForSlug }),"],
+
+  ["the-tool-search-since-a-date-cites-its-records", MCP,
+    "text: citedJsonAcrossTheWholeIndex(enrichedResult) }",
+    "text: citedJson(enrichedResult) }"],
+
+  ["the-tool-stack-recommendation-cites-its-records", MCP,
+    'params: { mode, use_case, requirements }, result_count: result.stack.length, session_id: getSessionId?.() });\n          return {\n            content: [{ type: "text" as const, text: citedJsonAcrossTheWholeIndex(result) }',
+    'params: { mode, use_case, requirements }, result_count: result.stack.length, session_id: getSessionId?.() });\n          return {\n            content: [{ type: "text" as const, text: citedJson(result) }'],
+
+  ["the-tool-cost-estimate-cites-its-records", MCP,
+    'params: { mode, services, scale: scale ?? "hobby" }, result_count: result.services.length, session_id: getSessionId?.() });\n          return {\n            content: [{ type: "text" as const, text: citedJsonAcrossTheWholeIndex(result) }',
+    'params: { mode, services, scale: scale ?? "hobby" }, result_count: result.services.length, session_id: getSessionId?.() });\n          return {\n            content: [{ type: "text" as const, text: citedJson(result) }'],
+
+  ["the-tool-stack-audit-cites-its-records", MCP,
+    'params: { mode, services }, result_count: result.services_analyzed, session_id: getSessionId?.() });\n          return {\n            content: [{ type: "text" as const, text: citedJsonAcrossTheWholeIndex(result) }',
+    'params: { mode, services }, result_count: result.services_analyzed, session_id: getSessionId?.() });\n          return {\n            content: [{ type: "text" as const, text: citedJson(result) }'],
+
+  ["the-fixture-catalogue-is-the-published-one", "test/catalogue-wide-route-citation.test.ts",
+    "    writeFileSync(fixture, JSON.stringify({ ...index, offers: [only] }));",
+    "    writeFileSync(fixture, JSON.stringify(index));"],
+];
+
+function run(cmd, args) {
+  try {
+    execFileSync(cmd, args, { stdio: "pipe", encoding: "utf-8" });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+const survivors = [];
+const uncompiled = [];
+const skipped = [];
+for (const [name, file, from, to] of MUTANTS) {
+  const original = readFileSync(file, "utf-8");
+  if (!original.includes(from)) {
+    console.log(`SKIP  ${name} — the line it mutates is not in ${file}`);
+    skipped.push(name);
+    continue;
+  }
+  writeFileSync(file, original.replace(from, to));
+  const built = run("npm", ["run", "build"]);
+  const green = built && run("node", ["--test", "--test-concurrency", "1", ...SUITE]);
+  writeFileSync(file, original);
+  if (!built) uncompiled.push(name);
+  console.log(`${green ? "SURVIVED" : built ? "killed  " : "DID NOT COMPILE"}  ${name}`);
+  if (green) survivors.push(name);
+}
+run("npm", ["run", "build"]);
+const killed = MUTANTS.length - survivors.length - uncompiled.length - skipped.length;
+console.log(`\n${killed}/${MUTANTS.length} killed`);
+if (survivors.length > 0) console.log("survivors:", survivors.join(", "));
+if (uncompiled.length > 0) console.log("did not compile:", uncompiled.join(", "));
+if (skipped.length > 0) console.log("skipped — target string moved, so these scored nothing:", skipped.join(", "));

--- a/src/provenance.ts
+++ b/src/provenance.ts
@@ -153,8 +153,8 @@ export function provenanceBlock(
   const withheld = records.length - ranked.length;
   const dated = ranked.length > 0 ? ranked : records;
   const date = oldestDate(dated) ?? options.dateOfTheLogConsulted ?? null;
-  const derived = options.path ?? narrowestPath(records);
-  const path = derived === "/" ? options.listingPath ?? "/" : derived;
+  const derived = narrowestPath(records);
+  const path = options.path ?? (derived === "/" ? options.listingPath ?? "/" : derived);
 
   const block: Record<string, unknown> = {
     ...citation(baseUrl, path, date, dated.length <= 1),

--- a/src/serve.ts
+++ b/src/serve.ts
@@ -53491,6 +53491,7 @@ const HOSTING_PRICING_CATEGORY = "Cloud Hosting";
 const LLM_PRICING_PAGE = `/category/${toSlug(LLM_PRICING_CATEGORY)}`;
 const HOSTING_PRICING_PAGE = `/category/${toSlug(HOSTING_PRICING_CATEGORY)}`;
 const REFERRAL_CODE_LISTING_PAGE = "/disclosure";
+const THE_WHOLE_INDEX = "/";
 
 function digestWeekPath(weekOf: string): string {
   const { year, week } = isoWeekOf(new Date(weekOf + "T00:00:00Z"));
@@ -53513,6 +53514,10 @@ function citedAt<T extends object>(payload: T, path: string): T & { _provenance:
   };
 }
 
+function citedAcrossTheWholeIndex<T extends object>(payload: T): T & { _provenance: Record<string, unknown> } {
+  return citedAt(payload, THE_WHOLE_INDEX);
+}
+
 function citedAgainstTheChangeLog<T extends object>(payload: T, path: string): T & { _provenance: Record<string, unknown> } {
   return {
     ...payload,
@@ -53524,10 +53529,14 @@ function citedAgainstTheChangeLog<T extends object>(payload: T, path: string): T
   };
 }
 
-function withAgentBlock<T extends object>(payload: T, slug?: string | null): T & { _agent: Record<string, unknown>; _provenance: Record<string, unknown> } {
+function withAgentBlock<T extends object>(payload: T, slug?: string | null, citePath?: string): T & { _agent: Record<string, unknown>; _provenance: Record<string, unknown> } {
   return {
     ...payload,
-    _provenance: provenanceBlock(BASE_URL, payload, { deference: false, dateForSlug: oldestVerifiedDateForSlug }),
+    _provenance: provenanceBlock(BASE_URL, payload, {
+      deference: false,
+      dateForSlug: oldestVerifiedDateForSlug,
+      ...(citePath ? { path: citePath } : {}),
+    }),
     _agent: agentBlock(BASE_URL, slug ?? null),
   };
 }
@@ -54185,7 +54194,7 @@ const httpServer = createHttpServer(async (req, res) => {
     const result = getStackRecommendation(useCase, requirements);
     logRequest({ ts: new Date().toISOString(), type: "api", endpoint: "/api/stack", params: { use_case: useCase, requirements }, user_agent: req.headers["user-agent"] ?? "unknown", result_count: result.stack.length });
     res.writeHead(200, { "Content-Type": "application/json", "Access-Control-Allow-Origin": "*" });
-    res.end(JSON.stringify(withAgentBlock(result)));
+    res.end(JSON.stringify(withAgentBlock(result, null, THE_WHOLE_INDEX)));
   } else if (url.pathname === "/api/costs" && isGetOrHead) {
     recordApiHit("/api/costs");
     const servicesParam = url.searchParams.get("services");
@@ -54204,7 +54213,7 @@ const httpServer = createHttpServer(async (req, res) => {
     const result = estimateCosts(services, scale);
     logRequest({ ts: new Date().toISOString(), type: "api", endpoint: "/api/costs", params: { services, scale }, user_agent: req.headers["user-agent"] ?? "unknown", result_count: result.services.length });
     res.writeHead(200, { "Content-Type": "application/json", "Access-Control-Allow-Origin": "*" });
-    res.end(JSON.stringify(cited(result)));
+    res.end(JSON.stringify(citedAcrossTheWholeIndex(result)));
   } else if (url.pathname === "/api/query-log" && isGetOrHead) {
     const limit = Math.min(Math.max(parseInt(url.searchParams.get("limit") ?? "50", 10) || 50, 1), 200);
     const log = await getPublicRequestLogResult(limit);
@@ -54299,7 +54308,7 @@ const httpServer = createHttpServer(async (req, res) => {
     const result = getNewOffers(days);
     logRequest({ ts: new Date().toISOString(), type: "api", endpoint: "/api/new", params: { days }, user_agent: req.headers["user-agent"] ?? "unknown", result_count: result.offers.length });
     res.writeHead(200, { "Content-Type": "application/json", "Access-Control-Allow-Origin": "*" });
-    res.end(JSON.stringify(cited(result)));
+    res.end(JSON.stringify(citedAcrossTheWholeIndex(result)));
   } else if (url.pathname === "/api/newest" && isGetOrHead) {
     recordApiHit("/api/newest");
     const since = url.searchParams.get("since") || undefined;
@@ -54317,7 +54326,7 @@ const httpServer = createHttpServer(async (req, res) => {
       deals: result.deals.map(o => ({ ...o, referral_code: getBestReferralCode(o.vendor) })),
     };
     res.writeHead(200, { "Content-Type": "application/json", "Access-Control-Allow-Origin": "*" });
-    res.end(JSON.stringify(cited(dealsWithCodes)));
+    res.end(JSON.stringify(citedAcrossTheWholeIndex(dealsWithCodes)));
   } else if (url.pathname === "/api/categories" && isGetOrHead) {
     recordApiHit("/api/categories");
     const cats = buildCategoryDirectory(getCategories(), loadOffers(), toSlug);
@@ -54653,7 +54662,7 @@ const httpServer = createHttpServer(async (req, res) => {
     const auditResult = auditStack(servicesList);
     logRequest({ ts: new Date().toISOString(), type: "api", endpoint: "/api/audit-stack", params: { services: servicesList }, user_agent: req.headers["user-agent"] ?? "unknown", result_count: auditResult.services_analyzed });
     res.writeHead(200, { "Content-Type": "application/json", "Access-Control-Allow-Origin": "*" });
-    res.end(JSON.stringify(cited(auditResult)));
+    res.end(JSON.stringify(citedAcrossTheWholeIndex(auditResult)));
   } else if (url.pathname.startsWith("/api/vendor-risk/") && isGetOrHead) {
     recordApiHit("/api/vendor-risk");
     const vendorParam = decodeURIComponent(url.pathname.slice("/api/vendor-risk/".length));

--- a/src/server.ts
+++ b/src/server.ts
@@ -23,9 +23,19 @@ import { withProvenance } from "./provenance.js";
 
 const SIGNAL_FOOTER_CONTENT = { type: "text" as const, text: MCP_SIGNAL_FOOTER };
 
+const THE_WHOLE_INDEX = "/";
+
 function citedJson<T extends object>(payload: T, listingPath?: string): string {
   return JSON.stringify(
     withProvenance(BASE_URL, payload, { dateForSlug: oldestVerifiedDateForSlug, ...(listingPath ? { listingPath } : {}) }),
+    null,
+    2,
+  );
+}
+
+function citedJsonAcrossTheWholeIndex<T extends object>(payload: T): string {
+  return JSON.stringify(
+    withProvenance(BASE_URL, payload, { dateForSlug: oldestVerifiedDateForSlug, path: THE_WHOLE_INDEX }),
     null,
     2,
   );
@@ -145,7 +155,7 @@ export function createServer(getSessionId?: () => string | undefined, getClientN
             ...gateDisclosureFor("deal", result.deals.map(o => o.gate)),
           };
           return {
-            content: [{ type: "text" as const, text: citedJson(enrichedResult) }, SIGNAL_FOOTER_CONTENT],
+            content: [{ type: "text" as const, text: citedJsonAcrossTheWholeIndex(enrichedResult) }, SIGNAL_FOOTER_CONTENT],
           };
         }
 
@@ -233,7 +243,7 @@ export function createServer(getSessionId?: () => string | undefined, getClientN
           const result = getStackRecommendation(use_case, requirements);
           logRequest({ ts: new Date().toISOString(), type: "mcp", endpoint: "plan_stack", params: { mode, use_case, requirements }, result_count: result.stack.length, session_id: getSessionId?.() });
           return {
-            content: [{ type: "text" as const, text: citedJson(result) }, SIGNAL_FOOTER_CONTENT],
+            content: [{ type: "text" as const, text: citedJsonAcrossTheWholeIndex(result) }, SIGNAL_FOOTER_CONTENT],
           };
         }
 
@@ -247,7 +257,7 @@ export function createServer(getSessionId?: () => string | undefined, getClientN
           const result = estimateCosts(services, scale ?? "hobby");
           logRequest({ ts: new Date().toISOString(), type: "mcp", endpoint: "plan_stack", params: { mode, services, scale: scale ?? "hobby" }, result_count: result.services.length, session_id: getSessionId?.() });
           return {
-            content: [{ type: "text" as const, text: citedJson(result) }, SIGNAL_FOOTER_CONTENT],
+            content: [{ type: "text" as const, text: citedJsonAcrossTheWholeIndex(result) }, SIGNAL_FOOTER_CONTENT],
           };
         }
 
@@ -261,7 +271,7 @@ export function createServer(getSessionId?: () => string | undefined, getClientN
           const result = auditStack(services);
           logRequest({ ts: new Date().toISOString(), type: "mcp", endpoint: "plan_stack", params: { mode, services }, result_count: result.services_analyzed, session_id: getSessionId?.() });
           return {
-            content: [{ type: "text" as const, text: citedJson(result) }, SIGNAL_FOOTER_CONTENT],
+            content: [{ type: "text" as const, text: citedJsonAcrossTheWholeIndex(result) }, SIGNAL_FOOTER_CONTENT],
           };
         }
 

--- a/test/catalogue-wide-route-citation.test.ts
+++ b/test/catalogue-wide-route-citation.test.ts
@@ -1,0 +1,167 @@
+import { describe, it, before, after } from "node:test";
+import assert from "node:assert";
+import { spawn, type ChildProcess } from "node:child_process";
+import { mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { citedRecords, narrowestPath } from "../dist/provenance.js";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const INDEX_PATH = path.join(__dirname, "..", "data", "index.json");
+
+interface IndexedOffer {
+  vendor: string;
+  category?: string;
+  verifiedDate?: string;
+  gate?: unknown;
+  terms_superseded?: unknown;
+  risk_level?: unknown;
+}
+
+function aVendorWhoseWholeCatalogueIsOneOffer(offers: IndexedOffer[]): IndexedOffer {
+  const offersPerVendor = new Map<string, number>();
+  for (const offer of offers) offersPerVendor.set(offer.vendor, (offersPerVendor.get(offer.vendor) ?? 0) + 1);
+  const found = offers.find((offer) =>
+    offersPerVendor.get(offer.vendor) === 1 &&
+    typeof offer.category === "string" && offer.category.length > 0 &&
+    typeof offer.verifiedDate === "string" &&
+    offer.gate === undefined &&
+    offer.terms_superseded === undefined &&
+    offer.risk_level !== null);
+  assert.ok(found, "no vendor in the index holds a single dated offer we publish in full");
+  return found;
+}
+
+const CATALOGUE_WIDE_ROUTES: [string, (vendor: string, category: string) => string][] = [
+  ["/api/new", () => "/api/new?days=3650"],
+  ["/api/newest", () => "/api/newest?limit=3"],
+  ["/api/audit-stack", (vendor) => `/api/audit-stack?services=${encodeURIComponent(vendor)}`],
+  ["/api/stack", (vendor, category) => `/api/stack?use_case=a+small+web+app&requirements=${encodeURIComponent(category)}`],
+  ["/api/costs", (vendor) => `/api/costs?services=${encodeURIComponent(vendor)}&scale=hobby`],
+];
+
+const CATALOGUE_WIDE_TOOLS: [string, string, (vendor: string, category: string) => unknown][] = [
+  ["search_deals since a date", "search_deals", () => ({ since: "2000-01-01" })],
+  ["plan_stack in recommend mode", "plan_stack", (vendor, category) => ({ mode: "recommend", use_case: "a small web app", requirements: [category] })],
+  ["plan_stack in estimate mode", "plan_stack", (vendor) => ({ mode: "estimate", services: [vendor], scale: "hobby" })],
+  ["plan_stack in audit mode", "plan_stack", (vendor) => ({ mode: "audit", services: [vendor] })],
+];
+
+const ANSWERED_FROM_THE_WHOLE_CATALOGUE = [
+  ...CATALOGUE_WIDE_ROUTES.map(([route]) => route),
+  ...CATALOGUE_WIDE_TOOLS.map(([label]) => label),
+];
+
+describe("a route answering from the whole catalogue cites the whole catalogue", () => {
+  let proc: ChildProcess;
+  let base: string;
+  let vendor: string;
+  let category: string;
+  let sessionId: string;
+  const bodies = new Map<string, string>();
+
+  const callTool = async (name: string, args: unknown, id: number): Promise<string> => {
+    const res = await fetch(`${base}/mcp`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Accept: "application/json, text/event-stream",
+        "Mcp-Session-Id": sessionId,
+      },
+      body: JSON.stringify({ jsonrpc: "2.0", id, method: "tools/call", params: { name, arguments: args } }),
+    });
+    const text = await res.text();
+    const line = text.split("\n").find((l) => l.startsWith("data: ")) ?? text;
+    const payload = JSON.parse(line.replace(/^data: /, ""));
+    const first = payload?.result?.content?.[0]?.text;
+    assert.ok(typeof first === "string", `${name} answered ${text.slice(0, 200)}`);
+    return first;
+  };
+
+  before(async () => {
+    const index = JSON.parse(readFileSync(INDEX_PATH, "utf-8")) as { offers: IndexedOffer[] };
+    const only = aVendorWhoseWholeCatalogueIsOneOffer(index.offers);
+    vendor = only.vendor;
+    category = only.category!;
+    const fixture = path.join(mkdtempSync(path.join(tmpdir(), "one-vendor-index-")), "index.json");
+    writeFileSync(fixture, JSON.stringify({ ...index, offers: [only] }));
+
+    const serverPath = path.join(__dirname, "..", "dist", "serve.js");
+    const started = await new Promise<{ proc: ChildProcess; port: number }>((resolve, reject) => {
+      const child = spawn("node", [serverPath], {
+        stdio: ["pipe", "pipe", "pipe"],
+        env: { ...process.env, PORT: "0", BASE_URL: "http://127.0.0.1", AGENTDEALS_INDEX_PATH: fixture },
+      });
+      const timer = setTimeout(() => { child.kill("SIGKILL"); reject(new Error("startup timeout")); }, 60000);
+      child.stderr?.on("data", (b: Buffer) => {
+        const m = b.toString().match(/running on http:\/\/localhost:(\d+)/);
+        if (m) { clearTimeout(timer); resolve({ proc: child, port: parseInt(m[1], 10) }); }
+      });
+      child.on("error", (e) => { clearTimeout(timer); reject(e); });
+    });
+    proc = started.proc;
+    base = `http://127.0.0.1:${started.port}`;
+    for (const [route, probe] of CATALOGUE_WIDE_ROUTES) {
+      bodies.set(route, await (await fetch(`${base}${probe(vendor, category)}`)).text());
+    }
+
+    const init = await fetch(`${base}/mcp`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", Accept: "application/json, text/event-stream" },
+      body: JSON.stringify({
+        jsonrpc: "2.0", id: 1, method: "initialize",
+        params: { protocolVersion: "2025-06-18", capabilities: {}, clientInfo: { name: "test", version: "1.0.0" } },
+      }),
+    });
+    sessionId = init.headers.get("mcp-session-id") ?? "";
+    await fetch(`${base}/mcp`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", Accept: "application/json, text/event-stream", "Mcp-Session-Id": sessionId },
+      body: JSON.stringify({ jsonrpc: "2.0", method: "notifications/initialized" }),
+    });
+    for (const [index, [label, tool, args]] of CATALOGUE_WIDE_TOOLS.entries()) {
+      bodies.set(label, await callTool(tool, args(vendor, category), 100 + index));
+    }
+  });
+
+  after(() => { proc?.kill("SIGKILL"); });
+
+  it("serves a catalogue of exactly one vendor", async () => {
+    const offers = JSON.parse(await (await fetch(`${base}/api/offers?limit=100`)).text()) as { offers: { vendor: string }[] };
+    assert.deepStrictEqual([...new Set(offers.offers.map((o) => o.vendor))], [vendor]);
+  });
+
+  it("checks every surface that answers from the whole catalogue", () => {
+    assert.deepStrictEqual([...bodies.keys()].sort(), [...ANSWERED_FROM_THE_WHOLE_CATALOGUE].sort());
+  });
+
+  for (const route of ANSWERED_FROM_THE_WHOLE_CATALOGUE) {
+    it(`${route} draws on records a derived citation would narrow to`, () => {
+      const records = citedRecords(JSON.parse(bodies.get(route)!));
+      assert.notStrictEqual(records.length, 0, `${route} answers with no record, so this probe proves nothing`);
+      assert.notStrictEqual(
+        narrowestPath(records),
+        "/",
+        `${route} answers with records spread wider than one page, so this probe proves nothing`,
+      );
+    });
+
+    it(`${route} cites the site root over a catalogue holding one vendor`, () => {
+      const block = (JSON.parse(bodies.get(route)!) as Record<string, unknown>)._provenance as Record<string, unknown>;
+      assert.strictEqual(new URL(String(block.url)).pathname, "/", `${route} cites ${block.url}`);
+    });
+
+    it(`${route} counts the records it answered with`, () => {
+      const block = (JSON.parse(bodies.get(route)!) as Record<string, unknown>)._provenance as Record<string, unknown>;
+      const published = citedRecords(JSON.parse(bodies.get(route)!)).filter((r) => !r.withheld).length;
+      assert.strictEqual(block.verified_records, published, `${route} counts records it did not answer with`);
+    });
+
+    it(`${route} cites a page that answers`, async () => {
+      const block = (JSON.parse(bodies.get(route)!) as Record<string, unknown>)._provenance as Record<string, unknown>;
+      const res = await fetch(`${base}${new URL(String(block.url)).pathname}`, { redirect: "manual" });
+      assert.strictEqual(res.status, 200, `${route} cites a page answering ${res.status}`);
+    });
+  }
+});

--- a/test/response-provenance.test.ts
+++ b/test/response-provenance.test.ts
@@ -112,6 +112,53 @@ describe("the cited page is the narrowest one holding the whole response", () =>
   });
 });
 
+describe("a response whose population is stated does not take a page from its records", () => {
+  const oneVendor = { results: [{ vendor: "Neon", category: "Databases", verifiedDate: "2026-08-17" }] };
+  const oneCategory = {
+    results: [
+      { vendor: "Neon", category: "Databases", verifiedDate: "2026-08-17" },
+      { vendor: "Supabase", category: "Databases", verifiedDate: "2026-08-17" },
+    ],
+  };
+  const spanningCategories = {
+    results: [
+      { vendor: "Neon", category: "Databases", verifiedDate: "2026-08-17" },
+      { vendor: "Vercel", category: "Cloud Hosting", verifiedDate: "2026-08-17" },
+    ],
+  };
+
+  it("derives the narrowest page when no page is stated", () => {
+    assert.strictEqual(provenanceBlock(BASE, oneVendor).url, "https://agentdeals.dev/vendor/neon");
+    assert.strictEqual(provenanceBlock(BASE, oneCategory).url, "https://agentdeals.dev/category/databases");
+  });
+
+  it("keeps the stated page over the vendor page its records would have derived", () => {
+    assert.strictEqual(provenanceBlock(BASE, oneVendor, { path: "/" }).url, "https://agentdeals.dev");
+  });
+
+  it("keeps the stated page over the category page its records would have derived", () => {
+    assert.strictEqual(provenanceBlock(BASE, oneCategory, { path: "/" }).url, "https://agentdeals.dev");
+  });
+
+  it("keeps the stated page over the listing page an empty derivation falls back to", () => {
+    assert.strictEqual(
+      provenanceBlock(BASE, spanningCategories, { listingPath: "/changes" }).url,
+      "https://agentdeals.dev/changes",
+    );
+    assert.strictEqual(
+      provenanceBlock(BASE, spanningCategories, { path: "/", listingPath: "/changes" }).url,
+      "https://agentdeals.dev",
+    );
+  });
+
+  it("counts and dates the records it answered with whatever page it states", () => {
+    const block = provenanceBlock(BASE, oneCategory, { path: "/" });
+    assert.strictEqual(block.verified_records, 2);
+    assert.strictEqual(block.verified, "2026-08-17");
+    assert.strictEqual(citedUrl(block.cite_as), block.url);
+  });
+});
+
 describe("the citation names us, a page and a date", () => {
   it("composes the check date for a single record", () => {
     assert.strictEqual(


### PR DESCRIPTION
Refs #1546.

`/api/newest` built its citation from the records it happened to return. `narrowestPath` gives the narrowest page covering every record, so whenever the newest 20 clustered in one category the citation narrowed to that category page — and `test/documented-route-citation.test.ts` refuses that, because the route is one of five it pins to the site root. Five consecutive scheduled runs were refused on it and nothing scheduled has pushed since 09-09. The assertion names no vendor, so the holdback from #1530 cannot subtract it.

**The route was wrong, not the test.** These five answer a question whose population is the whole catalogue; which categories land in any one response is an accident of which records the re-read queue reached. They now state their page instead of deriving one.

## What changed

- `provenanceBlock` treats a stated `path` as final. It was being fed into the derivation, so a stated `/` fell through to `listingPath`. Nothing passed both, so no behaviour moved — but a stated page now means what it says.
- `/api/new`, `/api/newest`, `/api/audit-stack`, `/api/stack` and `/api/costs` state the whole index. Every other documented route keeps `narrowestPath` (AC-4), verified below.

## Beyond the criteria, and reversible in one line

The same four answers are served over MCP — `search_deals({since})`, and `plan_stack` in recommend, estimate and audit mode — through `citedJson` in `src/server.ts`, which derived the same way. Fixing only HTTP would have left the same answer citing two different pages by transport: `/api/costs?services=UptimeRobot` cites the root while `plan_stack({mode:"estimate",services:["UptimeRobot"]})` cited `/vendor/uptimerobot`. I measured that against this branch before deciding. Reverting is `citedJsonAcrossTheWholeIndex` → `citedJson` at four call sites.

## The test that was missing

The refusals were data-dependent, so a probe against the published index proves nothing on a day the data happens to span categories. `test/catalogue-wide-route-citation.test.ts` starts a second server on a fixture index holding **one vendor** — picked from `data/index.json` at run time, not named — where every one of the nine surfaces would derive `/vendor/<slug>`. Each is asserted to cite the root, to count the records it answered with, and to cite a page that answers 200; and each carries a guard asserting the probe really would have narrowed, so the test goes red rather than quiet if a future index stops reproducing it.

Against this branch's code with `src/` reverted, all nine fail and every guard passes.

## Measured

- The reported signature: `/api/newest?category=Email&limit=3` cited `/category/email`, `?limit=1` cited `/vendor/zoho-campaigns`. Both cite the root now.
- Unchanged, on a running server: `/api/offers` `/category/cloud-hosting`, `/api/details/supabase` `/vendor/supabase`, `/api/compare` `/category/databases`, `/api/changes` `/vendor/aws`, `/api/categories` `/category`, `/api/llm-pricing` `/category/ai-ml`, `/api/hosting-pricing` `/category/cloud-hosting`, `/api/digest/weekly` `/digest/2026-w37`, `/api/referral-codes` `/disclosure`.
- `verified_records` and the check date are unchanged on all nine — only the page moves.
- End to end over a real MCP session (initialize → tools/call) on the published index, and over HTTP.
- 659 of 659 in the affected files: the citation, provenance, MCP, costs, stacks and audit suites.
