### PR TITLE
Stop rendering a refused change as a signal that nothing changed

### DIFF
--- a/src/change-refusal.ts
+++ b/src/change-refusal.ts
@@ -49,13 +49,13 @@ export function unreconciledRead(refusals: readonly RefusedRead[]): RefusedRead 
   return mostRecent(refusals.filter(r => !refusalConfirmsTheStoredTerms(r)));
 }
 
-export interface StabilityWithheldByARefusal {
+export interface StabilityEvidence {
   historyLevel: string | null;
   publishedChanges: number;
   refusals: readonly RefusedRead[];
 }
 
-export function readNotReconciled(state: StabilityWithheldByARefusal): RefusedRead | null {
+export function readNotReconciled(state: StabilityEvidence): RefusedRead | null {
   if (state.historyLevel !== "stable") return null;
   if (state.publishedChanges > 0) return null;
   return unreconciledRead(state.refusals);
@@ -92,7 +92,7 @@ export function unreconciledReadSentence(subject: string, refusedOn: string): st
     + ` we found a change we could not reconcile with the terms we publish for it.`;
 }
 
-export function readsWeCouldNotReconcile(
+export function refusalsByVendor(
   refusals: readonly ChangeRefusal[],
 ): Map<string, ChangeRefusal[]> {
   const byVendor = new Map<string, ChangeRefusal[]>();

--- a/src/change-refusal.ts
+++ b/src/change-refusal.ts
@@ -1,0 +1,106 @@
+export interface ChangeRefusal {
+  vendor: string;
+  change_type: string;
+  reason: string;
+  detail: string | null;
+  summary: string | null;
+  previous_state: string | null;
+  current_state: string | null;
+  source_url: string | null;
+  category: string | null;
+  refused_date: string;
+}
+
+export interface ChangeRefusalIndex {
+  refusals: ChangeRefusal[];
+}
+
+export const REFUSAL_REASONS_THAT_CONFIRM_THE_STORED_TERMS = [
+  "confirmed_unchanged",
+  "free_tier_still_offered",
+] as const;
+
+export type ConfirmingRefusalReason =
+  (typeof REFUSAL_REASONS_THAT_CONFIRM_THE_STORED_TERMS)[number];
+
+const CONFIRMING_REASONS = new Set<string>(REFUSAL_REASONS_THAT_CONFIRM_THE_STORED_TERMS);
+
+const CONFIRMING_REASON_CLAUSES: Record<ConfirmingRefusalReason, string> = {
+  confirmed_unchanged: "the change we last considered recording restated the terms we already publish",
+  free_tier_still_offered:
+    "the change we last considered recording proposed removing a free tier the page still offers",
+};
+
+export type RefusedRead = Pick<ChangeRefusal, "reason" | "refused_date">;
+
+export function refusalConfirmsTheStoredTerms(refusal: Pick<ChangeRefusal, "reason">): boolean {
+  return CONFIRMING_REASONS.has(refusal.reason);
+}
+
+function mostRecent<T extends RefusedRead>(refusals: readonly T[]): T | null {
+  let held: T | null = null;
+  for (const refusal of refusals) {
+    if (held === null || refusal.refused_date > held.refused_date) held = refusal;
+  }
+  return held;
+}
+
+export function unreconciledRead(refusals: readonly RefusedRead[]): RefusedRead | null {
+  return mostRecent(refusals.filter(r => !refusalConfirmsTheStoredTerms(r)));
+}
+
+export interface StabilityWithheldByARefusal {
+  historyLevel: string | null;
+  publishedChanges: number;
+  refusals: readonly RefusedRead[];
+}
+
+export function readNotReconciled(state: StabilityWithheldByARefusal): RefusedRead | null {
+  if (state.historyLevel !== "stable") return null;
+  if (state.publishedChanges > 0) return null;
+  return unreconciledRead(state.refusals);
+}
+
+export function confirmingRead(refusals: readonly RefusedRead[]): RefusedRead | null {
+  return mostRecent(refusals.filter(refusalConfirmsTheStoredTerms));
+}
+
+const CONFIRMING_REASON_SENTENCES: Record<ConfirmingRefusalReason, (subject: string) => string> = {
+  confirmed_unchanged: (subject) =>
+    `The last change we considered recording for ${subject} restated the terms we already publish, so we published none.`,
+  free_tier_still_offered: (subject) =>
+    `The last change we considered recording for ${subject} proposed removing a free tier the page still offers, so we published none.`,
+};
+
+export function confirmingReadClause(refusal: RefusedRead): string {
+  return CONFIRMING_REASON_CLAUSES[refusal.reason as ConfirmingRefusalReason];
+}
+
+export function confirmingReadSentence(subject: string, refusal: RefusedRead): string {
+  return CONFIRMING_REASON_SENTENCES[refusal.reason as ConfirmingRefusalReason](subject);
+}
+
+export const UNRECONCILED_READ_BADGE_LABEL = "unrated — change not reconciled";
+
+export function unreconciledReadClause(refusedOn: string): string {
+  return `when we last read the page we cite for this offer, on ${refusedOn},`
+    + ` we found a change we could not reconcile with the terms we publish`;
+}
+
+export function unreconciledReadSentence(subject: string, refusedOn: string): string {
+  return `When we last read the page we cite for ${subject}, on ${refusedOn},`
+    + ` we found a change we could not reconcile with the terms we publish for it.`;
+}
+
+export function readsWeCouldNotReconcile(
+  refusals: readonly ChangeRefusal[],
+): Map<string, ChangeRefusal[]> {
+  const byVendor = new Map<string, ChangeRefusal[]>();
+  for (const refusal of refusals) {
+    const key = refusal.vendor.toLowerCase();
+    const held = byVendor.get(key);
+    if (held) held.push(refusal);
+    else byVendor.set(key, [refusal]);
+  }
+  return byVendor;
+}

--- a/src/change-refusal.ts
+++ b/src/change-refusal.ts
@@ -37,12 +37,12 @@ export function refusalConfirmsTheStoredTerms(refusal: Pick<ChangeRefusal, "reas
   return CONFIRMING_REASONS.has(refusal.reason);
 }
 
-function mostRecent<T extends RefusedRead>(refusals: readonly T[]): T | null {
-  let held: T | null = null;
+function mostRecent(refusals: readonly RefusedRead[]): RefusedRead | null {
+  let held: RefusedRead | null = null;
   for (const refusal of refusals) {
     if (held === null || refusal.refused_date > held.refused_date) held = refusal;
   }
-  return held;
+  return held === null ? null : { reason: held.reason, refused_date: held.refused_date };
 }
 
 export function unreconciledRead(refusals: readonly RefusedRead[]): RefusedRead | null {

--- a/src/comparison-verdict.ts
+++ b/src/comparison-verdict.ts
@@ -1,4 +1,5 @@
 import { withheldLevelSentence, type LevelWithheldReason } from "./source-check.js";
+import { unreconciledReadSentence, type RefusedRead } from "./change-refusal.js";
 
 export type StabilityRating = "stable" | "caution" | "risky";
 
@@ -7,6 +8,7 @@ export interface ComparisonSide {
   recordedChanges: number;
   rating: StabilityRating | null;
   ratingWithheldBecause: LevelWithheldReason | null;
+  refusedRead?: RefusedRead | null;
   unconfirmableSince: string;
 }
 
@@ -28,9 +30,11 @@ export function moreStableSide(a: ComparisonSide, b: ComparisonSide): Comparison
 }
 
 function whyWithheld(side: ComparisonSide): string {
-  return side.ratingWithheldBecause
-    ? withheldLevelSentence(side.ratingWithheldBecause, side.vendor, side.unconfirmableSince)
-    : `We are not publishing a stability rating for ${side.vendor}.`;
+  if (side.ratingWithheldBecause) {
+    return withheldLevelSentence(side.ratingWithheldBecause, side.vendor, side.unconfirmableSince);
+  }
+  if (side.refusedRead) return unreconciledReadSentence(side.vendor, side.refusedRead.refused_date);
+  return `We are not publishing a stability rating for ${side.vendor}.`;
 }
 
 export function stabilitySentences(a: ComparisonSide, b: ComparisonSide): string[] {

--- a/src/data.ts
+++ b/src/data.ts
@@ -32,7 +32,7 @@ import { resolveCategoryName } from "./category-scope.js";
 import { survivingVendorName } from "./vendor-merges.js";
 import {
   readNotReconciled,
-  readsWeCouldNotReconcile,
+  refusalsByVendor as groupRefusalsByVendor,
   unreconciledReadSentence,
   type ChangeRefusal,
   type ChangeRefusalIndex,
@@ -103,7 +103,7 @@ export function resetCache(): void {
   cachedOffers = null;
   cachedChanges = null;
   cachedRefusals = null;
-  refusalsByVendor = null;
+  refusalIndex = null;
   publishedChangesByVendor = null;
   resetLinkHealthCache();
   resetVerificationStateCache();
@@ -602,11 +602,11 @@ export function loadChangeRefusals(): ChangeRefusal[] {
   return cachedRefusals;
 }
 
-let refusalsByVendor: Map<string, ChangeRefusal[]> | null = null;
+let refusalIndex: Map<string, ChangeRefusal[]> | null = null;
 
 export function refusalsForVendor(vendor: string): ChangeRefusal[] {
-  if (!refusalsByVendor) refusalsByVendor = readsWeCouldNotReconcile(loadChangeRefusals());
-  return refusalsByVendor.get(vendor.trim().toLowerCase()) ?? [];
+  if (!refusalIndex) refusalIndex = groupRefusalsByVendor(loadChangeRefusals());
+  return refusalIndex.get(vendor.trim().toLowerCase()) ?? [];
 }
 
 let publishedChangesByVendor: Map<string, number> | null = null;

--- a/src/data.ts
+++ b/src/data.ts
@@ -30,6 +30,14 @@ import { changeCitesASource, changeIsUncited, changeSummaryHtml, changeSummaryMa
 import { endedVerdictSentence } from "./retirement.js";
 import { resolveCategoryName } from "./category-scope.js";
 import { survivingVendorName } from "./vendor-merges.js";
+import {
+  readNotReconciled,
+  readsWeCouldNotReconcile,
+  unreconciledReadSentence,
+  type ChangeRefusal,
+  type ChangeRefusalIndex,
+  type RefusedRead,
+} from "./change-refusal.js";
 
 export function gateForOffer(offer: Offer): Gate | null {
   return gateFor(offer, utcDate());
@@ -47,9 +55,12 @@ const INDEX_PATH =
   process.env.AGENTDEALS_INDEX_PATH || path.join(__dirname, "..", "data", "index.json");
 const CHANGES_PATH =
   process.env.AGENTDEALS_CHANGES_PATH || path.join(__dirname, "..", "data", "deal_changes.json");
+const REFUSALS_PATH =
+  process.env.AGENTDEALS_REFUSALS_PATH || path.join(__dirname, "..", "data", "change_refusals.json");
 
 let cachedOffers: Offer[] | null = null;
 let cachedChanges: DealChange[] | null = null;
+let cachedRefusals: ChangeRefusal[] | null = null;
 
 export function loadOffers(): Offer[] {
   if (cachedOffers) return cachedOffers;
@@ -91,6 +102,9 @@ export function loadOffers(): Offer[] {
 export function resetCache(): void {
   cachedOffers = null;
   cachedChanges = null;
+  cachedRefusals = null;
+  refusalsByVendor = null;
+  publishedChangesByVendor = null;
   resetLinkHealthCache();
   resetVerificationStateCache();
 }
@@ -379,8 +393,9 @@ export function withheldStability(
   linkUnreachable: LinkUnreachable | null,
   stability: StabilityClass,
   vendorChanges: readonly DealChange[] = [],
+  refusedRead: RefusedRead | null = null,
 ): StabilityClass | null {
-  if (!linkUnreachable && standingNarrowingsCitingNoSource(vendorChanges).length === 0) return stability;
+  if (!linkUnreachable && !refusedRead && standingNarrowingsCitingNoSource(vendorChanges).length === 0) return stability;
   return FAVOURABLE_STABILITY_CLASSES.has(stability) ? null : stability;
 }
 
@@ -390,7 +405,22 @@ export function publishedStabilityFor(vendorName: string): StabilityClass | null
   const offer = loadOffers().find((o) => o.vendor.toLowerCase() === key);
   if (!offer) return classifyStability(vendorChanges);
   const grading = changesRatingTheListedTier(offer, vendorChanges);
-  return withheldStability(unreachableNoticeForUrl(offer.url), classifyStability(grading), grading);
+  return withheldStability(
+    unreachableNoticeForUrl(offer.url),
+    classifyStability(grading),
+    grading,
+    publishedRisk(offer, vendorChanges).refused_read,
+  );
+}
+
+export function stabilityWithheldSentence(vendorName: string): string {
+  const offer = loadOffers().find((o) => o.vendor.toLowerCase() === vendorName.toLowerCase());
+  if (!offer) return vendorNotIndexedSentence(vendorName);
+  const vendorChanges = loadDealChanges().filter((c) => c.vendor.toLowerCase() === vendorName.toLowerCase());
+  const risk = publishedRisk(offer, vendorChanges);
+  if (risk.refused_read) return unreconciledReadSentence(vendorName, risk.refused_read.refused_date);
+  if (risk.link_unreachable) return withheldLevelSentence("link_unreachable", vendorName, risk.link_unreachable.last_reachable ? LAST_RESOLVED(risk.link_unreachable.last_reachable) : "");
+  return ratingWithheldForNoSourceSentence(vendorName);
 }
 
 export function getStabilityMap(): Map<string, StabilityClass> {
@@ -457,7 +487,7 @@ export function enrichOffers(offers: Offer[]): EnrichedOffer[] {
       }
     }
 
-    const { risk_level, risk_cause, rating_withheld, link_unreachable, gate } = publishedRisk(
+    const { risk_level, risk_cause, rating_withheld, link_unreachable, gate, refused_read } = publishedRisk(
       offer,
       vendorAllChangesList.get(key) ?? [],
       servedOn,
@@ -470,6 +500,7 @@ export function enrichOffers(offers: Offer[]): EnrichedOffer[] {
       link_unreachable,
       classifyStability(grading),
       grading,
+      refused_read,
     );
 
     const days_since_verified = Math.floor(
@@ -481,7 +512,7 @@ export function enrichOffers(offers: Offer[]): EnrichedOffer[] {
 
     const terms_superseded = supersededTermsRecordFor(offer, vendorAllChangesList.get(key) ?? []);
 
-    const enriched = { ...offer, recent_change, expires_soon, risk_level, risk_cause, rating_withheld, stability, days_since_verified, last_read_date, days_since_read, link_unreachable, gate, terms_superseded };
+    const enriched = { ...offer, recent_change, expires_soon, risk_level, risk_cause, rating_withheld, stability, days_since_verified, last_read_date, days_since_read, link_unreachable, gate, refused_read, terms_superseded };
     return stripReferrerValue(enriched);
   });
 }
@@ -538,6 +569,57 @@ export function loadDealChanges(): DealChange[] {
     return survivor ? { ...change, vendor: survivor } : change;
   });
   return cachedChanges;
+}
+
+export function loadChangeRefusals(): ChangeRefusal[] {
+  if (cachedRefusals) return cachedRefusals;
+
+  if (!fs.existsSync(REFUSALS_PATH)) {
+    cachedRefusals = [];
+    return cachedRefusals;
+  }
+
+  let data: ChangeRefusalIndex;
+  try {
+    data = JSON.parse(fs.readFileSync(REFUSALS_PATH, "utf-8"));
+  } catch (err) {
+    console.error(`Change refusals could not be read: ${err}`);
+    cachedRefusals = [];
+    return cachedRefusals;
+  }
+
+  if (!data || !Array.isArray(data.refusals)) {
+    console.error("Change refusals is missing 'refusals' array, using empty list");
+    cachedRefusals = [];
+    return cachedRefusals;
+  }
+
+  const live = new Set(loadOffers().map((o) => o.vendor.trim().toLowerCase()));
+  cachedRefusals = data.refusals.map((refusal) => {
+    const survivor = survivingVendorName(refusal.vendor, live);
+    return survivor ? { ...refusal, vendor: survivor } : refusal;
+  });
+  return cachedRefusals;
+}
+
+let refusalsByVendor: Map<string, ChangeRefusal[]> | null = null;
+
+export function refusalsForVendor(vendor: string): ChangeRefusal[] {
+  if (!refusalsByVendor) refusalsByVendor = readsWeCouldNotReconcile(loadChangeRefusals());
+  return refusalsByVendor.get(vendor.trim().toLowerCase()) ?? [];
+}
+
+let publishedChangesByVendor: Map<string, number> | null = null;
+
+export function publishedChangeCount(vendor: string): number {
+  if (!publishedChangesByVendor) {
+    publishedChangesByVendor = new Map();
+    for (const change of loadDealChanges()) {
+      const key = change.vendor.trim().toLowerCase();
+      publishedChangesByVendor.set(key, (publishedChangesByVendor.get(key) ?? 0) + 1);
+    }
+  }
+  return publishedChangesByVendor.get(vendor.trim().toLowerCase()) ?? 0;
 }
 
 export { EVENT_DATED_SOURCES, partitionByDateProvenance } from "./change-dates.js";
@@ -906,6 +988,7 @@ export interface PublishedRisk {
   link_unreachable: LinkUnreachable | null;
   source_check: SourceCheck | null;
   gate: Gate | null;
+  refused_read: RefusedRead | null;
 }
 
 export function changesRatingTheListedTier(
@@ -924,9 +1007,15 @@ export function publishedRisk(
   const assessment = vendorRiskAssessment(changesRatingTheListedTier(offer, vendorChanges), nowMs);
   const link_unreachable = unreachableNoticeForUrl(offer.url, nowMs);
   const gate = gateFor(offer, servedOn);
+  const refused_read = readNotReconciled({
+    historyLevel: assessment.level,
+    publishedChanges: publishedChangeCount(offer.vendor),
+    refusals: refusalsForVendor(offer.vendor),
+  });
   const withheld =
     gate !== null ||
     assessment.rating_withheld !== null ||
+    refused_read !== null ||
     (cannotVouchForLevel(offer, link_unreachable) && assessment.level === "stable");
   return {
     risk_level: withheld ? null : assessment.level,
@@ -937,6 +1026,7 @@ export function publishedRisk(
     link_unreachable,
     source_check: offer.source_check ?? null,
     gate,
+    refused_read,
   };
 }
 
@@ -949,7 +1039,9 @@ export function levelWithheldStatement(vendor: string, risk: PublishedRisk): str
   if (risk.gate) return gateRiskSummary(risk.gate);
   if (risk.rating_withheld) return ratingWithheldForNoSourceSentence(vendor);
   const reason = levelWithheldReason({ source_check: risk.source_check ?? undefined }, risk.link_unreachable);
-  if (!reason) return null;
+  if (!reason) {
+    return risk.refused_read ? unreconciledReadSentence(vendor, risk.refused_read.refused_date) : null;
+  }
   const since = levelWithheldSince({ source_check: risk.source_check ?? undefined }, risk.link_unreachable);
   return withheldLevelSentence(reason, vendor, since);
 }
@@ -1030,6 +1122,8 @@ export function checkVendorRisk(
     summary = `${ratingWithheldForNoSourceSentence(offer.vendor)}${unreachableClause}`;
   } else if (withheldReason) {
     summary = `${withheldLevelSentence(withheldReason, offer.vendor, withheldSince)} Nothing we have read describes this offer. Treat that as a statement about our records, not as a stable pricing history.`;
+  } else if (published.refused_read) {
+    summary = `${unreconciledReadSentence(offer.vendor, published.refused_read.refused_date)} We publish no change we could not reconcile, so we are not calling this a stable pricing history.`;
   } else {
     summary = `${vendorHistorySentence(offer.vendor, "stable", cause)} Free tier verified for ${longevityDays} days.`;
   }

--- a/src/llm-api-readme.ts
+++ b/src/llm-api-readme.ts
@@ -1,6 +1,7 @@
 import { BASE_URL } from "./base-url.js";
 import { readingIsBehindTheLoop } from "./badge-staleness.js";
 import { citationLabel, ratingWithheldForNoSourceSentence } from "./change-citation.js";
+import { unreconciledReadSentence } from "./change-refusal.js";
 import { CHANGE_DIRECTION } from "./change-direction.js";
 import { gateRiskSummary, publishedRisk } from "./data.js";
 import { LINK_GRACE_DAYS } from "./link-health.js";
@@ -143,6 +144,7 @@ function withheldSentence(
 ): string {
   if (because.reason === "gated") return gate ? gateRiskSummary(gate) : `We do not rate an offer we do not list.`;
   if (because.reason === "no_source") return ratingWithheldForNoSourceSentence(vendor);
+  if (because.reason === "read_not_reconciled") return unreconciledReadSentence(vendor, because.refusedOn);
   return withheldLevelSentence(because.reason, vendor, since);
 }
 

--- a/src/serve.ts
+++ b/src/serve.ts
@@ -6,6 +6,8 @@ import { dirname, join } from "node:path";
 import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
 import { createServer, getServerCard } from "./server.js";
 import { oldestVerifiedDateForSlug, vendorRiskAssessment, publishedRisk, levelWithheldStatement, vendorNotIndexedSentence, riskCauseOf, freeTierEndingRecord, NEGATIVE_CHANGE_TYPES, POSITIVE_CHANGE_TYPES, SEVERE_CHANGE_TYPES, loadOffers, getCategories, getNewOffers, getNewestDeals, searchOffers, enrichOffers, gateForOffer, loadDealChanges, getDealChanges, changeContext, DEFAULT_CHANGE_WINDOW_DAYS, getOfferDetails, compareServices, checkVendorRisk, auditStack, getExpiringDeals, getWeeklyDigest, getFormattedWeeklyDigest, getFreshnessMetrics, getStabilityMap, getVendorReferral, sanitizeQuery, getChangeLogFreshness, isEventDated, partitionByDateProvenance } from "./data.js";
+import { loadChangeRefusals } from "./data.js";
+import { confirmingRead, confirmingReadSentence, readsWeCouldNotReconcile, unreconciledReadSentence, UNRECONCILED_READ_BADGE_LABEL, type ChangeRefusal } from "./change-refusal.js";
 import { getStackRecommendation } from "./stacks.js";
 import { estimateCosts } from "./costs.js";
 import { classifyRequest } from "./client-class.js";
@@ -31,7 +33,7 @@ import { NO_CURRENT_FIGURE, costHeadlineCaveat, limitCellText, mayRecommendAsFre
 import { changesByVendor } from "./superseded-census.js";
 import { buildComparisonMap, comparisonSlug } from "./comparison-pairs.js";
 import { comparisonVerdictText, freeTierFaqAnswer, stabilityFaqAnswer, type ComparisonSide, type FreeTierSide, type SideFreeTier, type StabilityRating } from "./comparison-verdict.js";
-import { publishedVendorLevel, vendorVerdictSentence, vendorBadge, freeTierClaim, statesRiskCause, narrowingSentence, changeKindNoun, termsUnconfirmedBySource, unconfirmedTermsMetaSentence, type BadgeWithholding, type FreeTierClaim, type VendorVerdictInput } from "./vendor-verdict.js";
+import { publishedVendorLevel, vendorVerdictSentence, vendorBadge, freeTierClaim, statesRiskCause, narrowingSentence, changeKindNoun, readWeCouldNotReconcile, refusalWithholdsStability, termsUnconfirmedBySource, unconfirmedTermsMetaSentence, type BadgeWithholding, type FreeTierClaim, type VendorVerdictInput } from "./vendor-verdict.js";
 import { tierRecordsAFreeTier } from "./free-tier-record.js";
 import { PAGE_HEAD_OPEN, withLedeBeforeNav } from "./page-lede.js";
 import { freshnessClaimFor, withFreshnessClaim } from "./page-freshness.js";
@@ -542,6 +544,12 @@ function changesFor(vendorName: string): DealChange[] {
   return changesByVendorName.get(vendorName.toLowerCase()) ?? [];
 }
 
+const refusalsByVendorName = readsWeCouldNotReconcile(loadChangeRefusals());
+
+function refusalsFor(vendorName: string): ChangeRefusal[] {
+  return refusalsByVendorName.get(vendorName.toLowerCase()) ?? [];
+}
+
 type StoredTermsOf = Pick<Offer, "vendor" | "description" | "tier">;
 
 function supersedingChangeFor(offer: StoredTermsOf): DealChange | null {
@@ -886,9 +894,9 @@ const GATED_BADGE_LABELS: Record<GateCode, string> = {
 };
 
 function withheldBadgeLabel(because: BadgeWithholding): string {
-  return because.reason === "gated"
-    ? GATED_BADGE_LABELS[because.gate]
-    : WITHHELD_BADGE_LABELS[because.reason];
+  if (because.reason === "gated") return GATED_BADGE_LABELS[because.gate];
+  if (because.reason === "read_not_reconciled") return UNRECONCILED_READ_BADGE_LABEL;
+  return WITHHELD_BADGE_LABELS[because.reason];
 }
 
 let reverificationInterval: { on: string; days: number } | null = null;
@@ -970,6 +978,7 @@ function buildVendorVerdictContext(vendorName: string, servedOn: string): Vendor
       gate: gate?.code ?? null,
       linkUnreachable: Boolean(linkUnreachable),
       sourceCheck: primary.source_check?.outcome ?? null,
+      refusedReads: refusalsFor(vendorName),
     },
   };
 }
@@ -1191,6 +1200,7 @@ function endedFreeTiersIn(population: readonly Offer[], servedOn: string): Offer
 function unconfirmedFreeTierSentence(vendor: string, because: BadgeWithholding, context: VendorVerdictContext): string {
   if (because.reason === "gated") return context.gate?.reason ?? "";
   if (because.reason === "no_source") return ratingWithheldForNoSourceSentence(vendor);
+  if (because.reason === "read_not_reconciled") return unreconciledReadSentence(vendor, because.refusedOn);
   return withheldLevelSentence(because.reason, vendor, context.unconfirmableSince);
 }
 
@@ -2888,7 +2898,7 @@ ${demeritRows}
   <h3>The risk label is not a rank, and it is never a count</h3>
   <p>Vendor pages carry a <code>stable</code> / <code>caution</code> / <code>risky</code> label. <strong style="color:var(--text)">It moves no order on this site</strong> &mdash; the ranking module cannot read it, and flipping every label leaves every listing we publish in the same order.</p>
   <p>It is decided by the <em>type</em> of a recorded change, never by how many records we hold. A vendor that expanded its free tier, postponed a fee, added a tier or changed its name cannot be labelled <code>caution</code> for any of those. <strong style="color:var(--text)">A <code>caution</code> or <code>risky</code> label always renders together with the single dated record that produced it, on the same page and next to the label. Where we cannot show the reason, we do not show the label.</strong></p>
-  <p>The honest limit: <code>stable</code> means we hold no record of a free tier removal, a limit reduction or a pricing restructure for that vendor. It is a statement about our records, not a clean bill of health &mdash; a vendor we have never had cause to examine reads the same as one with a long clean history. Until August 2026 the label was derived from a count of records of any type, which inverted that: the vendors we watched most closely were the ones it flagged, and several were flagged for good news. That is fixed, and this paragraph is here so the next version of it is checkable.</p>
+  <p>The honest limit: <code>stable</code> means we hold no record of a free tier removal, a limit reduction or a pricing restructure for that vendor, and that no read of its pricing page since has turned up a change we could not reconcile with the terms we publish. A change we read and then refused to record is not evidence that nothing moved, so it takes the label off rather than leaving it on. It is a statement about our records, not a clean bill of health &mdash; a vendor we have never had cause to examine reads the same as one with a long clean history. Until August 2026 the label was derived from a count of records of any type, which inverted that: the vendors we watched most closely were the ones it flagged, and several were flagged for good news. That is fixed, and this paragraph is here so the next version of it is checkable.</p>
 
   <h3>What we publish when the link itself stops resolving</h3>
   <p>Verification asks whether an offer's terms are still right. A separate daily check asks the cheaper question of whether its link still resolves at all, and it runs over every record regardless of how recently that record was verified.</p>
@@ -3229,6 +3239,7 @@ function buildComparisonPage(slug: string): string | null {
       recordedChanges,
       rating: rated as StabilityRating | null,
       ratingWithheldBecause: levelWithheldReason(risk, risk.link_unreachable),
+      refusedRead: risk.refused_read,
       unconfirmableSince: levelWithheldSince(risk, risk.link_unreachable),
     };
   };
@@ -4633,6 +4644,11 @@ function buildVendorPage(slug: string): string | null {
 
   const riskColors: Record<string, string> = { stable: "#3fb950", caution: "#d29922", risky: "#f85149" };
   const riskCause = enriched.risk_cause;
+  const refusedRead = readWeCouldNotReconcile(verdictInput);
+  const unreconciled = refusalWithholdsStability(verdictInput);
+  const confirmedByRefusal = refusedRead || vendorChanges.length > 0
+    ? null
+    : confirmingRead(verdictInput.refusedReads ?? []);
   const riskLevel = publishedVendorLevel(enriched.risk_level ?? null, riskCause);
   const historyLevel = verdictInput.historyLevel;
   const levelWithheldBecause = levelWithheldStatement(vendorName, publishedRisk(primary, vendorChanges, servedOn));
@@ -5122,8 +5138,12 @@ ${allCompareLinks.join("\n")}
     ? `${vendorName} has had ${vendorChanges.length} recorded pricing change${vendorChanges.length > 1 ? "s" : ""}. Most recently: ${changeSummaryText(vendorChanges[0])} (${changeDateLabel(vendorChanges[0])}).${offerHasEnded ? ` ${ENDED_SINCE_CHANGES_SENTENCE}` : ""}`
     : offerHasEnded
     ? endedEmptyChangeHistorySentence(vendorName)
+    : refusedRead
+    ? `${unreconciledReadSentence(vendorName, refusedRead.refused_date)} We publish no change we could not reconcile, so we cannot tell you that nothing changed.`
     : levelWithheld
     ? `We hold no recorded pricing changes for ${vendorName}, but ${withheldClause}, so that is a statement about our records rather than a positive signal.`
+    : confirmedByRefusal
+    ? confirmingReadSentence(vendorName, confirmedByRefusal)
     : primaryGate
     ? `No, ${vendorName} has had no recorded pricing changes.`
     : `No, ${vendorName} has had no recorded pricing changes. This is a positive stability signal.`;
@@ -45987,7 +46007,7 @@ ${globalNavCss()}
   <p class="section-desc">We analyzed ${offers.length.toLocaleString()} developer tool offerings across ${categories.length} categories, tracking ${changesInForce.length} pricing changes over 2024&ndash;2026. Here&rsquo;s what the data shows:</p>
   <ul class="key-takeaways">
     <li><strong>${vouchedPct}% of tracked services offer a free tier we can vouch for today</strong> &mdash; we hold a free-tier record for ${recordedPct}% of them, and can confirm ${freeTiers.vouched.toLocaleString()} of those ${freeTiers.recorded.toLocaleString()} against a source we have read.</li>
-    <li><strong>${freeTiers.unconfirmed.toLocaleString()} recorded free tiers we cannot confirm today</strong> &mdash; the record stands, but the page we hold for it states no price we can read, cannot be read at all, or does not name the vendor. Unconfirmed is not the same as gone.</li>
+    <li><strong>${freeTiers.unconfirmed.toLocaleString()} recorded free tiers we cannot confirm today</strong> &mdash; the record stands, but the page we hold for it states no price we can read, cannot be read at all, does not name the vendor, or carried a change on our last read that we could not reconcile with the terms we publish. Unconfirmed is not the same as gone.</li>
     <li><strong>${freeTiers.ended} free tiers we have recorded as ended</strong> &mdash; excluded from every count above, and from every category total on this site.</li>
     <li><strong>${negativeChanges.length} negative pricing changes vs ${positiveChanges.length} positive</strong> &mdash; free tier removals and restrictions outpace expansions ${directionRatioLabel(negativeChanges.length, positiveChanges.length)}.</li>
     <li><strong>${durability.stillInForce.length} free tiers completely removed</strong> &mdash; ${escHtmlServer(lastingExamples.map(e => e.vendor).join(", "))}, and more. ${escHtmlServer(removalReturnRateSentence(durability))}</li>
@@ -46158,7 +46178,7 @@ ${globalNavCss()}
   <h2>Methodology</h2>
   <p class="section-desc">How we built this dataset:</p>
   <ul style="color:var(--text-muted);font-size:.9rem;padding-left:1.25rem;margin-bottom:1rem">
-    <li style="margin-bottom:.4rem"><strong>Verification:</strong> Every offer records the date we read the vendor&rsquo;s public pricing page and the URL we read it from. That is not the same as being able to vouch for it today: ${freeTiers.unconfirmed.toLocaleString()} of the ${freeTiers.recorded.toLocaleString()} recorded free tiers have a source that states no price we can read, cannot be read at all, or does not name the vendor, and those are the ones counted as unconfirmed above.</li>
+    <li style="margin-bottom:.4rem"><strong>Verification:</strong> Every offer records the date we read the vendor&rsquo;s public pricing page and the URL we read it from. That is not the same as being able to vouch for it today: ${freeTiers.unconfirmed.toLocaleString()} of the ${freeTiers.recorded.toLocaleString()} recorded free tiers have a source that states no price we can read, cannot be read at all, does not name the vendor, or carried a change on our last read that we could not reconcile with the terms we publish, and those are the ones counted as unconfirmed above.</li>
     <li style="margin-bottom:.4rem"><strong>Change tracking:</strong> ${changesInForce.length} pricing changes tracked with date, previous state, current state, impact level, and source documentation.</li>
     <li style="margin-bottom:.4rem"><strong>Definition of &ldquo;free tier&rdquo;:</strong> Perpetual free plans, always-free offerings, and generous hobby/starter tiers without time limits. We exclude limited trials (e.g., 14-day, 30-day) and one-time credits.</li>
     <li style="margin-bottom:.4rem"><strong>Update frequency:</strong> Continuous. Our <a href="/freshness">data freshness dashboard</a> shows verification recency by category.</li>

--- a/src/serve.ts
+++ b/src/serve.ts
@@ -7,7 +7,7 @@ import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/
 import { createServer, getServerCard } from "./server.js";
 import { oldestVerifiedDateForSlug, vendorRiskAssessment, publishedRisk, levelWithheldStatement, vendorNotIndexedSentence, riskCauseOf, freeTierEndingRecord, NEGATIVE_CHANGE_TYPES, POSITIVE_CHANGE_TYPES, SEVERE_CHANGE_TYPES, loadOffers, getCategories, getNewOffers, getNewestDeals, searchOffers, enrichOffers, gateForOffer, loadDealChanges, getDealChanges, changeContext, DEFAULT_CHANGE_WINDOW_DAYS, getOfferDetails, compareServices, checkVendorRisk, auditStack, getExpiringDeals, getWeeklyDigest, getFormattedWeeklyDigest, getFreshnessMetrics, getStabilityMap, getVendorReferral, sanitizeQuery, getChangeLogFreshness, isEventDated, partitionByDateProvenance } from "./data.js";
 import { loadChangeRefusals } from "./data.js";
-import { confirmingRead, confirmingReadSentence, readsWeCouldNotReconcile, unreconciledReadSentence, UNRECONCILED_READ_BADGE_LABEL, type ChangeRefusal } from "./change-refusal.js";
+import { confirmingRead, confirmingReadSentence, refusalsByVendor, unreconciledReadSentence, UNRECONCILED_READ_BADGE_LABEL, type ChangeRefusal } from "./change-refusal.js";
 import { getStackRecommendation } from "./stacks.js";
 import { estimateCosts } from "./costs.js";
 import { classifyRequest } from "./client-class.js";
@@ -544,10 +544,10 @@ function changesFor(vendorName: string): DealChange[] {
   return changesByVendorName.get(vendorName.toLowerCase()) ?? [];
 }
 
-const refusalsByVendorName = readsWeCouldNotReconcile(loadChangeRefusals());
+const refusalsHeldByVendor = refusalsByVendor(loadChangeRefusals());
 
 function refusalsFor(vendorName: string): ChangeRefusal[] {
-  return refusalsByVendorName.get(vendorName.toLowerCase()) ?? [];
+  return refusalsHeldByVendor.get(vendorName.toLowerCase()) ?? [];
 }
 
 type StoredTermsOf = Pick<Offer, "vendor" | "description" | "tier">;

--- a/src/server.ts
+++ b/src/server.ts
@@ -3,7 +3,7 @@ import { join, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
 import { McpServer, ResourceTemplate } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
-import { oldestVerifiedDateForSlug, getCategories, getDealChanges, getPersonalizedChanges, getNewOffers, getNewestDeals, getOfferDetails, searchOffers, enrichOffers, gateForOffer, compareServices, checkVendorRisk, auditStack, getExpiringDeals, getWeeklyDigest, loadOffers, loadDealChanges, classifyStability, publishedStabilityFor, getVendorReferral, sanitizeQuery } from "./data.js";
+import { oldestVerifiedDateForSlug, getCategories, getDealChanges, getPersonalizedChanges, getNewOffers, getNewestDeals, getOfferDetails, searchOffers, enrichOffers, gateForOffer, compareServices, checkVendorRisk, auditStack, getExpiringDeals, getWeeklyDigest, loadOffers, loadDealChanges, classifyStability, publishedStabilityFor, stabilityWithheldSentence, getVendorReferral, sanitizeQuery } from "./data.js";
 import { gateDisclosureFor } from "./gate-disclosure.js";
 import { toSlug, vendorSlugMap, resolveVendorSlug } from "./vendor-slug.js";
 import { recordToolCall, logRequest, recordSearchQuery } from "./stats.js";
@@ -788,13 +788,15 @@ Suggested monitoring cadence: run this check weekly to catch pricing changes ear
         return { contents: [{ uri: `agentdeals://vendor/${slug}`, text: `No vendor found matching "${slug}".`, mimeType: "text/plain" }] };
       }
       const changes = loadDealChanges().filter(c => c.vendor.toLowerCase() === match.vendor.toLowerCase());
-      const stability = classifyStability(changes);
+      const stability = publishedStabilityFor(match.vendor);
       const alternatives = substitutesFor(offers, match).slice(0, 5);
 
       let text = `# ${match.vendor}\n\n`;
       text += `**Category:** ${match.category}\n`;
       text += `**Tier:** ${match.tier}\n`;
-      text += `**Stability:** ${stability}\n`;
+      text += stability
+        ? `**Stability:** ${stability}\n`
+        : `**Stability:** not published — ${stabilityWithheldSentence(match.vendor)}\n`;
       text += `**Description:** ${match.description}\n`;
       text += `**Pricing Page:** ${match.url}\n`;
       text += `**Verified:** ${match.verifiedDate}\n`;

--- a/src/types.ts
+++ b/src/types.ts
@@ -149,6 +149,7 @@ export interface EnrichedOffer extends Offer {
   days_since_read: number;
   link_unreachable: LinkUnreachable | null;
   gate: import("./ranking.js").Gate | null;
+  refused_read: import("./change-refusal.js").RefusedRead | null;
   terms_superseded: import("./superseded-description.js").SupersededTermsRecord | null;
 }
 

--- a/src/vendor-verdict.ts
+++ b/src/vendor-verdict.ts
@@ -14,6 +14,13 @@ import {
 import type { GateCode } from "./ranking.js";
 import { endedVerdictSentence } from "./retirement.js";
 import { vendorHistorySentence, type PublishedRiskLevel } from "./vendor-history.js";
+import {
+  confirmingRead,
+  confirmingReadClause,
+  readNotReconciled,
+  unreconciledReadClause,
+  type RefusedRead,
+} from "./change-refusal.js";
 
 export type { PublishedRiskLevel };
 
@@ -52,11 +59,13 @@ export interface VendorVerdictInput {
   gate?: GateCode | null;
   linkUnreachable?: boolean;
   sourceCheck?: SourceCheckOutcome | null;
+  refusedReads?: readonly RefusedRead[];
 }
 
 export type BadgeWithholding =
   | { reason: "gated"; gate: GateCode }
   | { reason: "no_source" }
+  | { reason: "read_not_reconciled"; refusedOn: string }
   | { reason: LevelWithheldReason };
 
 export type VendorBadge =
@@ -112,7 +121,24 @@ export function withholdingDecides(input: VendorVerdictInput): boolean {
 export function vendorVerdictWord(input: VendorVerdictInput): PublishedRiskLevel | null {
   if (input.offerEnded) return null;
   if (withholdingDecides(input)) return null;
+  if (refusalWithholdsStability(input)) return null;
   return publishedVendorLevel(input.level, input.cause);
+}
+
+export function readWeCouldNotReconcile(input: VendorVerdictInput): RefusedRead | null {
+  return readNotReconciled({
+    historyLevel: input.historyLevel,
+    publishedChanges: input.changes.length,
+    refusals: input.refusedReads ?? [],
+  });
+}
+
+export function refusalWithholdsStability(input: VendorVerdictInput): RefusedRead | null {
+  if (input.offerEnded) return null;
+  if (input.gate) return null;
+  if (withholdingDecides(input)) return null;
+  if (input.linkUnreachable) return null;
+  return readWeCouldNotReconcile(input);
 }
 
 export function badgeWithholding(input: VendorVerdictInput): BadgeWithholding | null {
@@ -120,6 +146,8 @@ export function badgeWithholding(input: VendorVerdictInput): BadgeWithholding | 
     return { reason: input.levelWithheld ?? "no_source" };
   }
   if (input.gate) return { reason: "gated", gate: input.gate };
+  const unreconciled = refusalWithholdsStability(input);
+  if (unreconciled) return { reason: "read_not_reconciled", refusedOn: unreconciled.refused_date };
   if (input.level === null) return { reason: input.levelWithheld ?? "no_source" };
   if (input.linkUnreachable && publishedVendorLevel(input.level, input.cause) === "stable") {
     return { reason: "link_unreachable" };
@@ -210,6 +238,11 @@ export function vendorVerdictSentence(input: VendorVerdictInput): string {
     const clause = withheldLevelClause(input.levelWithheld, input.unconfirmableSince);
     return `${clause.charAt(0).toUpperCase()}${clause.slice(1)}, so we cannot confirm these terms today.`;
   }
+  const unreconciled = refusalWithholdsStability(input);
+  if (unreconciled) {
+    return `${capitalise(unreconciledReadClause(unreconciled.refused_date))}, so we are not rating this offer today.`;
+  }
+
   const level = publishedVendorLevel(input.level, input.cause);
   if (input.gate || level === null) return vendorHistorySentence(input.vendor, input.historyLevel, input.cause);
 
@@ -220,6 +253,11 @@ export function vendorVerdictSentence(input: VendorVerdictInput): string {
     return `We rate it ${level} — one recorded ${changeKindNoun(input.cause.change_type)}, ${changeDateClause(input.cause)}.${unconfirmed}`;
   }
 
-  if (input.changes.length === 0) return `It's stable — zero pricing changes recorded.`;
+  if (input.changes.length === 0) {
+    const confirmed = confirmingRead(input.refusedReads ?? []);
+    return confirmed
+      ? `It's stable — ${confirmingReadClause(confirmed)}.`
+      : `It's stable — zero pricing changes recorded.`;
+  }
   return `We rate it stable. ${narrowingSentence(input.changes, { vendor: input.vendor, tier: input.tier })}`;
 }

--- a/test/badge-withholding.test.ts
+++ b/test/badge-withholding.test.ts
@@ -44,6 +44,7 @@ const WITHHELD_LABELS: Record<string, string> = {
   offer_expired: "unrated — offer expired",
   offer_retired: "unrated — offer ended",
   verification_lapsed: "unrated — not re-confirmed",
+  read_not_reconciled: "unrated — change not reconciled",
 };
 
 const WITHHELD_LABEL_SET = new Set(Object.values(WITHHELD_LABELS));
@@ -84,7 +85,7 @@ function badgeColor(svg: string): string {
 }
 
 before(async () => {
-  const { loadOffers, loadDealChanges, enrichOffers } = await import("../dist/data.js");
+  const { loadOffers, loadDealChanges, enrichOffers, publishedRisk, refusalsForVendor } = await import("../dist/data.js");
   const { vendorSlugMap } = await import("../dist/vendor-slug.js");
   const { levelWithheldReason } = await import("../dist/source-check.js");
   const { vendorBadge } = await import("../dist/vendor-verdict.js");
@@ -109,11 +110,14 @@ before(async () => {
       risk_level: string | null; risk_cause: never; rating_withheld: never; link_unreachable: unknown;
     };
     const levelWithheld = levelWithheldReason(primary, e.link_unreachable);
+    const vendorChanges = changes.filter((c: { vendor: string }) => c.vendor.toLowerCase() === vendor.toLowerCase());
     const badge = vendorBadge({
       vendor,
       level: e.risk_level as never,
+      historyLevel: publishedRisk(primary, vendorChanges, servedOn, nowMs).history_level,
       cause: e.risk_cause,
-      changes: changes.filter((c: { vendor: string }) => c.vendor.toLowerCase() === vendor.toLowerCase()),
+      changes: vendorChanges,
+      refusedReads: refusalsForVendor(vendor),
       levelWithheld,
       unconfirmableSince: "",
       ratingWithheld: e.rating_withheld,

--- a/test/compare-free-tier-claim.test.ts
+++ b/test/compare-free-tier-claim.test.ts
@@ -86,6 +86,7 @@ before(async () => {
   const { gateFor, utcDate } = await import("../dist/ranking.js");
   const { levelWithheldReason, levelWithheldSince, withheldLevelSentence } = await import("../dist/source-check.js");
   const { ratingWithheldForNoSourceSentence } = await import("../dist/change-citation.js");
+  const { unreconciledReadSentence } = await import("../dist/change-refusal.js");
 
   const offers = loadOffers();
   const changes = loadDealChanges();
@@ -112,9 +113,11 @@ before(async () => {
     const unreachable = enriched.link_unreachable;
     const withheld = levelWithheldReason(primary, unreachable);
     const since = levelWithheldSince(primary, unreachable);
+    const refusedRead = enriched.refused_read;
     const reasonsItCouldGive = [
       gateFor(primary, servedOn)?.reason,
       withheld ? withheldLevelSentence(withheld, vendor, since) : null,
+      refusedRead ? unreconciledReadSentence(vendor, refusedRead.refused_date) : null,
       ratingWithheldForNoSourceSentence(vendor),
     ].filter((r): r is string => typeof r === "string" && r !== "");
 

--- a/test/comparison-verdict.test.ts
+++ b/test/comparison-verdict.test.ts
@@ -275,6 +275,7 @@ function sideFor(vendor: string): ComparisonSide | null {
     recordedChanges: countFor(vendor),
     rating: (e.risk_cause || e.risk_level === "stable" ? e.risk_level : null) as ComparisonSide["rating"],
     ratingWithheldBecause: levelWithheldReason(e, e.link_unreachable),
+    refusedRead: e.refused_read,
     unconfirmableSince: levelWithheldSince(e, e.link_unreachable),
   };
 }

--- a/test/enrich.test.ts
+++ b/test/enrich.test.ts
@@ -36,12 +36,15 @@ describe("enrichOffers", () => {
     const { enrichOffers, loadOffers } = await import("../dist/data.js");
     const offers = loadOffers();
 
-    const { loadDealChanges } = await import("../dist/data.js");
+    const { loadChangeRefusals, loadDealChanges } = await import("../dist/data.js");
     const changes = loadDealChanges();
     const changedVendors = new Set(changes.map((c: { vendor: string }) => c.vendor.toLowerCase()));
+    const refusedVendors = new Set(loadChangeRefusals().map((r: { vendor: string }) => r.vendor.toLowerCase()));
 
-    const stableOffer = offers.find((o: { vendor: string }) => !changedVendors.has(o.vendor.toLowerCase()));
-    assert.ok(stableOffer, "Should find at least one vendor with no changes");
+    const stableOffer = offers.find(
+      (o: { vendor: string }) => !changedVendors.has(o.vendor.toLowerCase()) && !refusedVendors.has(o.vendor.toLowerCase()),
+    );
+    assert.ok(stableOffer, "Should find at least one vendor with no changes and no refused read");
 
     const enriched = enrichOffers([stableOffer]);
     assert.strictEqual(enriched[0].risk_level, "stable");
@@ -118,8 +121,8 @@ describe("enrichOffers", () => {
     const { levelWithheldReason } = await import("../dist/source-check.js");
     const withheld = enrichOffers(loadOffers()).filter((o: { risk_level: string | null }) => o.risk_level === null);
     const unexplained = withheld.filter(
-      (o: { link_unreachable: unknown; rating_withheld: unknown; gate: unknown }) =>
-        !levelWithheldReason(o as never, o.link_unreachable) && !o.rating_withheld && !o.gate
+      (o: { link_unreachable: unknown; rating_withheld: unknown; gate: unknown; refused_read: unknown }) =>
+        !levelWithheldReason(o as never, o.link_unreachable) && !o.rating_withheld && !o.gate && !o.refused_read
     );
     assert.strictEqual(unexplained.length, 0, `${unexplained.length} offers publish no level and no reason for withholding it`);
   });

--- a/test/refused-change-not-stable.test.ts
+++ b/test/refused-change-not-stable.test.ts
@@ -1,0 +1,233 @@
+import { describe, it, before, after } from "node:test";
+import assert from "node:assert";
+import { spawn, type ChildProcess } from "node:child_process";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { assertCoversPopulation, assertPopulationFloor, vendorsInTheCatalogue } from "./population-floor.ts";
+import { GATE_REASONS } from "../scripts/change-gate.js";
+import { SUPPRESSED_SAME_TRANSITION_REGRADED } from "../scripts/change-log.js";
+import { REFUSAL_REASONS_THAT_CONFIRM_THE_STORED_TERMS } from "../dist/change-refusal.js";
+import { enrichOffers, loadChangeRefusals, loadDealChanges, loadOffers } from "../dist/data.js";
+import { vendorSlugMap } from "../dist/vendor-slug.js";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO = path.join(__dirname, "..");
+
+const STABILITY_CLAIMS: Array<{ name: string; pattern: RegExp }> = [
+  { name: "zero changes recorded", pattern: /It's stable — zero pricing changes recorded/ },
+  { name: "positive stability signal", pattern: /positive stability signal/ },
+  { name: "no recorded pricing changes", pattern: /has had no recorded pricing changes/ },
+  { name: "rated stable", pattern: /We rate it stable/ },
+  { name: "considered stable", pattern: /is considered stable/ },
+  { name: "stable badge", pattern: /class="risk-badge"[^>]*>stable</ },
+];
+
+const CONFIRMING = new Set<string>(REFUSAL_REASONS_THAT_CONFIRM_THE_STORED_TERMS);
+
+const WITHHELD_FOR_A_REFUSAL = /we found a change we could not reconcile with the terms we publish/;
+
+interface Subject {
+  slug: string;
+  vendor: string;
+  reasons: string[];
+  unreconciled: boolean;
+  confirmingOnly: boolean;
+  published: number;
+}
+
+let subjects: Subject[] = [];
+let serverPort = 0;
+let proc: ChildProcess | null = null;
+const pages = new Map<string, string>();
+
+function startHttpServer(): Promise<{ child: ChildProcess; port: number }> {
+  return new Promise((resolve, reject) => {
+    const child = spawn("node", [path.join(REPO, "dist", "serve.js")], {
+      stdio: ["pipe", "pipe", "pipe"],
+      env: { ...process.env, PORT: "0", BASE_URL: "http://localhost" },
+    });
+    const timeout = setTimeout(() => { child.kill(); reject(new Error("Server startup timeout")); }, 30000);
+    child.stderr!.on("data", (data: Buffer) => {
+      const m = data.toString().match(/running on http:\/\/localhost:(\d+)/);
+      if (m) { clearTimeout(timeout); resolve({ child, port: parseInt(m[1], 10) }); }
+    });
+    child.on("error", (err) => { clearTimeout(timeout); reject(err); });
+  });
+}
+
+before(async () => {
+  const refusals = loadChangeRefusals();
+  const changes = loadDealChanges();
+  const published = new Map<string, number>();
+  for (const change of changes) {
+    const key = change.vendor.toLowerCase();
+    published.set(key, (published.get(key) ?? 0) + 1);
+  }
+  const held = new Map<string, string[]>();
+  for (const refusal of refusals) {
+    const key = refusal.vendor.toLowerCase();
+    const list = held.get(key) ?? [];
+    list.push(refusal.reason);
+    held.set(key, list);
+  }
+
+  subjects = [...vendorSlugMap.entries()].map(([slug, vendor]) => {
+    const reasons = held.get(vendor.toLowerCase()) ?? [];
+    const count = published.get(vendor.toLowerCase()) ?? 0;
+    return {
+      slug,
+      vendor,
+      reasons,
+      published: count,
+      unreconciled: count === 0 && reasons.some(r => !CONFIRMING.has(r)),
+      confirmingOnly: count === 0 && reasons.length > 0 && reasons.every(r => CONFIRMING.has(r)),
+    };
+  });
+
+  const started = await startHttpServer();
+  proc = started.child;
+  serverPort = started.port;
+
+  let queue = 0;
+  const worker = async () => {
+    while (queue < subjects.length) {
+      const { slug } = subjects[queue++];
+      const res = await fetch(`http://localhost:${serverPort}/vendor/${slug}`);
+      assert.strictEqual(res.status, 200, `/vendor/${slug} returned ${res.status}`);
+      pages.set(slug, await res.text());
+    }
+  };
+  await Promise.all(Array.from({ length: 12 }, worker));
+});
+
+after(() => { if (proc) proc.kill(); });
+
+const claimsOn = (slug: string): string[] =>
+  STABILITY_CLAIMS.filter(c => c.pattern.test(pages.get(slug) ?? "")).map(c => c.name);
+
+describe("a refused change is not a signal that nothing changed", () => {
+  it("publishes no stability claim on a vendor whose last read we could not reconcile", () => {
+    const claiming: string[] = [];
+    let swept = 0;
+    for (const subject of subjects) {
+      swept++;
+      if (!subject.unreconciled) continue;
+      const claims = claimsOn(subject.slug);
+      if (claims.length > 0) claiming.push(`/vendor/${subject.slug}: ${claims.join(", ")}`);
+    }
+    assert.deepStrictEqual(claiming.slice(0, 20), [], `stability claimed over a read we refused:\n${claiming.slice(0, 20).join("\n")}`);
+    assertCoversPopulation(swept, vendorsInTheCatalogue(), "vendor pages read for a stability claim");
+    assertPopulationFloor(subjects.filter(s => s.unreconciled).length, 100, "vendors hold a refused read and no published change");
+  });
+
+  it("keeps the rating where the refusal is itself a finding that the terms held", () => {
+    const taken: string[] = [];
+    for (const subject of subjects.filter(s => s.confirmingOnly)) {
+      if (WITHHELD_FOR_A_REFUSAL.test(pages.get(subject.slug) ?? "")) taken.push(`/vendor/${subject.slug}`);
+    }
+    assert.deepStrictEqual(taken, [], `a refusal that confirms our terms took the rating with it:\n${taken.join("\n")}`);
+    for (const slug of ["activepieces", "assemblyai"]) {
+      const subject = subjects.find(s => s.slug === slug);
+      assert.ok(subject?.confirmingOnly, `/vendor/${slug} no longer holds only refusals that confirm our terms`);
+      assert.ok(claimsOn(slug).length > 0, `/vendor/${slug} publishes no rating, and its refusal is a finding that the terms held`);
+    }
+    assert.ok(
+      subjects.some(s => s.confirmingOnly && s.reasons.includes("free_tier_still_offered")),
+      "no vendor's free tier was found still on the page, so that half of the exception is untested",
+    );
+    assert.ok(
+      subjects.some(s => s.confirmingOnly && s.reasons.includes("confirmed_unchanged")),
+      "no vendor's proposed change was found to restate our terms, so that half of the exception is untested",
+    );
+  });
+
+  it("stops telling a reader no change was recorded wherever we refused one", () => {
+    const asserting: string[] = [];
+    for (const subject of subjects.filter(s => s.reasons.length > 0 && s.published === 0)) {
+      const page = pages.get(subject.slug) ?? "";
+      if (/zero pricing changes recorded/.test(page)) asserting.push(`/vendor/${subject.slug}`);
+      if (/has had no recorded pricing changes/.test(page)) asserting.push(`/vendor/${subject.slug} (FAQ)`);
+    }
+    assert.deepStrictEqual(asserting.slice(0, 20), [], `pages still counting our refusals as nothing:\n${asserting.slice(0, 20).join("\n")}`);
+  });
+
+  it("leaves a vendor with a published change and no refusal exactly as it was", () => {
+    const unaffected = subjects.filter(s => s.reasons.length === 0 && s.published > 0);
+    assert.ok(unaffected.length > 0, "no vendor carries a published change and no refusal, so the control is empty");
+    const dub = subjects.find(s => s.slug === "dub-co");
+    assert.ok(dub, "the catalogue no longer holds the record this control was written against");
+    assert.ok(dub.published > 0, "dub-co no longer carries a published change");
+    assert.match(pages.get("dub-co") ?? "", /We rate it caution/);
+  });
+
+  it("names the reason on every rating it withholds for a refused read", () => {
+    const silent: string[] = [];
+    for (const subject of subjects.filter(s => s.unreconciled)) {
+      const page = pages.get(subject.slug) ?? "";
+      if (!/we found a change we could not reconcile with the terms we publish/.test(page)) {
+        silent.push(`/vendor/${subject.slug}`);
+      }
+    }
+    assert.deepStrictEqual(silent.slice(0, 20), [], `ratings withheld with nothing saying why:\n${silent.slice(0, 20).join("\n")}`);
+  });
+
+  it("publishes none of the records it refused", () => {
+    const published = new Set(
+      loadDealChanges().map(c => `${c.vendor.toLowerCase()}|${c.change_type}|${(c.summary ?? "").trim()}`),
+    );
+    const refusals = loadChangeRefusals().filter(r => r.reason !== SUPPRESSED_SAME_TRANSITION_REGRADED);
+    const admitted = refusals
+      .filter(r => published.has(`${r.vendor.toLowerCase()}|${r.change_type}|${(r.summary ?? "").trim()}`))
+      .map(r => `${r.vendor} (${r.reason})`);
+    assert.deepStrictEqual(admitted, [], `a refused record reached the published log:\n${admitted.join("\n")}`);
+    assertPopulationFloor(refusals.length, 180, "records were refused and checked against the published log");
+    for (const vendor of ["Tavily AI", "Reducto"]) {
+      assert.ok(
+        refusals.some(r => r.vendor === vendor && r.reason === "removal_read_from_root"),
+        `${vendor} no longer holds the refusal this control was written against`,
+      );
+    }
+  });
+
+  it("goes on offering the free tier of a vendor whose removal the absence rule refused", () => {
+    const offers = loadOffers();
+    const ended: string[] = [];
+    for (const vendor of ["Activepieces", "Integrately", "Mergify"]) {
+      const own = offers.filter(o => o.vendor === vendor);
+      assert.ok(own.length > 0, `${vendor} is no longer in the catalogue this control was written against`);
+      assert.ok(
+        loadChangeRefusals().some(r => r.vendor === vendor),
+        `${vendor} no longer holds the refusal this control was written against`,
+      );
+      for (const row of enrichOffers(own)) {
+        if (row.risk_cause?.change_type === "free_tier_removed") ended.push(vendor);
+      }
+    }
+    assert.deepStrictEqual(ended, [], `a free tier the page still offers is published as removed:\n${ended.join("\n")}`);
+  });
+});
+
+describe("the refusal log and the rules that write it read the same vocabulary", () => {
+  const refusalLog = () =>
+    JSON.parse(readFileSync(process.env.AGENTDEALS_REFUSALS_PATH || path.join(REPO, "data", "change_refusals.json"), "utf-8")).refusals as Array<{ reason: string }>;
+
+  const REASONS_A_RULE_CAN_WRITE = new Set<string>([...GATE_REASONS, SUPPRESSED_SAME_TRANSITION_REGRADED]);
+
+  it("holds no refusal under a reason no rule can write", () => {
+    const known = REASONS_A_RULE_CAN_WRITE;
+    const unknown = [...new Set(refusalLog().map(r => r.reason))].filter(r => !known.has(r));
+    assert.deepStrictEqual(unknown, [], `refusal reasons no gate rule writes: ${unknown.join(", ")}`);
+  });
+
+  it("draws every reason it treats as a confirmation from that same vocabulary", () => {
+    const known = REASONS_A_RULE_CAN_WRITE;
+    const stray = REFUSAL_REASONS_THAT_CONFIRM_THE_STORED_TERMS.filter(r => !known.has(r));
+    assert.deepStrictEqual(stray, [], `reasons kept as confirmations that no gate rule writes: ${stray.join(", ")}`);
+  });
+
+  it("treats a reason it has never seen as one it could not reconcile", () => {
+    const invented = "a_rule_no_gate_writes";
+    assert.ok(!CONFIRMING.has(invented), "an unclassified reason is read as a confirmation");
+  });
+});

--- a/test/refused-change-not-stable.test.ts
+++ b/test/refused-change-not-stable.test.ts
@@ -270,6 +270,23 @@ describe("a refused change is not a signal that nothing changed", () => {
     assert.deepStrictEqual(silent.slice(0, 10), [], `the risk summary still reads as a stable history:\n${silent.slice(0, 10).join("\n")}`);
   });
 
+  it("publishes the day of a refused read and none of its prose", async () => {
+    const payload = await (await fetch(`http://localhost:${serverPort}/api/offers?limit=2000`)).json() as {
+      offers: Array<{ vendor: string; refused_read: Record<string, unknown> | null }>;
+      _provenance: { verified_records: number; withheld_records?: number };
+    };
+    const published = payload.offers.filter(row => row.refused_read);
+    assert.ok(published.length > 0, "no row carries a refused read, so the field is untested");
+    const fields = new Set(published.flatMap(row => Object.keys(row.refused_read!)));
+    assert.deepStrictEqual(
+      [...fields].sort(),
+      ["reason", "refused_date"],
+      "the refusal record reaches the API beyond the day it was refused and the rule that refused it",
+    );
+    const counted = payload._provenance.verified_records + (payload._provenance.withheld_records ?? 0);
+    assert.strictEqual(counted, payload.offers.length, "the provenance block counts a record the response does not return");
+  });
+
   it("publishes none of the records it refused", () => {
     const published = new Set(
       loadDealChanges().map(c => `${c.vendor.toLowerCase()}|${c.change_type}|${(c.summary ?? "").trim()}`),

--- a/test/refused-change-not-stable.test.ts
+++ b/test/refused-change-not-stable.test.ts
@@ -7,8 +7,8 @@ import { fileURLToPath } from "node:url";
 import { assertCoversPopulation, assertPopulationFloor, vendorsInTheCatalogue } from "./population-floor.ts";
 import { GATE_REASONS } from "../scripts/change-gate.js";
 import { SUPPRESSED_SAME_TRANSITION_REGRADED } from "../scripts/change-log.js";
-import { REFUSAL_REASONS_THAT_CONFIRM_THE_STORED_TERMS } from "../dist/change-refusal.js";
-import { enrichOffers, loadChangeRefusals, loadDealChanges, loadOffers } from "../dist/data.js";
+import { readNotReconciled, REFUSAL_REASONS_THAT_CONFIRM_THE_STORED_TERMS, UNRECONCILED_READ_BADGE_LABEL } from "../dist/change-refusal.js";
+import { checkVendorRisk, enrichOffers, loadChangeRefusals, loadDealChanges, loadOffers } from "../dist/data.js";
 import { vendorSlugMap } from "../dist/vendor-slug.js";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -23,6 +23,16 @@ const STABILITY_CLAIMS: Array<{ name: string; pattern: RegExp }> = [
   { name: "stable badge", pattern: /class="risk-badge"[^>]*>stable</ },
 ];
 
+const A_STABLE_HISTORY = /has a stable pricing history/;
+
+const verdictParagraphOf = (html: string): string =>
+  html.match(/<div class="quick-verdict">\s*<p>([\s\S]*?)<\/p>/)?.[1] ?? "";
+
+const badgeLabelOf = (svg: string): string => {
+  const title = svg.match(/<title>([\s\S]*?)<\/title>/)?.[1] ?? "";
+  return (title.split(": ").slice(1).join(": ").split(" · ")[0] ?? "").trim();
+};
+
 const CONFIRMING = new Set<string>(REFUSAL_REASONS_THAT_CONFIRM_THE_STORED_TERMS);
 
 const WITHHELD_FOR_A_REFUSAL = /we found a change we could not reconcile with the terms we publish/;
@@ -32,6 +42,7 @@ interface Subject {
   vendor: string;
   reasons: string[];
   unreconciled: boolean;
+  onlyTheRefusal: boolean;
   confirmingOnly: boolean;
   published: number;
 }
@@ -72,15 +83,25 @@ before(async () => {
     held.set(key, list);
   }
 
+  const offers = loadOffers();
+  const rowFor = new Map(enrichOffers(offers).map(row => [row.vendor, row]));
+
   subjects = [...vendorSlugMap.entries()].map(([slug, vendor]) => {
     const reasons = held.get(vendor.toLowerCase()) ?? [];
     const count = published.get(vendor.toLowerCase()) ?? 0;
+    const unreconciled = count === 0 && reasons.some(r => !CONFIRMING.has(r));
+    const row = rowFor.get(vendor);
+    const otherwiseWithheld = Boolean(
+      row?.gate || row?.rating_withheld || row?.link_unreachable
+      || (row?.source_check && row.source_check.outcome !== "ok"),
+    );
     return {
       slug,
       vendor,
       reasons,
       published: count,
-      unreconciled: count === 0 && reasons.some(r => !CONFIRMING.has(r)),
+      unreconciled,
+      onlyTheRefusal: unreconciled && !otherwiseWithheld,
       confirmingOnly: count === 0 && reasons.length > 0 && reasons.every(r => CONFIRMING.has(r)),
     };
   });
@@ -103,6 +124,31 @@ before(async () => {
 
 after(() => { if (proc) proc.kill(); });
 
+async function readResourceOverHttp(uri: string): Promise<string> {
+  const base = `http://localhost:${serverPort}/mcp`;
+  const accept = "application/json, text/event-stream";
+  const init = await fetch(base, {
+    method: "POST",
+    headers: { "Content-Type": "application/json", Accept: accept },
+    body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "initialize", params: { protocolVersion: "2025-06-18", capabilities: {}, clientInfo: { name: "test", version: "1.0.0" } } }),
+  });
+  const session = init.headers.get("mcp-session-id") ?? "";
+  const headers = { "Content-Type": "application/json", Accept: accept, "Mcp-Session-Id": session };
+  await fetch(base, { method: "POST", headers, body: JSON.stringify({ jsonrpc: "2.0", method: "notifications/initialized" }) });
+  const res = await fetch(base, {
+    method: "POST",
+    headers,
+    body: JSON.stringify({ jsonrpc: "2.0", id: 2, method: "resources/read", params: { uri } }),
+  });
+  const text = await res.text();
+  const line = text.split("\n").find((l) => l.startsWith("data: ")) ?? text;
+  const payload = JSON.parse(line.replace(/^data: /, "")) as { result?: { contents?: Array<{ text?: string }> } };
+  return payload.result?.contents?.[0]?.text ?? "";
+}
+
+const stabilityLineOf = (resource: string): string =>
+  resource.split("\n").find(l => l.startsWith("**Stability:**")) ?? "";
+
 const claimsOn = (slug: string): string[] =>
   STABILITY_CLAIMS.filter(c => c.pattern.test(pages.get(slug) ?? "")).map(c => c.name);
 
@@ -119,6 +165,12 @@ describe("a refused change is not a signal that nothing changed", () => {
     assert.deepStrictEqual(claiming.slice(0, 20), [], `stability claimed over a read we refused:\n${claiming.slice(0, 20).join("\n")}`);
     assertCoversPopulation(swept, vendorsInTheCatalogue(), "vendor pages read for a stability claim");
     assertPopulationFloor(subjects.filter(s => s.unreconciled).length, 100, "vendors hold a refused read and no published change");
+
+    const history = subjects
+      .filter(s => s.onlyTheRefusal && A_STABLE_HISTORY.test(pages.get(s.slug) ?? ""))
+      .map(s => `/vendor/${s.slug}`);
+    assert.deepStrictEqual(history.slice(0, 20), [], `pages calling it a stable pricing history:\n${history.slice(0, 20).join("\n")}`);
+    assertPopulationFloor(subjects.filter(s => s.onlyTheRefusal).length, 80, "vendors have the refused read as the only reason we withhold");
   });
 
   it("keeps the rating where the refusal is itself a finding that the terms held", () => {
@@ -163,13 +215,59 @@ describe("a refused change is not a signal that nothing changed", () => {
 
   it("names the reason on every rating it withholds for a refused read", () => {
     const silent: string[] = [];
-    for (const subject of subjects.filter(s => s.unreconciled)) {
-      const page = pages.get(subject.slug) ?? "";
-      if (!/we found a change we could not reconcile with the terms we publish/.test(page)) {
-        silent.push(`/vendor/${subject.slug}`);
-      }
+    for (const subject of subjects.filter(s => s.onlyTheRefusal)) {
+      const verdict = verdictParagraphOf(pages.get(subject.slug) ?? "");
+      if (verdict === "") { silent.push(`/vendor/${subject.slug} renders no verdict paragraph`); continue; }
+      if (!WITHHELD_FOR_A_REFUSAL.test(verdict)) silent.push(`/vendor/${subject.slug}: ${verdict.slice(0, 120)}`);
     }
-    assert.deepStrictEqual(silent.slice(0, 20), [], `ratings withheld with nothing saying why:\n${silent.slice(0, 20).join("\n")}`);
+    assert.deepStrictEqual(silent.slice(0, 20), [], `verdicts withheld with nothing saying why:\n${silent.slice(0, 20).join("\n")}`);
+  });
+
+  it("gives the badge the same reason the page gives", async () => {
+    const wrong: string[] = [];
+    const withheld = subjects.filter(s => s.onlyTheRefusal);
+    let queue = 0;
+    const worker = async () => {
+      while (queue < withheld.length) {
+        const { slug } = withheld[queue++];
+        const res = await fetch(`http://localhost:${serverPort}/badge/${slug}.svg`);
+        if (res.status !== 200) { wrong.push(`/badge/${slug}.svg returned ${res.status}`); continue; }
+        const label = badgeLabelOf(await res.text());
+        if (label !== UNRECONCILED_READ_BADGE_LABEL) wrong.push(`/badge/${slug}.svg reads "${label}"`);
+      }
+    };
+    await Promise.all(Array.from({ length: 12 }, worker));
+    assert.deepStrictEqual(wrong.slice(0, 20), [], `badges naming the wrong reason:\n${wrong.slice(0, 20).join("\n")}`);
+    assertPopulationFloor(withheld.length, 80, "badges were read for the reason they withhold");
+  });
+
+  it("answers an agent the way it answers a reader, on either scale", async () => {
+    const withheld = subjects.filter(s => s.onlyTheRefusal).slice(0, 6);
+    assert.ok(withheld.length >= 3, "too few withheld vendors to read over MCP");
+    for (const subject of withheld) {
+      const line = stabilityLineOf(await readResourceOverHttp(`agentdeals://vendor/${subject.slug}`));
+      assert.ok(line !== "", `agentdeals://vendor/${subject.slug} publishes no stability line at all`);
+      assert.doesNotMatch(line, /\*\*Stability:\*\* stable/, `agentdeals://vendor/${subject.slug} calls it stable`);
+      assert.match(line, WITHHELD_FOR_A_REFUSAL, `agentdeals://vendor/${subject.slug} withholds without saying why`);
+    }
+    for (const subject of subjects.filter(s => s.confirmingOnly).slice(0, 3)) {
+      const line = stabilityLineOf(await readResourceOverHttp(`agentdeals://vendor/${subject.slug}`));
+      assert.doesNotMatch(line, WITHHELD_FOR_A_REFUSAL, `agentdeals://vendor/${subject.slug} lost its rating to a refusal that confirms our terms`);
+    }
+  });
+
+  it("gives the same answer in the risk summary an agent reads", () => {
+    const silent: string[] = [];
+    for (const subject of subjects.filter(s => s.unreconciled)) {
+      const answer = checkVendorRisk(subject.vendor) as { result?: { risk_level: string | null; summary: string } };
+      const result = answer.result;
+      if (!result) continue;
+      if (result.risk_level !== null) silent.push(`${subject.vendor} answers ${result.risk_level}`);
+      if (!subject.onlyTheRefusal) continue;
+      if (A_STABLE_HISTORY.test(result.summary)) silent.push(`${subject.vendor}: ${result.summary}`);
+      if (!WITHHELD_FOR_A_REFUSAL.test(result.summary)) silent.push(`${subject.vendor} summarises without saying why`);
+    }
+    assert.deepStrictEqual(silent.slice(0, 10), [], `the risk summary still reads as a stable history:\n${silent.slice(0, 10).join("\n")}`);
   });
 
   it("publishes none of the records it refused", () => {
@@ -224,6 +322,22 @@ describe("the refusal log and the rules that write it read the same vocabulary",
     const known = REASONS_A_RULE_CAN_WRITE;
     const stray = REFUSAL_REASONS_THAT_CONFIRM_THE_STORED_TERMS.filter(r => !known.has(r));
     assert.deepStrictEqual(stray, [], `reasons kept as confirmations that no gate rule writes: ${stray.join(", ")}`);
+  });
+
+  it("leaves a rating the records themselves earned alone", () => {
+    const refusals = [{ reason: "unquantified_limit", refused_date: "2026-09-11" }];
+    assert.notStrictEqual(
+      readNotReconciled({ historyLevel: "stable", publishedChanges: 0, refusals }),
+      null,
+      "a refused read over an otherwise stable history does not withhold",
+    );
+    for (const historyLevel of ["caution", "risky"]) {
+      assert.strictEqual(
+        readNotReconciled({ historyLevel, publishedChanges: 0, refusals }),
+        null,
+        `a refused read takes over a ${historyLevel} the records earned`,
+      );
+    }
   });
 
   it("treats a reason it has never seen as one it could not reconcile", () => {

--- a/test/stability.test.ts
+++ b/test/stability.test.ts
@@ -164,6 +164,13 @@ describe("enrichOffers includes stability", () => {
     const enriched = enrichOffers(results.slice(0, 5));
     for (const offer of enriched) {
       assert.ok("stability" in offer, "Should have stability field");
+      if (offer.stability === null) {
+        assert.ok(
+          offer.link_unreachable || offer.rating_withheld || offer.refused_read,
+          `${offer.vendor} publishes no stability class and nothing says why`
+        );
+        continue;
+      }
       assert.ok(
         ["stable", "watch", "volatile", "improving"].includes(offer.stability),
         `stability should be valid, got: ${offer.stability}`

--- a/test/vendor-verdict.test.ts
+++ b/test/vendor-verdict.test.ts
@@ -14,7 +14,7 @@ import {
   vendorVerdictWord,
   type VendorVerdictInput,
 } from "../dist/vendor-verdict.js";
-import { CHANGE_DIRECTION, enrichOffers, loadDealChanges, loadOffers, publishedRisk, vendorRiskAssessment, classifyStability } from "../dist/data.js";
+import { CHANGE_DIRECTION, enrichOffers, loadDealChanges, loadOffers, publishedRisk, refusalsForVendor, vendorRiskAssessment, classifyStability } from "../dist/data.js";
 import { vendorSlugMap } from "../dist/vendor-slug.js";
 import { isNoLongerInForce } from "../dist/change-resolution.js";
 import { levelWithheldReason, levelWithheldSince } from "../dist/source-check.js";
@@ -349,6 +349,7 @@ function vendorRows(): VendorRow[] {
         ratingWithheld: enriched.rating_withheld ?? null,
         offerEnded: ended,
         gate: gate?.code ?? null,
+        refusedReads: refusalsForVendor(vendor),
       }),
       tier: primary.tier,
       changes: vendorChanges,


### PR DESCRIPTION
Refs #1139.

## What was wrong

A refused change record is not a signal that nothing changed. It is a record that we read the vendor's page, found something, and could not decide what it was. **147 vendors held one with no published change, and 134 of their pages published an affirmative stability claim over it.**

Measured page by page against `main`, over those 147 vendor routes:

| claim | main | this branch |
|---|---|---|
| green `stable` badge beside the h1 | 129 | 0 |
| `It's stable — zero pricing changes recorded.` | 129 | 0 |
| `This is a positive stability signal.` | 129 | 0 |
| `No, X has had no recorded pricing changes.` | 134 | 0 |
| `We rate it stable and it offers …` | 129 | 0 |
| `X's free tier is considered stable.` | 129 | 0 |
| **pages carrying at least one of them** | **134** | **0** |

`/vendor/pubnub-com` published *"1 million transactions each month"* under a green `stable` badge, against a refusal recording *"The free tier now offers up to 200 Monthly Active Users (MAUs) instead of 1 million transactions."* It now says what it actually knows.

## What it does

`publishedRisk` gains a **fourth withholding condition** beside the gate, the uncited rating and the source check — AC-1 asks for a third condition on an existing mechanism, and this is that. Every surface that already reads `risk_level` follows with no list of surfaces to keep:

- **vendor page** — no badge, and the verdict reads *"When we last read the page we cite for this offer, on 2026-09-11, we found a change we could not reconcile with the terms we publish, so we are not rating this offer today."*
- **listing tables and `/best/*` cards** — swept 136 routes, 4,524 single-vendor blocks, 1,543 carrying a rating: **0 of them rate a withheld vendor**, and 35 still rate the vendors the exception keeps.
- **embeddable badge** — `unrated — change not reconciled`, in the title and the aria-label.
- **`/api/offers`** — `risk_level: null` with a new `refused_read` field naming the day, so a consumer is never told nothing without being told why.
- **comparison pages** — the side states the reason instead of the bare *"We are not publishing a stability rating for X."*
- **MCP over HTTP** — `agentdeals://vendor/lokalise` published `**Stability:** stable`; it now publishes the sentence. `compare_vendors` returned the summary *"Lokalise has a stable pricing history. Free tier verified for 45 days."* beside `risk_level: null`; it now returns the reason.

## AC-1's exception

`confirmed_unchanged` and `free_tier_still_offered` are findings that the terms held, not failures to decide. **31 vendors carry only those and keep the rating** — Activepieces and AssemblyAI among them. Their pages stop claiming zero records, because we hold one: *"It's stable — the change we last considered recording proposed removing a free tier the page still offers."*

## Two consequences worth reading before merging

**1. 124 free tiers move from vouched to unconfirmed.** `freeTierClaim` derives from the badge, so withholding the rating withholds the free-tier claim with it, exactly as every other withholding reason already does. `/state-of-free-tiers` moves from **752 vouched (49%)** to **628 (41%)**, and from 574 unconfirmed to 698. That is the honest reading — a change we could not reconcile may be about the free tier itself — but it is a visible headline number and it is a widening beyond AC-1's literal text.

**2. Two published sentences became false and are corrected here.** `/state-of-free-tiers` enumerated the reasons a free tier is unconfirmed — *"states no price we can read, cannot be read at all, or does not name the vendor"* — and that list was now short one reason. `/criteria` said *"`stable` means we hold no record of a free tier removal, a limit reduction or a pricing restructure for that vendor"*, which is no longer the whole rule. Both now name the refused read.

## Left for follow-ups, deliberately

- **AC-3 and AC-6** are not in this PR. AC-3 changes the gate, which regenerates data and risks re-opening #1134; AC-6 needs a fresh read of lokalise.com/pricing to decide the replacement terms, which is #1114's queue. This PR is the rendering fix the issue says the general defect is.
- **AC-4 and AC-5 hold by construction** here, since no gate rule changed, and are asserted anyway: no refused record's own summary appears in the published log, and Activepieces, Integrately and Mergify still publish a live free tier.

## Tests

`test/refused-change-not-stable.test.ts` — the sweep runs over **every vendor route in the catalogue**, not a sample, via `assertCoversPopulation`. It asserts no stability claim on the withheld population, the rating kept on the exception, a reason named on every withheld rating, no refused record in the published log, and that every reason the refusal log holds is one a rule can actually write — a guard against `src/` and `scripts/` drifting apart, since `src/` cannot import `scripts/`.

Five existing test files needed their fixtures given the new input; each of them rebuilds `VendorVerdictInput` by hand and so had gone quietly out of step with what the server builds.

## Mutation

12 mutants, **12 killed by a test.** The first round killed 9; the three survivors were real gaps and are the reason for the second commit:

| survivor | what it published | what now catches it |
|---|---|---|
| the verdict drops its refusal branch | falls through to *"Lokalise has a stable pricing history."* — a phrase the claim list did not carry | the `quick-verdict` paragraph is extracted and asserted, not the page |
| the badge reports `no_source` instead | the badge withheld, but under the wrong reason, and nothing read the label | the badge title is asserted per slug against the withheld population |
| an adverse history is withheld too | nothing — `historyLevel !== "stable"` cannot hold while `publishedChanges === 0`, since the level is derived from those changes | a direct unit test on the predicate, which is the only path that reaches it |

The first two are one mistake: a page-wide regex cannot see which paragraph made the claim.

## One more movement, measured

`stability` — the second, four-valued scale (`stable` / `watch` / `volatile` / `improving`) — has been nullable since an unresolving link started withholding it. A refused read withholds it on the same grounds, which is what makes `agentdeals://vendor/lokalise` stop publishing `**Stability:** stable`. **149 records now hold no class for that reason alone, of 184 holding none at all.**

`test/stability.test.ts` asserted the field is always one of the four words. That had been passing on the five records its search happened to draw rather than on the field's type; it now asserts what the rest of the codebase asserts, that a withheld value names the reason it was withheld.

## Where the refusals sit in time

The rule is *any* unreconciled refusal withholds, not *the latest read* wins. Six vendors hold both a confirming and an unreconciled refusal, and on all six the unreconciled one is the newer — so on today's data the two rules agree and no vendor is withheld on a refusal a later read has already answered.

## A leak the response's own accounting caught

`RefusedRead` is `Pick<ChangeRefusal, "reason" | "refused_date">` — a type, not a runtime projection. The object reaching `refused_read` on `/api/offers` was the **whole refusal record**: its summary, its previous and current state, the URL it was read from. 149 rows of internal text, on an issue whose own criterion says the refusals are not what we publish.

`test/superseded-terms-listings.test.ts` is what found it, and not by looking at the field. `citedRecords` walks a payload for anything carrying a vendor name, so each leaked refusal counted as a second record and `verified_records + withheld_records` came to **1,694 against 1,547 rows returned**. The field set is now pinned by a test that reads it off the response, beside an assertion that the provenance block counts exactly the rows the response carries.