### PR TITLE
Publish the day we read the page, not a day drawn from a three-day window

### DIFF
--- a/scripts/mutate-1545.mjs
+++ b/scripts/mutate-1545.mjs
@@ -1,0 +1,78 @@
+import { readFileSync, writeFileSync } from "node:fs";
+import { execFileSync } from "node:child_process";
+
+const ROLLING = "scripts/reverify-rolling.js";
+const STATE = "scripts/verification-state.js";
+
+const SUITE = [
+  "test/reverify-rolling.test.ts",
+  "test/change-log-writer.test.ts",
+  "test/change-gate.test.ts",
+];
+
+const A_RANDOM_DAY_BACK = (target) =>
+  `data.offers[${target}].verifiedDate = new Date(now.getTime() - Math.floor(Math.random() * 3) * 86400000).toISOString().slice(0, 10);`;
+
+const MUTANTS = [
+  ["the-url-mode-stamp-goes-back-a-random-day-again", ROLLING,
+    `data.offers[v.index].verifiedDate = isoDay(now);`,
+    A_RANDOM_DAY_BACK("v.index")],
+
+  ["the-ai-mode-stamp-goes-back-a-random-day-again", ROLLING,
+    `data.offers[index].verifiedDate = isoDay(now);`,
+    A_RANDOM_DAY_BACK("index")],
+
+  ["the-url-mode-stamp-goes-back-exactly-one-day", ROLLING,
+    `data.offers[v.index].verifiedDate = isoDay(now);`,
+    `data.offers[v.index].verifiedDate = isoDay(new Date(now.getTime() - 86400000));`],
+
+  ["the-ai-mode-stamp-goes-back-exactly-one-day", ROLLING,
+    `data.offers[index].verifiedDate = isoDay(now);`,
+    `data.offers[index].verifiedDate = isoDay(new Date(now.getTime() - 86400000));`],
+
+  ["the-url-mode-stamp-reads-the-wall-clock-rather-than-the-run", ROLLING,
+    `data.offers[v.index].verifiedDate = isoDay(now);`,
+    `data.offers[v.index].verifiedDate = isoDay(new Date());`],
+
+  ["the-ai-mode-stamp-reads-the-wall-clock-rather-than-the-run", ROLLING,
+    `data.offers[index].verifiedDate = isoDay(now);`,
+    `data.offers[index].verifiedDate = isoDay(new Date());`],
+
+  ["a-read-that-could-not-take-the-terms-stamps-anyway", ROLLING,
+    `      if (holdsVerifiedDate(check.outcome)) {`,
+    `      if (false) {`],
+
+  ["a-confirmation-over-an-unusable-source-stamps-anyway", ROLLING,
+    `      if (!sourceOk) {\n        await sleep(rateLimitMs);\n        continue;\n      }`,
+    ``],
+
+  ["the-state-file-dates-the-confirmation-a-day-before-we-publish-it", STATE,
+    `  const date = isoDay(now);`,
+    `  const date = isoDay(new Date(now.getTime() - 86400000));`],
+];
+
+function run(cmd, args) {
+  try {
+    execFileSync(cmd, args, { stdio: "pipe", encoding: "utf-8" });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+const survivors = [];
+for (const [name, file, from, to] of MUTANTS) {
+  const original = readFileSync(file, "utf-8");
+  if (!original.includes(from)) {
+    console.log(`SKIP  ${name} — the line it mutates is not in ${file}`);
+    survivors.push(`${name} (not applied)`);
+    continue;
+  }
+  writeFileSync(file, original.replace(from, to));
+  const green = run("node", ["--test", "--test-concurrency", "1", ...SUITE]);
+  writeFileSync(file, original);
+  console.log(`${green ? "SURVIVED" : "killed  "}  ${name}`);
+  if (green) survivors.push(name);
+}
+console.log(`\n${MUTANTS.length - survivors.length}/${MUTANTS.length} killed`);
+if (survivors.length > 0) console.log("survivors:", survivors.join(", "));

--- a/scripts/reverify-rolling.js
+++ b/scripts/reverify-rolling.js
@@ -68,7 +68,6 @@ const INDEX_PATH =
 const DEFAULT_LIMIT = 100;
 const URL_CONCURRENCY = 10;
 const AI_RATE_LIMIT_MS = 500;
-const STAGGER_WINDOW_DAYS = 3;
 const QUARANTINE_RETRY_SHARE = 0.2;
 
 export function lastAttemptedDate(offer, refusedOn = null, verificationRecord = null) {
@@ -128,12 +127,6 @@ export function repickedNextRun(picked, offers, limit, now, options = {}) {
   const { picked: next } = pickOldestEntries(offers, limit, tomorrow, options);
   const checked = new Set(picked.map(({ offer }) => offerKey(offer?.vendor, offer?.url)));
   return next.filter(({ offer }) => checked.has(offerKey(offer?.vendor, offer?.url))).length;
-}
-
-export function staggeredDate(now, rand = Math.random) {
-  const offsetDays = Math.floor(rand() * STAGGER_WINDOW_DAYS);
-  const d = new Date(now.getTime() - offsetDays * 24 * 60 * 60 * 1000);
-  return d.toISOString().split("T")[0];
 }
 
 function sleep(ms) {
@@ -211,7 +204,7 @@ export async function runUrlMode(picked, data, dryRun, now, options = {}) {
         continue;
       }
       if (!dryRun) {
-        data.offers[v.index].verifiedDate = staggeredDate(now);
+        data.offers[v.index].verifiedDate = isoDay(now);
       }
       if (statesNoPrice) recorder.note(offer, ATTEMPT_STATES_NO_PRICE, check.detail);
       else recorder.note(offer, ATTEMPT_LINK_OK);
@@ -290,7 +283,7 @@ export async function runAiMode(picked, data, dryRun, now, options = {}) {
         continue;
       }
       if (!dryRun) {
-        data.offers[index].verifiedDate = staggeredDate(now);
+        data.offers[index].verifiedDate = isoDay(now);
       }
       verified++;
     } else if (result.status === "changed") {

--- a/test/change-log-writer.test.ts
+++ b/test/change-log-writer.test.ts
@@ -758,10 +758,11 @@ describe("change log writer", () => {
       assert.deepStrictEqual(result.changes, []);
     });
 
-    it("stamps a fresh verifiedDate on a page that answered and named the vendor", async () => {
+    it("stamps the day of the read on a page that answered and named the vendor", async () => {
       const data = { offers: picked.map((p) => ({ ...p.offer })) };
       await runUrlMode(picked, data, false, NOW, { batchFn: reachable, fetchFn: namesEveryone });
-      assert.notStrictEqual(data.offers[0].verifiedDate, "2026-01-01");
+      assert.strictEqual(data.offers[0].verifiedDate, "2026-08-27");
+      assert.strictEqual(data.offers[0].source_check.checked, "2026-08-27");
       assert.strictEqual(data.offers[0].source_check.outcome, "ok");
     });
 

--- a/test/reverify-rolling.test.ts
+++ b/test/reverify-rolling.test.ts
@@ -1,10 +1,8 @@
 import { describe, it } from "node:test";
 import assert from "node:assert";
-import { assertPopulationFloor } from "./population-floor.ts";
 
 const {
   pickOldestEntries,
-  staggeredDate,
   lastAttemptedDate,
   repickedNextRun,
   quarantineRetryBudget,
@@ -90,44 +88,81 @@ describe("rolling re-verification", () => {
     });
   });
 
-  describe("staggeredDate", () => {
-    const now = new Date("2026-04-21T12:00:00Z");
+  describe("the date a read publishes is the day the read happened", () => {
+    const NOW = new Date("2026-04-21T00:30:00Z");
+    const THE_DAY_WE_READ = "2026-04-21";
+    const A_WHOLE_BATCH = 24;
 
-    it("returns today's date when rand picks offset 0", () => {
-      const stamp = staggeredDate(now, () => 0);
-      assert.strictEqual(stamp, "2026-04-21");
+    const readable = Array.from({ length: A_WHOLE_BATCH }, (_, i) => {
+      const name = `Vendor${"abcdefghijklmnopqrstuvwx"[i]}`;
+      return {
+        vendor: name,
+        url: `https://${name.toLowerCase()}.example/pricing`,
+        description: "Free tier: 10 GB",
+        category: "Storage",
+        verifiedDate: "2026-01-01",
+      };
+    });
+    const picked = readable.map((offer, index) => ({ index, offer }));
+
+    const pageNaming = async (url: string) => {
+      const vendor = url.split("//")[1].split(".")[0];
+      return { ok: true, text: `${vendor} pricing. Free tier: 10 GB per month for $0.`, truncated: false };
+    };
+    const everyOneReachable = async (batch: any[]) => ({
+      verified: batch.map((b) => ({ index: b.index, vendor: b.offer.vendor })),
+      flagged: [],
     });
 
-    it("returns yesterday when rand picks offset 1", () => {
-      const stamp = staggeredDate(now, () => 0.4);
-      assert.strictEqual(stamp, "2026-04-20");
+    it("stamps the day of the read on every record a URL-mode run confirms", async () => {
+      const data = { offers: readable.map((o) => ({ ...o })) };
+      const result = await runUrlMode(picked, data, false, NOW, {
+        batchFn: everyOneReachable,
+        fetchFn: pageNaming,
+      });
+      assert.strictEqual(result.verified, A_WHOLE_BATCH);
+      assert.deepStrictEqual([...new Set(data.offers.map((o: any) => o.verifiedDate))], [THE_DAY_WE_READ]);
     });
 
-    it("returns day-before when rand picks offset 2", () => {
-      const stamp = staggeredDate(now, () => 0.8);
-      assert.strictEqual(stamp, "2026-04-19");
+    it("stamps the day of the read on every record an AI-mode run confirms", async () => {
+      const data = { offers: readable.map((o) => ({ ...o })) };
+      const result = await runAiMode(picked, data, false, NOW, {
+        fetchFn: pageNaming,
+        verifyFn: async () => ({ status: "confirmed" }),
+        confirmFn: async () => ({ describes_change: true }),
+        rateLimitMs: 0,
+      });
+      assert.strictEqual(result.verified, A_WHOLE_BATCH);
+      assert.deepStrictEqual([...new Set(data.offers.map((o: any) => o.verifiedDate))], [THE_DAY_WE_READ]);
     });
 
-    it("never produces dates outside the 3-day window", () => {
-      const dates = new Set<string>();
-      for (let i = 0; i < 200; i++) {
-        dates.add(staggeredDate(now));
-      }
-      const allowed = new Set(["2026-04-21", "2026-04-20", "2026-04-19"]);
-      for (const d of dates) {
-        assert.ok(allowed.has(d), `unexpected stamped date ${d}`);
-      }
+    it("publishes the same day the state file records the confirmation on", async () => {
+      const data = { offers: readable.map((o) => ({ ...o })) };
+      const result = await runAiMode(picked, data, false, NOW, {
+        fetchFn: pageNaming,
+        verifyFn: async () => ({ status: "confirmed" }),
+        confirmFn: async () => ({ describes_change: true }),
+        rateLimitMs: 0,
+      });
+      const state = new Map();
+      recordAttempts(state, result.attempts, NOW);
+      const confirmed = [...state.values()].filter((r: any) => r.last_outcome === ATTEMPT_CONFIRMED);
+      assert.strictEqual(confirmed.length, A_WHOLE_BATCH);
+      const published = new Map(data.offers.map((o: any) => [o.vendor, o.verifiedDate]));
+      const disagreeing = confirmed.filter((r: any) => published.get(r.vendor) !== r.last_success);
+      assert.deepStrictEqual(disagreeing, []);
     });
 
-    it("distributes across all three days over many samples", () => {
-      const counts: Record<string, number> = {};
-      for (let i = 0; i < 600; i++) {
-        const d = staggeredDate(now);
-        counts[d] = (counts[d] ?? 0) + 1;
-      }
-      assertPopulationFloor(counts["2026-04-21"], 100, "samples land on the first of the three days");
-      assertPopulationFloor(counts["2026-04-20"], 100, "samples land on the second of the three days");
-      assertPopulationFloor(counts["2026-04-19"], 100, "samples land on the third of the three days");
+    it("holds the published date where the source check could not read terms", async () => {
+      const data = { offers: readable.map((o) => ({ ...o })) };
+      const result = await runAiMode(picked, data, false, NOW, {
+        fetchFn: async () => ({ ok: true, text: "An about page naming nobody and pricing nothing.", truncated: false }),
+        verifyFn: async () => ({ status: "confirmed" }),
+        confirmFn: async () => ({ describes_change: true }),
+        rateLimitMs: 0,
+      });
+      assert.strictEqual(result.verified, 0);
+      assert.deepStrictEqual([...new Set(data.offers.map((o: any) => o.verifiedDate))], ["2026-01-01"]);
     });
   });
 });


### PR DESCRIPTION
Refs #1545.

`verifiedDate` was stamped with `staggeredDate(now)` — a day drawn at random from the three days ending at the read. On `main` at 02b0a3c, of the 275 confirmed records in that window, 92 published the day we read them, 98 a day older and 85 two days older. **183 of 275, 67%, published a date older than the read.** The field is the one thing we sell over an undated list, and `/api/offers` publishes it exactly, with `days_since_verified` derived from it.

Both write sites now take `isoDay(now)` — the same instant `source_check.checked` already recorded, so the two agree on every record.

## AC-3: the smoothing is not wanted, and the five tests are deleted

The jitter came from #959 as a de-cliffing device for one event: 1,586 records verified inside the April 7-21 sweep, all due to cross the 30-day threshold together. Its criterion was to spread that batch so future re-verifications would not cliff again.

Nothing now depends on the spread:

- `data/index.json` holds **93 distinct `verifiedDate` values across 1,547 records**, 1 to 42 per day, spanning 2026-04-05 to 2026-09-10. The cliff is gone.
- `pickOldestEntries` sorts on last-attempt age and slices the limit. It reads no staleness threshold, so the queue draws the same records whatever the dates look like — the rolling process is what keeps the distribution smooth, not the jitter.
- No test and no served surface pins a freshness count. `/api/freshness` will step by a run's worth of records rather than a third of one; that is the honest shape of "we read 100 pages today".

So there is no queue-side field to move them to, and they are gone rather than relocated.

## Measured, on real runs against live pricing pages

Same five-record fixture (Supabase, Cloudflare, Netlify, Render, Fly.io, each seeded at `2026-01-01`), read on 2026-09-11, `main` in a worktree against this branch:

| run | stamps |
|---|---|
| `main`, run 1 | 09-10, 09-11, 09-10, 09-09, 09-09 — **4 of 5 backdated** |
| `main`, run 2 | 09-09, 09-09, 09-09, 09-09, 09-11 — **4 of 5 backdated** |
| this branch | 09-11 ×5, and `source_check.checked` agrees on all five |

## Tests

`test/reverify-rolling.test.ts` replaces the `staggeredDate` block with four tests driving the real run functions:

- a URL-mode run and an AI-mode run each confirm a batch of 24, and the set of distinct dates the batch publishes is exactly `["2026-04-21"]`. A batch rather than a record on purpose: one record passes a reintroduced three-day jitter a third of the time, 24 pass it once in 3^24.
- the published day equals the `last_success` the state file records for the same confirmation — the invariant AC-2 measures on `main`.
- a read whose source check could not take the terms still publishes nothing, so the batch assertion above cannot pass by the write never running.

`test/change-log-writer.test.ts` had `assert.notStrictEqual(verifiedDate, "2026-01-01")` — as much as it could say while the stamp was random. It now pins the read day.

266 of 266 in the three affected files. **9 mutants, 9 killed** (`scripts/mutate-1545.mjs`): the jitter reintroduced at either write site, a fixed one-day backdate at either site, the wall clock read instead of the run's clock at either site, the `holdsVerifiedDate` guard dropped, the unusable-source guard dropped, and the state file dating a confirmation a day before we publish it. The random-jitter mutants were re-run three times and died every time.

## Not in this PR

183 records already carry a day we know is wrong, and the right one is sitting in `data/verification_state.json`. Backfilling them is a data correction that turns on the `states_no_terms` question #1545 flags as separate, so it is a comment on the issue rather than a commit here.
