### PR TITLE
State the reason a refusal withholds, not one the refusal contradicts

### DIFF
--- a/src/change-refusal.ts
+++ b/src/change-refusal.ts
@@ -31,10 +31,24 @@ const CONFIRMING_REASON_CLAUSES: Record<ConfirmingRefusalReason, string> = {
     "the change we last considered recording proposed removing a free tier the page still offers",
 };
 
+export const REFUSAL_REASONS_THAT_MEASURED_NO_DIFFERENCE = [
+  "measures_no_change",
+  "states_no_difference",
+  "null_comparison",
+] as const;
+
+const MEASURED_NO_DIFFERENCE_REASONS = new Set<string>(
+  REFUSAL_REASONS_THAT_MEASURED_NO_DIFFERENCE,
+);
+
 export type RefusedRead = Pick<ChangeRefusal, "reason" | "refused_date">;
 
 export function refusalConfirmsTheStoredTerms(refusal: Pick<ChangeRefusal, "reason">): boolean {
   return CONFIRMING_REASONS.has(refusal.reason);
+}
+
+export function refusalMeasuredNoDifference(refusal: Pick<ChangeRefusal, "reason">): boolean {
+  return MEASURED_NO_DIFFERENCE_REASONS.has(refusal.reason);
 }
 
 function mostRecent(refusals: readonly RefusedRead[]): RefusedRead | null {
@@ -45,8 +59,10 @@ function mostRecent(refusals: readonly RefusedRead[]): RefusedRead | null {
   return held === null ? null : { reason: held.reason, refused_date: held.refused_date };
 }
 
-export function unreconciledRead(refusals: readonly RefusedRead[]): RefusedRead | null {
-  return mostRecent(refusals.filter(r => !refusalConfirmsTheStoredTerms(r)));
+export function refusedReadThatWithholds(refusals: readonly RefusedRead[]): RefusedRead | null {
+  const withholding = refusals.filter(r => !refusalConfirmsTheStoredTerms(r));
+  const unreconciled = withholding.filter(r => !refusalMeasuredNoDifference(r));
+  return mostRecent(unreconciled.length > 0 ? unreconciled : withholding);
 }
 
 export interface StabilityEvidence {
@@ -55,10 +71,10 @@ export interface StabilityEvidence {
   refusals: readonly RefusedRead[];
 }
 
-export function readNotReconciled(state: StabilityEvidence): RefusedRead | null {
+export function refusedReadWithholdingStability(state: StabilityEvidence): RefusedRead | null {
   if (state.historyLevel !== "stable") return null;
   if (state.publishedChanges > 0) return null;
-  return unreconciledRead(state.refusals);
+  return refusedReadThatWithholds(state.refusals);
 }
 
 export function confirmingRead(refusals: readonly RefusedRead[]): RefusedRead | null {
@@ -81,6 +97,7 @@ export function confirmingReadSentence(subject: string, refusal: RefusedRead): s
 }
 
 export const UNRECONCILED_READ_BADGE_LABEL = "unrated — change not reconciled";
+export const MEASURED_NO_DIFFERENCE_BADGE_LABEL = "unrated — change refused";
 
 export function unreconciledReadClause(refusedOn: string): string {
   return `when we last read the page we cite for this offer, on ${refusedOn},`
@@ -90,6 +107,30 @@ export function unreconciledReadClause(refusedOn: string): string {
 export function unreconciledReadSentence(subject: string, refusedOn: string): string {
   return `When we last read the page we cite for ${subject}, on ${refusedOn},`
     + ` we found a change we could not reconcile with the terms we publish for it.`;
+}
+
+export function measuredNoDifferenceClause(refusedOn: string): string {
+  return `when we last read the page we cite for this offer, on ${refusedOn},`
+    + ` we refused the change we considered recording because it named no figure that had moved,`
+    + ` and refusing a change is not a confirmation of the terms above`;
+}
+
+export function measuredNoDifferenceSentence(subject: string, refusedOn: string): string {
+  return `When we last read the page we cite for ${subject}, on ${refusedOn},`
+    + ` we refused the change we considered recording because it named no figure that had moved,`
+    + ` and refusing a change is not a confirmation of the terms we publish for it.`;
+}
+
+export function refusedReadClause(refusal: RefusedRead): string {
+  return refusalMeasuredNoDifference(refusal)
+    ? measuredNoDifferenceClause(refusal.refused_date)
+    : unreconciledReadClause(refusal.refused_date);
+}
+
+export function refusedReadSentence(subject: string, refusal: RefusedRead): string {
+  return refusalMeasuredNoDifference(refusal)
+    ? measuredNoDifferenceSentence(subject, refusal.refused_date)
+    : unreconciledReadSentence(subject, refusal.refused_date);
 }
 
 export function refusalsByVendor(

--- a/src/comparison-verdict.ts
+++ b/src/comparison-verdict.ts
@@ -1,5 +1,5 @@
 import { withheldLevelSentence, type LevelWithheldReason } from "./source-check.js";
-import { unreconciledReadSentence, type RefusedRead } from "./change-refusal.js";
+import { refusedReadSentence, type RefusedRead } from "./change-refusal.js";
 
 export type StabilityRating = "stable" | "caution" | "risky";
 
@@ -33,7 +33,7 @@ function whyWithheld(side: ComparisonSide): string {
   if (side.ratingWithheldBecause) {
     return withheldLevelSentence(side.ratingWithheldBecause, side.vendor, side.unconfirmableSince);
   }
-  if (side.refusedRead) return unreconciledReadSentence(side.vendor, side.refusedRead.refused_date);
+  if (side.refusedRead) return refusedReadSentence(side.vendor, side.refusedRead);
   return `We are not publishing a stability rating for ${side.vendor}.`;
 }
 

--- a/src/data.ts
+++ b/src/data.ts
@@ -31,9 +31,9 @@ import { endedVerdictSentence } from "./retirement.js";
 import { resolveCategoryName } from "./category-scope.js";
 import { survivingVendorName } from "./vendor-merges.js";
 import {
-  readNotReconciled,
+  refusedReadSentence,
+  refusedReadWithholdingStability,
   refusalsByVendor as groupRefusalsByVendor,
-  unreconciledReadSentence,
   type ChangeRefusal,
   type ChangeRefusalIndex,
   type RefusedRead,
@@ -418,7 +418,7 @@ export function stabilityWithheldSentence(vendorName: string): string {
   if (!offer) return vendorNotIndexedSentence(vendorName);
   const vendorChanges = loadDealChanges().filter((c) => c.vendor.toLowerCase() === vendorName.toLowerCase());
   const risk = publishedRisk(offer, vendorChanges);
-  if (risk.refused_read) return unreconciledReadSentence(vendorName, risk.refused_read.refused_date);
+  if (risk.refused_read) return refusedReadSentence(vendorName, risk.refused_read);
   if (risk.link_unreachable) return withheldLevelSentence("link_unreachable", vendorName, risk.link_unreachable.last_reachable ? LAST_RESOLVED(risk.link_unreachable.last_reachable) : "");
   return ratingWithheldForNoSourceSentence(vendorName);
 }
@@ -1007,7 +1007,7 @@ export function publishedRisk(
   const assessment = vendorRiskAssessment(changesRatingTheListedTier(offer, vendorChanges), nowMs);
   const link_unreachable = unreachableNoticeForUrl(offer.url, nowMs);
   const gate = gateFor(offer, servedOn);
-  const refused_read = readNotReconciled({
+  const refused_read = refusedReadWithholdingStability({
     historyLevel: assessment.level,
     publishedChanges: publishedChangeCount(offer.vendor),
     refusals: refusalsForVendor(offer.vendor),
@@ -1040,7 +1040,7 @@ export function levelWithheldStatement(vendor: string, risk: PublishedRisk): str
   if (risk.rating_withheld) return ratingWithheldForNoSourceSentence(vendor);
   const reason = levelWithheldReason({ source_check: risk.source_check ?? undefined }, risk.link_unreachable);
   if (!reason) {
-    return risk.refused_read ? unreconciledReadSentence(vendor, risk.refused_read.refused_date) : null;
+    return risk.refused_read ? refusedReadSentence(vendor, risk.refused_read) : null;
   }
   const since = levelWithheldSince({ source_check: risk.source_check ?? undefined }, risk.link_unreachable);
   return withheldLevelSentence(reason, vendor, since);
@@ -1123,7 +1123,7 @@ export function checkVendorRisk(
   } else if (withheldReason) {
     summary = `${withheldLevelSentence(withheldReason, offer.vendor, withheldSince)} Nothing we have read describes this offer. Treat that as a statement about our records, not as a stable pricing history.`;
   } else if (published.refused_read) {
-    summary = `${unreconciledReadSentence(offer.vendor, published.refused_read.refused_date)} We publish no change we could not reconcile, so we are not calling this a stable pricing history.`;
+    summary = `${refusedReadSentence(offer.vendor, published.refused_read)} We publish no change we refused to record, so we are not calling this a stable pricing history.`;
   } else {
     summary = `${vendorHistorySentence(offer.vendor, "stable", cause)} Free tier verified for ${longevityDays} days.`;
   }

--- a/src/llm-api-readme.ts
+++ b/src/llm-api-readme.ts
@@ -1,7 +1,7 @@
 import { BASE_URL } from "./base-url.js";
 import { readingIsBehindTheLoop } from "./badge-staleness.js";
 import { citationLabel, ratingWithheldForNoSourceSentence } from "./change-citation.js";
-import { unreconciledReadSentence } from "./change-refusal.js";
+
 import { CHANGE_DIRECTION } from "./change-direction.js";
 import { gateRiskSummary, publishedRisk } from "./data.js";
 import { LINK_GRACE_DAYS } from "./link-health.js";
@@ -25,6 +25,8 @@ import { readingBehindTheChange, supersedingChange } from "./superseded-descript
 import type { DealChange, LinkUnreachable, Offer } from "./types.js";
 import {
   CHANGE_KIND_NOUN,
+  refusedReadWithholdingSentence,
+  withheldForARefusedRead,
   vendorBadge,
   vendorVerdictSentence,
   type BadgeWithholding,
@@ -144,7 +146,7 @@ function withheldSentence(
 ): string {
   if (because.reason === "gated") return gate ? gateRiskSummary(gate) : `We do not rate an offer we do not list.`;
   if (because.reason === "no_source") return ratingWithheldForNoSourceSentence(vendor);
-  if (because.reason === "read_not_reconciled") return unreconciledReadSentence(vendor, because.refusedOn);
+  if (withheldForARefusedRead(because)) return refusedReadWithholdingSentence(vendor, because);
   return withheldLevelSentence(because.reason, vendor, since);
 }
 

--- a/src/serve.ts
+++ b/src/serve.ts
@@ -7,7 +7,7 @@ import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/
 import { createServer, getServerCard } from "./server.js";
 import { oldestVerifiedDateForSlug, vendorRiskAssessment, publishedRisk, levelWithheldStatement, vendorNotIndexedSentence, riskCauseOf, freeTierEndingRecord, NEGATIVE_CHANGE_TYPES, POSITIVE_CHANGE_TYPES, SEVERE_CHANGE_TYPES, loadOffers, getCategories, getNewOffers, getNewestDeals, searchOffers, enrichOffers, gateForOffer, loadDealChanges, getDealChanges, changeContext, DEFAULT_CHANGE_WINDOW_DAYS, getOfferDetails, compareServices, checkVendorRisk, auditStack, getExpiringDeals, getWeeklyDigest, getFormattedWeeklyDigest, getFreshnessMetrics, getStabilityMap, getVendorReferral, sanitizeQuery, getChangeLogFreshness, isEventDated, partitionByDateProvenance } from "./data.js";
 import { loadChangeRefusals } from "./data.js";
-import { confirmingRead, confirmingReadSentence, refusalsByVendor, unreconciledReadSentence, UNRECONCILED_READ_BADGE_LABEL, type ChangeRefusal } from "./change-refusal.js";
+import { confirmingRead, confirmingReadSentence, refusalsByVendor, refusedReadSentence, MEASURED_NO_DIFFERENCE_BADGE_LABEL, UNRECONCILED_READ_BADGE_LABEL, type ChangeRefusal } from "./change-refusal.js";
 import { getStackRecommendation } from "./stacks.js";
 import { estimateCosts } from "./costs.js";
 import { classifyRequest } from "./client-class.js";
@@ -33,7 +33,7 @@ import { NO_CURRENT_FIGURE, costHeadlineCaveat, limitCellText, mayRecommendAsFre
 import { changesByVendor } from "./superseded-census.js";
 import { buildComparisonMap, comparisonSlug } from "./comparison-pairs.js";
 import { comparisonVerdictText, freeTierFaqAnswer, stabilityFaqAnswer, type ComparisonSide, type FreeTierSide, type SideFreeTier, type StabilityRating } from "./comparison-verdict.js";
-import { publishedVendorLevel, vendorVerdictSentence, vendorBadge, freeTierClaim, statesRiskCause, narrowingSentence, changeKindNoun, readWeCouldNotReconcile, refusalWithholdsStability, termsUnconfirmedBySource, unconfirmedTermsMetaSentence, type BadgeWithholding, type FreeTierClaim, type VendorVerdictInput } from "./vendor-verdict.js";
+import { publishedVendorLevel, vendorVerdictSentence, vendorBadge, freeTierClaim, statesRiskCause, narrowingSentence, changeKindNoun, refusedReadWeHold, refusedReadWithholdingSentence, withheldForARefusedRead, refusalWithholdsStability, termsUnconfirmedBySource, unconfirmedTermsMetaSentence, type BadgeWithholding, type FreeTierClaim, type VendorVerdictInput } from "./vendor-verdict.js";
 import { tierRecordsAFreeTier } from "./free-tier-record.js";
 import { PAGE_HEAD_OPEN, withLedeBeforeNav } from "./page-lede.js";
 import { freshnessClaimFor, withFreshnessClaim } from "./page-freshness.js";
@@ -896,6 +896,7 @@ const GATED_BADGE_LABELS: Record<GateCode, string> = {
 function withheldBadgeLabel(because: BadgeWithholding): string {
   if (because.reason === "gated") return GATED_BADGE_LABELS[because.gate];
   if (because.reason === "read_not_reconciled") return UNRECONCILED_READ_BADGE_LABEL;
+  if (because.reason === "change_measured_no_difference") return MEASURED_NO_DIFFERENCE_BADGE_LABEL;
   return WITHHELD_BADGE_LABELS[because.reason];
 }
 
@@ -1200,7 +1201,7 @@ function endedFreeTiersIn(population: readonly Offer[], servedOn: string): Offer
 function unconfirmedFreeTierSentence(vendor: string, because: BadgeWithholding, context: VendorVerdictContext): string {
   if (because.reason === "gated") return context.gate?.reason ?? "";
   if (because.reason === "no_source") return ratingWithheldForNoSourceSentence(vendor);
-  if (because.reason === "read_not_reconciled") return unreconciledReadSentence(vendor, because.refusedOn);
+  if (withheldForARefusedRead(because)) return refusedReadWithholdingSentence(vendor, because);
   return withheldLevelSentence(because.reason, vendor, context.unconfirmableSince);
 }
 
@@ -2898,7 +2899,7 @@ ${demeritRows}
   <h3>The risk label is not a rank, and it is never a count</h3>
   <p>Vendor pages carry a <code>stable</code> / <code>caution</code> / <code>risky</code> label. <strong style="color:var(--text)">It moves no order on this site</strong> &mdash; the ranking module cannot read it, and flipping every label leaves every listing we publish in the same order.</p>
   <p>It is decided by the <em>type</em> of a recorded change, never by how many records we hold. A vendor that expanded its free tier, postponed a fee, added a tier or changed its name cannot be labelled <code>caution</code> for any of those. <strong style="color:var(--text)">A <code>caution</code> or <code>risky</code> label always renders together with the single dated record that produced it, on the same page and next to the label. Where we cannot show the reason, we do not show the label.</strong></p>
-  <p>The honest limit: <code>stable</code> means we hold no record of a free tier removal, a limit reduction or a pricing restructure for that vendor, and that no read of its pricing page since has turned up a change we could not reconcile with the terms we publish. A change we read and then refused to record is not evidence that nothing moved, so it takes the label off rather than leaving it on. It is a statement about our records, not a clean bill of health &mdash; a vendor we have never had cause to examine reads the same as one with a long clean history. Until August 2026 the label was derived from a count of records of any type, which inverted that: the vendors we watched most closely were the ones it flagged, and several were flagged for good news. That is fixed, and this paragraph is here so the next version of it is checkable.</p>
+  <p>The honest limit: <code>stable</code> means we hold no record of a free tier removal, a limit reduction or a pricing restructure for that vendor, and that no read of its pricing page since has turned up a change we refused to record. A change we read and then refused to record is not evidence that nothing moved, so it takes the label off rather than leaving it on. Each vendor page states the reason we refused the change we hold for it. It is a statement about our records, not a clean bill of health &mdash; a vendor we have never had cause to examine reads the same as one with a long clean history. Until August 2026 the label was derived from a count of records of any type, which inverted that: the vendors we watched most closely were the ones it flagged, and several were flagged for good news. That is fixed, and this paragraph is here so the next version of it is checkable.</p>
 
   <h3>What we publish when the link itself stops resolving</h3>
   <p>Verification asks whether an offer's terms are still right. A separate daily check asks the cheaper question of whether its link still resolves at all, and it runs over every record regardless of how recently that record was verified.</p>
@@ -4644,7 +4645,7 @@ function buildVendorPage(slug: string): string | null {
 
   const riskColors: Record<string, string> = { stable: "#3fb950", caution: "#d29922", risky: "#f85149" };
   const riskCause = enriched.risk_cause;
-  const refusedRead = readWeCouldNotReconcile(verdictInput);
+  const refusedRead = refusedReadWeHold(verdictInput);
   const unreconciled = refusalWithholdsStability(verdictInput);
   const confirmedByRefusal = refusedRead || vendorChanges.length > 0
     ? null
@@ -5139,7 +5140,7 @@ ${allCompareLinks.join("\n")}
     : offerHasEnded
     ? endedEmptyChangeHistorySentence(vendorName)
     : refusedRead
-    ? `${unreconciledReadSentence(vendorName, refusedRead.refused_date)} We publish no change we could not reconcile, so we cannot tell you that nothing changed.`
+    ? `${refusedReadSentence(vendorName, refusedRead)} We publish no change we refused to record, so we cannot tell you that nothing changed.`
     : levelWithheld
     ? `We hold no recorded pricing changes for ${vendorName}, but ${withheldClause}, so that is a statement about our records rather than a positive signal.`
     : confirmedByRefusal
@@ -46007,7 +46008,7 @@ ${globalNavCss()}
   <p class="section-desc">We analyzed ${offers.length.toLocaleString()} developer tool offerings across ${categories.length} categories, tracking ${changesInForce.length} pricing changes over 2024&ndash;2026. Here&rsquo;s what the data shows:</p>
   <ul class="key-takeaways">
     <li><strong>${vouchedPct}% of tracked services offer a free tier we can vouch for today</strong> &mdash; we hold a free-tier record for ${recordedPct}% of them, and can confirm ${freeTiers.vouched.toLocaleString()} of those ${freeTiers.recorded.toLocaleString()} against a source we have read.</li>
-    <li><strong>${freeTiers.unconfirmed.toLocaleString()} recorded free tiers we cannot confirm today</strong> &mdash; the record stands, but the page we hold for it states no price we can read, cannot be read at all, does not name the vendor, or carried a change on our last read that we could not reconcile with the terms we publish. Unconfirmed is not the same as gone.</li>
+    <li><strong>${freeTiers.unconfirmed.toLocaleString()} recorded free tiers we cannot confirm today</strong> &mdash; the record stands, but the page we hold for it states no price we can read, cannot be read at all, does not name the vendor, or carried a change on our last read that we refused to record. Unconfirmed is not the same as gone.</li>
     <li><strong>${freeTiers.ended} free tiers we have recorded as ended</strong> &mdash; excluded from every count above, and from every category total on this site.</li>
     <li><strong>${negativeChanges.length} negative pricing changes vs ${positiveChanges.length} positive</strong> &mdash; free tier removals and restrictions outpace expansions ${directionRatioLabel(negativeChanges.length, positiveChanges.length)}.</li>
     <li><strong>${durability.stillInForce.length} free tiers completely removed</strong> &mdash; ${escHtmlServer(lastingExamples.map(e => e.vendor).join(", "))}, and more. ${escHtmlServer(removalReturnRateSentence(durability))}</li>
@@ -46178,7 +46179,7 @@ ${globalNavCss()}
   <h2>Methodology</h2>
   <p class="section-desc">How we built this dataset:</p>
   <ul style="color:var(--text-muted);font-size:.9rem;padding-left:1.25rem;margin-bottom:1rem">
-    <li style="margin-bottom:.4rem"><strong>Verification:</strong> Every offer records the date we read the vendor&rsquo;s public pricing page and the URL we read it from. That is not the same as being able to vouch for it today: ${freeTiers.unconfirmed.toLocaleString()} of the ${freeTiers.recorded.toLocaleString()} recorded free tiers have a source that states no price we can read, cannot be read at all, does not name the vendor, or carried a change on our last read that we could not reconcile with the terms we publish, and those are the ones counted as unconfirmed above.</li>
+    <li style="margin-bottom:.4rem"><strong>Verification:</strong> Every offer records the date we read the vendor&rsquo;s public pricing page and the URL we read it from. That is not the same as being able to vouch for it today: ${freeTiers.unconfirmed.toLocaleString()} of the ${freeTiers.recorded.toLocaleString()} recorded free tiers have a source that states no price we can read, cannot be read at all, does not name the vendor, or carried a change on our last read that we refused to record, and those are the ones counted as unconfirmed above.</li>
     <li style="margin-bottom:.4rem"><strong>Change tracking:</strong> ${changesInForce.length} pricing changes tracked with date, previous state, current state, impact level, and source documentation.</li>
     <li style="margin-bottom:.4rem"><strong>Definition of &ldquo;free tier&rdquo;:</strong> Perpetual free plans, always-free offerings, and generous hobby/starter tiers without time limits. We exclude limited trials (e.g., 14-day, 30-day) and one-time credits.</li>
     <li style="margin-bottom:.4rem"><strong>Update frequency:</strong> Continuous. Our <a href="/freshness">data freshness dashboard</a> shows verification recency by category.</li>

--- a/src/vendor-verdict.ts
+++ b/src/vendor-verdict.ts
@@ -17,8 +17,11 @@ import { vendorHistorySentence, type PublishedRiskLevel } from "./vendor-history
 import {
   confirmingRead,
   confirmingReadClause,
-  readNotReconciled,
-  unreconciledReadClause,
+  measuredNoDifferenceSentence,
+  refusalMeasuredNoDifference,
+  refusedReadClause,
+  refusedReadWithholdingStability,
+  unreconciledReadSentence,
   type RefusedRead,
 } from "./change-refusal.js";
 
@@ -66,7 +69,32 @@ export type BadgeWithholding =
   | { reason: "gated"; gate: GateCode }
   | { reason: "no_source" }
   | { reason: "read_not_reconciled"; refusedOn: string }
+  | { reason: "change_measured_no_difference"; refusedOn: string }
   | { reason: LevelWithheldReason };
+
+export type RefusedReadWithholding = Extract<
+  BadgeWithholding,
+  { reason: "read_not_reconciled" | "change_measured_no_difference" }
+>;
+
+export function withheldForARefusedRead(because: BadgeWithholding): because is RefusedReadWithholding {
+  return because.reason === "read_not_reconciled" || because.reason === "change_measured_no_difference";
+}
+
+export function refusedReadWithholdingSentence(
+  subject: string,
+  because: RefusedReadWithholding,
+): string {
+  return because.reason === "change_measured_no_difference"
+    ? measuredNoDifferenceSentence(subject, because.refusedOn)
+    : unreconciledReadSentence(subject, because.refusedOn);
+}
+
+export function refusedReadWithholding(refusal: RefusedRead): BadgeWithholding {
+  return refusalMeasuredNoDifference(refusal)
+    ? { reason: "change_measured_no_difference", refusedOn: refusal.refused_date }
+    : { reason: "read_not_reconciled", refusedOn: refusal.refused_date };
+}
 
 export type VendorBadge =
   | { kind: "ended" }
@@ -125,8 +153,8 @@ export function vendorVerdictWord(input: VendorVerdictInput): PublishedRiskLevel
   return publishedVendorLevel(input.level, input.cause);
 }
 
-export function readWeCouldNotReconcile(input: VendorVerdictInput): RefusedRead | null {
-  return readNotReconciled({
+export function refusedReadWeHold(input: VendorVerdictInput): RefusedRead | null {
+  return refusedReadWithholdingStability({
     historyLevel: input.historyLevel,
     publishedChanges: input.changes.length,
     refusals: input.refusedReads ?? [],
@@ -138,7 +166,7 @@ export function refusalWithholdsStability(input: VendorVerdictInput): RefusedRea
   if (input.gate) return null;
   if (withholdingDecides(input)) return null;
   if (input.linkUnreachable) return null;
-  return readWeCouldNotReconcile(input);
+  return refusedReadWeHold(input);
 }
 
 export function badgeWithholding(input: VendorVerdictInput): BadgeWithholding | null {
@@ -146,8 +174,8 @@ export function badgeWithholding(input: VendorVerdictInput): BadgeWithholding | 
     return { reason: input.levelWithheld ?? "no_source" };
   }
   if (input.gate) return { reason: "gated", gate: input.gate };
-  const unreconciled = refusalWithholdsStability(input);
-  if (unreconciled) return { reason: "read_not_reconciled", refusedOn: unreconciled.refused_date };
+  const refused = refusalWithholdsStability(input);
+  if (refused) return refusedReadWithholding(refused);
   if (input.level === null) return { reason: input.levelWithheld ?? "no_source" };
   if (input.linkUnreachable && publishedVendorLevel(input.level, input.cause) === "stable") {
     return { reason: "link_unreachable" };
@@ -238,9 +266,9 @@ export function vendorVerdictSentence(input: VendorVerdictInput): string {
     const clause = withheldLevelClause(input.levelWithheld, input.unconfirmableSince);
     return `${clause.charAt(0).toUpperCase()}${clause.slice(1)}, so we cannot confirm these terms today.`;
   }
-  const unreconciled = refusalWithholdsStability(input);
-  if (unreconciled) {
-    return `${capitalise(unreconciledReadClause(unreconciled.refused_date))}, so we are not rating this offer today.`;
+  const refused = refusalWithholdsStability(input);
+  if (refused) {
+    return `${capitalise(refusedReadClause(refused))}, so we are not rating this offer today.`;
   }
 
   const level = publishedVendorLevel(input.level, input.cause);

--- a/test/badge-withholding.test.ts
+++ b/test/badge-withholding.test.ts
@@ -45,6 +45,7 @@ const WITHHELD_LABELS: Record<string, string> = {
   offer_retired: "unrated — offer ended",
   verification_lapsed: "unrated — not re-confirmed",
   read_not_reconciled: "unrated — change not reconciled",
+  change_measured_no_difference: "unrated — change refused",
 };
 
 const WITHHELD_LABEL_SET = new Set(Object.values(WITHHELD_LABELS));

--- a/test/compare-free-tier-claim.test.ts
+++ b/test/compare-free-tier-claim.test.ts
@@ -86,7 +86,7 @@ before(async () => {
   const { gateFor, utcDate } = await import("../dist/ranking.js");
   const { levelWithheldReason, levelWithheldSince, withheldLevelSentence } = await import("../dist/source-check.js");
   const { ratingWithheldForNoSourceSentence } = await import("../dist/change-citation.js");
-  const { unreconciledReadSentence } = await import("../dist/change-refusal.js");
+  const { refusedReadSentence } = await import("../dist/change-refusal.js");
 
   const offers = loadOffers();
   const changes = loadDealChanges();
@@ -117,7 +117,7 @@ before(async () => {
     const reasonsItCouldGive = [
       gateFor(primary, servedOn)?.reason,
       withheld ? withheldLevelSentence(withheld, vendor, since) : null,
-      refusedRead ? unreconciledReadSentence(vendor, refusedRead.refused_date) : null,
+      refusedRead ? refusedReadSentence(vendor, refusedRead) : null,
       ratingWithheldForNoSourceSentence(vendor),
     ].filter((r): r is string => typeof r === "string" && r !== "");
 

--- a/test/refused-change-not-stable.test.ts
+++ b/test/refused-change-not-stable.test.ts
@@ -425,8 +425,10 @@ describe("a page states the reason we withheld, not a reason its own refusal con
     const narrow: string[] = [];
     for (const route of ["/state-of-free-tiers", "/criteria"]) {
       const page = await (await fetch(`http://localhost:${serverPort}${route}`)).text();
-      if (COULD_NOT_RECONCILE.test(page)) narrow.push(`${route} names only the reads we could not reconcile`);
-      if (NAMED_NO_FIGURE_THAT_MOVED.test(page)) narrow.push(`${route} names only the equality findings`);
+      if (/could not reconcile with the terms we publish/.test(page)) {
+        narrow.push(`${route} names only the reads we could not reconcile`);
+      }
+      if (/named no figure that had moved/.test(page)) narrow.push(`${route} names only the equality findings`);
     }
     assert.deepStrictEqual(narrow, [], `a page counting every refusal describes one kind of them:\n${narrow.join("\n")}`);
   });

--- a/test/refused-change-not-stable.test.ts
+++ b/test/refused-change-not-stable.test.ts
@@ -5,7 +5,7 @@ import { readFileSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { assertCoversPopulation, assertPopulationFloor, vendorsInTheCatalogue } from "./population-floor.ts";
-import { GATE_REASONS } from "../scripts/change-gate.js";
+import { GATE_REASONS, REJECT_MEASURES_NO_CHANGE, REJECT_NULL_COMPARISON, REJECT_STATES_NO_DIFFERENCE } from "../scripts/change-gate.js";
 import { SUPPRESSED_SAME_TRANSITION_REGRADED } from "../scripts/change-log.js";
 import { refusedReadWithholdingStability, REFUSAL_REASONS_THAT_CONFIRM_THE_STORED_TERMS, REFUSAL_REASONS_THAT_MEASURED_NO_DIFFERENCE, MEASURED_NO_DIFFERENCE_BADGE_LABEL, UNRECONCILED_READ_BADGE_LABEL } from "../dist/change-refusal.js";
 import { checkVendorRisk, enrichOffers, loadChangeRefusals, loadDealChanges, loadOffers } from "../dist/data.js";
@@ -435,6 +435,42 @@ describe("a page states the reason we withheld, not a reason its own refusal con
       r => !subjects.some(s => s.reasons.includes(r)),
     );
     assert.deepStrictEqual(unseen, [], `no vendor holds a refusal under these reasons, so they are untested: ${unseen.join(", ")}`);
+  });
+
+  it("reads an equality finding on every rule the gate refuses an equality under", () => {
+    const refusedOnAnEquality = [
+      REJECT_MEASURES_NO_CHANGE,
+      REJECT_STATES_NO_DIFFERENCE,
+      REJECT_NULL_COMPARISON,
+    ];
+    assert.deepStrictEqual(
+      [...REFUSAL_REASONS_THAT_MEASURED_NO_DIFFERENCE].sort(),
+      [...refusedOnAnEquality].sort(),
+      "the pages read a different set of equality findings from the set the gate refuses under",
+    );
+
+    const misread: string[] = [];
+    const exercised: string[] = [];
+    for (const rule of refusedOnAnEquality) {
+      const held = subjects.filter(
+        s => s.unreconciled && s.reasons.filter(r => !CONFIRMING.has(r)).every(r => r === rule),
+      );
+      if (held.length > 0) exercised.push(rule);
+      for (const subject of held) {
+        const page = pages.get(subject.slug) ?? "";
+        if (COULD_NOT_RECONCILE.test(page)) misread.push(`/vendor/${subject.slug} (${rule})`);
+        if (!NAMED_NO_FIGURE_THAT_MOVED.test(page)) misread.push(`/vendor/${subject.slug} names no equality finding (${rule})`);
+      }
+    }
+    assert.deepStrictEqual(
+      misread.slice(0, 20),
+      [],
+      `an equality the gate measured reaches a reader as a change we could not reconcile:\n${misread.slice(0, 20).join("\n")}`,
+    );
+    assert.ok(
+      exercised.length > 0,
+      `no vendor holds any of ${refusedOnAnEquality.join(", ")} as its only reason, so no page exercises this reading`,
+    );
   });
 });
 

--- a/test/refused-change-not-stable.test.ts
+++ b/test/refused-change-not-stable.test.ts
@@ -7,7 +7,7 @@ import { fileURLToPath } from "node:url";
 import { assertCoversPopulation, assertPopulationFloor, vendorsInTheCatalogue } from "./population-floor.ts";
 import { GATE_REASONS } from "../scripts/change-gate.js";
 import { SUPPRESSED_SAME_TRANSITION_REGRADED } from "../scripts/change-log.js";
-import { readNotReconciled, REFUSAL_REASONS_THAT_CONFIRM_THE_STORED_TERMS, UNRECONCILED_READ_BADGE_LABEL } from "../dist/change-refusal.js";
+import { refusedReadWithholdingStability, REFUSAL_REASONS_THAT_CONFIRM_THE_STORED_TERMS, REFUSAL_REASONS_THAT_MEASURED_NO_DIFFERENCE, MEASURED_NO_DIFFERENCE_BADGE_LABEL, UNRECONCILED_READ_BADGE_LABEL } from "../dist/change-refusal.js";
 import { checkVendorRisk, enrichOffers, loadChangeRefusals, loadDealChanges, loadOffers } from "../dist/data.js";
 import { vendorSlugMap } from "../dist/vendor-slug.js";
 
@@ -34,18 +34,32 @@ const badgeLabelOf = (svg: string): string => {
 };
 
 const CONFIRMING = new Set<string>(REFUSAL_REASONS_THAT_CONFIRM_THE_STORED_TERMS);
+const MEASURED_NO_DIFFERENCE = new Set<string>(REFUSAL_REASONS_THAT_MEASURED_NO_DIFFERENCE);
 
-const WITHHELD_FOR_A_REFUSAL = /we found a change we could not reconcile with the terms we publish/;
+const COULD_NOT_RECONCILE = /we found a change we could not reconcile with the terms we publish/;
+const NAMED_NO_FIGURE_THAT_MOVED =
+  /we refused the change we considered recording because it named no figure that had moved/;
+const WITHHELD_FOR_A_REFUSAL = new RegExp(`${COULD_NOT_RECONCILE.source}|${NAMED_NO_FIGURE_THAT_MOVED.source}`);
 
 interface Subject {
   slug: string;
   vendor: string;
   reasons: string[];
   unreconciled: boolean;
+  measuredNoDifference: boolean;
   onlyTheRefusal: boolean;
   confirmingOnly: boolean;
   published: number;
 }
+
+const reasonWePublish = (subject: Subject): RegExp =>
+  subject.measuredNoDifference ? NAMED_NO_FIGURE_THAT_MOVED : COULD_NOT_RECONCILE;
+
+const reasonWeMustNotPublish = (subject: Subject): RegExp =>
+  subject.measuredNoDifference ? COULD_NOT_RECONCILE : NAMED_NO_FIGURE_THAT_MOVED;
+
+const badgeWeExpect = (subject: Subject): string =>
+  subject.measuredNoDifference ? MEASURED_NO_DIFFERENCE_BADGE_LABEL : UNRECONCILED_READ_BADGE_LABEL;
 
 let subjects: Subject[] = [];
 let serverPort = 0;
@@ -89,7 +103,8 @@ before(async () => {
   subjects = [...vendorSlugMap.entries()].map(([slug, vendor]) => {
     const reasons = held.get(vendor.toLowerCase()) ?? [];
     const count = published.get(vendor.toLowerCase()) ?? 0;
-    const unreconciled = count === 0 && reasons.some(r => !CONFIRMING.has(r));
+    const triggering = reasons.filter(r => !CONFIRMING.has(r));
+    const unreconciled = count === 0 && triggering.length > 0;
     const row = rowFor.get(vendor);
     const otherwiseWithheld = Boolean(
       row?.gate || row?.rating_withheld || row?.link_unreachable
@@ -101,6 +116,7 @@ before(async () => {
       reasons,
       published: count,
       unreconciled,
+      measuredNoDifference: unreconciled && triggering.every(r => MEASURED_NO_DIFFERENCE.has(r)),
       onlyTheRefusal: unreconciled && !otherwiseWithheld,
       confirmingOnly: count === 0 && reasons.length > 0 && reasons.every(r => CONFIRMING.has(r)),
     };
@@ -218,7 +234,7 @@ describe("a refused change is not a signal that nothing changed", () => {
     for (const subject of subjects.filter(s => s.onlyTheRefusal)) {
       const verdict = verdictParagraphOf(pages.get(subject.slug) ?? "");
       if (verdict === "") { silent.push(`/vendor/${subject.slug} renders no verdict paragraph`); continue; }
-      if (!WITHHELD_FOR_A_REFUSAL.test(verdict)) silent.push(`/vendor/${subject.slug}: ${verdict.slice(0, 120)}`);
+      if (!reasonWePublish(subject).test(verdict)) silent.push(`/vendor/${subject.slug}: ${verdict.slice(0, 120)}`);
     }
     assert.deepStrictEqual(silent.slice(0, 20), [], `verdicts withheld with nothing saying why:\n${silent.slice(0, 20).join("\n")}`);
   });
@@ -229,11 +245,13 @@ describe("a refused change is not a signal that nothing changed", () => {
     let queue = 0;
     const worker = async () => {
       while (queue < withheld.length) {
-        const { slug } = withheld[queue++];
+        const subject = withheld[queue++];
+        const { slug } = subject;
         const res = await fetch(`http://localhost:${serverPort}/badge/${slug}.svg`);
         if (res.status !== 200) { wrong.push(`/badge/${slug}.svg returned ${res.status}`); continue; }
         const label = badgeLabelOf(await res.text());
-        if (label !== UNRECONCILED_READ_BADGE_LABEL) wrong.push(`/badge/${slug}.svg reads "${label}"`);
+        const expected = badgeWeExpect(subject);
+        if (label !== expected) wrong.push(`/badge/${slug}.svg reads "${label}", not "${expected}"`);
       }
     };
     await Promise.all(Array.from({ length: 12 }, worker));
@@ -248,7 +266,7 @@ describe("a refused change is not a signal that nothing changed", () => {
       const line = stabilityLineOf(await readResourceOverHttp(`agentdeals://vendor/${subject.slug}`));
       assert.ok(line !== "", `agentdeals://vendor/${subject.slug} publishes no stability line at all`);
       assert.doesNotMatch(line, /\*\*Stability:\*\* stable/, `agentdeals://vendor/${subject.slug} calls it stable`);
-      assert.match(line, WITHHELD_FOR_A_REFUSAL, `agentdeals://vendor/${subject.slug} withholds without saying why`);
+      assert.match(line, reasonWePublish(subject), `agentdeals://vendor/${subject.slug} withholds without saying why`);
     }
     for (const subject of subjects.filter(s => s.confirmingOnly).slice(0, 3)) {
       const line = stabilityLineOf(await readResourceOverHttp(`agentdeals://vendor/${subject.slug}`));
@@ -265,7 +283,7 @@ describe("a refused change is not a signal that nothing changed", () => {
       if (result.risk_level !== null) silent.push(`${subject.vendor} answers ${result.risk_level}`);
       if (!subject.onlyTheRefusal) continue;
       if (A_STABLE_HISTORY.test(result.summary)) silent.push(`${subject.vendor}: ${result.summary}`);
-      if (!WITHHELD_FOR_A_REFUSAL.test(result.summary)) silent.push(`${subject.vendor} summarises without saying why`);
+      if (!reasonWePublish(subject).test(result.summary)) silent.push(`${subject.vendor} summarises without saying why`);
     }
     assert.deepStrictEqual(silent.slice(0, 10), [], `the risk summary still reads as a stable history:\n${silent.slice(0, 10).join("\n")}`);
   });
@@ -323,6 +341,103 @@ describe("a refused change is not a signal that nothing changed", () => {
   });
 });
 
+describe("a page states the reason we withheld, not a reason its own refusal contradicts", () => {
+  it("says no change was unreconcilable wherever every refusal we hold measured the two states as equal", () => {
+    const contradicting: string[] = [];
+    for (const subject of subjects.filter(s => s.measuredNoDifference)) {
+      const page = pages.get(subject.slug) ?? "";
+      if (COULD_NOT_RECONCILE.test(page)) {
+        contradicting.push(`/vendor/${subject.slug} (${subject.reasons.join(", ")})`);
+      }
+    }
+    assert.deepStrictEqual(
+      contradicting.slice(0, 20),
+      [],
+      `pages reporting an equality finding as a change we could not reconcile:\n${contradicting.slice(0, 20).join("\n")}`,
+    );
+    assertPopulationFloor(
+      subjects.filter(s => s.measuredNoDifference).length,
+      20,
+      "vendors hold only refusals that measured the two states as equal",
+    );
+    assertCoversPopulation(subjects.length, vendorsInTheCatalogue(), "vendor pages read for the reason they withhold");
+  });
+
+  it("keeps the reason a page gives out of the family it does not belong to", () => {
+    const crossed: string[] = [];
+    for (const subject of subjects.filter(s => s.onlyTheRefusal)) {
+      const page = pages.get(subject.slug) ?? "";
+      if (reasonWeMustNotPublish(subject).test(page)) crossed.push(`/vendor/${subject.slug}`);
+      if (!reasonWePublish(subject).test(page)) crossed.push(`/vendor/${subject.slug} states neither reason`);
+    }
+    assert.deepStrictEqual(crossed.slice(0, 20), [], `pages naming the wrong family of refusal:\n${crossed.slice(0, 20).join("\n")}`);
+    assert.ok(
+      subjects.some(s => s.onlyTheRefusal && s.measuredNoDifference)
+      && subjects.some(s => s.onlyTheRefusal && !s.measuredNoDifference),
+      "one of the two families is empty, so this control compares nothing",
+    );
+  });
+
+  it("takes no rating back for a vendor whose refusal only measured the quantities it compared", () => {
+    for (const slug of ["pagertree-com", "cloudflare-workers", "aiven", "uptimerobot"]) {
+      const subject = subjects.find(s => s.slug === slug);
+      assert.ok(subject?.measuredNoDifference, `/vendor/${slug} no longer holds only equality refusals`);
+      const page = pages.get(slug) ?? "";
+      assert.doesNotMatch(page, COULD_NOT_RECONCILE, `/vendor/${slug} still reports the equality finding as unreconcilable`);
+      assert.match(page, NAMED_NO_FIGURE_THAT_MOVED, `/vendor/${slug} states no reason for withholding`);
+      assert.deepStrictEqual(claimsOn(slug), [], `/vendor/${slug} publishes a stability claim over a refusal`);
+    }
+  });
+
+  it("leaves the vendors #1139 was filed on withheld and unrated", () => {
+    for (const slug of ["pubnub-com", "typeform-com", "lokalise"]) {
+      const subject = subjects.find(s => s.slug === slug);
+      assert.ok(subject?.unreconciled, `/vendor/${slug} no longer holds a refusal and no published change`);
+      assert.ok(!subject.measuredNoDifference, `/vendor/${slug} is no longer a read we could not reconcile`);
+      const page = pages.get(slug) ?? "";
+      assert.match(page, COULD_NOT_RECONCILE, `/vendor/${slug} lost the sentence #1139 put on it`);
+      assert.deepStrictEqual(claimsOn(slug), [], `/vendor/${slug} regained a stability claim`);
+    }
+  });
+
+  it("leaves a vendor holding both an equality refusal and a published change on the verdict its records give it", () => {
+    const both = subjects.filter(
+      s => s.published > 0 && s.reasons.some(r => MEASURED_NO_DIFFERENCE.has(r)),
+    );
+    assert.ok(both.length > 0, "no vendor holds both an equality refusal and a published change, so the control is empty");
+    const moved: string[] = [];
+    for (const subject of both) {
+      const page = pages.get(subject.slug) ?? "";
+      if (WITHHELD_FOR_A_REFUSAL.test(page)) moved.push(`/vendor/${subject.slug} withholds for a refusal`);
+      const verdict = verdictParagraphOf(page);
+      if (!/We rate it /.test(verdict)) moved.push(`/vendor/${subject.slug}: ${verdict.slice(0, 120)}`);
+    }
+    assert.deepStrictEqual(moved, [], `a published change stopped setting the verdict:\n${moved.join("\n")}`);
+  });
+
+  it("gives an agent the same reason on either transport", async () => {
+    const oneOfEach = [
+      subjects.find(s => s.onlyTheRefusal && s.measuredNoDifference),
+      subjects.find(s => s.onlyTheRefusal && !s.measuredNoDifference),
+    ];
+    for (const subject of oneOfEach) {
+      assert.ok(subject, "a family of refused read has no vendor to read over MCP");
+      const line = stabilityLineOf(await readResourceOverHttp(`agentdeals://vendor/${subject.slug}`));
+      assert.match(line, reasonWePublish(subject), `agentdeals://vendor/${subject.slug} names the wrong reason`);
+      assert.doesNotMatch(line, reasonWeMustNotPublish(subject), `agentdeals://vendor/${subject.slug} names the other family`);
+    }
+  });
+
+  it("draws both families of refusal from the vocabulary the gate writes", () => {
+    const overlap = REFUSAL_REASONS_THAT_MEASURED_NO_DIFFERENCE.filter(r => CONFIRMING.has(r));
+    assert.deepStrictEqual(overlap, [], `a reason is both a confirmation and an equality finding: ${overlap.join(", ")}`);
+    const unseen = REFUSAL_REASONS_THAT_MEASURED_NO_DIFFERENCE.filter(
+      r => !subjects.some(s => s.reasons.includes(r)),
+    );
+    assert.deepStrictEqual(unseen, [], `no vendor holds a refusal under these reasons, so they are untested: ${unseen.join(", ")}`);
+  });
+});
+
 describe("the refusal log and the rules that write it read the same vocabulary", () => {
   const refusalLog = () =>
     JSON.parse(readFileSync(process.env.AGENTDEALS_REFUSALS_PATH || path.join(REPO, "data", "change_refusals.json"), "utf-8")).refusals as Array<{ reason: string }>;
@@ -341,16 +456,36 @@ describe("the refusal log and the rules that write it read the same vocabulary",
     assert.deepStrictEqual(stray, [], `reasons kept as confirmations that no gate rule writes: ${stray.join(", ")}`);
   });
 
+  it("draws every reason it treats as an equality finding from that same vocabulary", () => {
+    const known = REASONS_A_RULE_CAN_WRITE;
+    const stray = REFUSAL_REASONS_THAT_MEASURED_NO_DIFFERENCE.filter(r => !known.has(r));
+    assert.deepStrictEqual(stray, [], `reasons kept as equality findings that no gate rule writes: ${stray.join(", ")}`);
+  });
+
+  it("publishes the reason of the refusal it could not reconcile wherever it holds one of each", () => {
+    const refusals = [
+      { reason: "measures_no_change", refused_date: "2026-09-11" },
+      { reason: "unquantified_limit", refused_date: "2026-08-01" },
+    ];
+    const published = refusedReadWithholdingStability({ historyLevel: "stable", publishedChanges: 0, refusals });
+    assert.strictEqual(
+      published?.reason,
+      "unquantified_limit",
+      "a later equality finding published its own reason over a refusal we could not reconcile",
+    );
+    assert.strictEqual(published?.refused_date, "2026-08-01", "the day published is not the day of the reason published");
+  });
+
   it("leaves a rating the records themselves earned alone", () => {
     const refusals = [{ reason: "unquantified_limit", refused_date: "2026-09-11" }];
     assert.notStrictEqual(
-      readNotReconciled({ historyLevel: "stable", publishedChanges: 0, refusals }),
+      refusedReadWithholdingStability({ historyLevel: "stable", publishedChanges: 0, refusals }),
       null,
       "a refused read over an otherwise stable history does not withhold",
     );
     for (const historyLevel of ["caution", "risky"]) {
       assert.strictEqual(
-        readNotReconciled({ historyLevel, publishedChanges: 0, refusals }),
+        refusedReadWithholdingStability({ historyLevel, publishedChanges: 0, refusals }),
         null,
         `a refused read takes over a ${historyLevel} the records earned`,
       );

--- a/test/refused-change-not-stable.test.ts
+++ b/test/refused-change-not-stable.test.ts
@@ -284,6 +284,9 @@ describe("a refused change is not a signal that nothing changed", () => {
       if (!subject.onlyTheRefusal) continue;
       if (A_STABLE_HISTORY.test(result.summary)) silent.push(`${subject.vendor}: ${result.summary}`);
       if (!reasonWePublish(subject).test(result.summary)) silent.push(`${subject.vendor} summarises without saying why`);
+      if (!/We publish no change we refused to record/.test(result.summary)) {
+        silent.push(`${subject.vendor} leaves an agent to read a missing record as nothing having changed`);
+      }
     }
     assert.deepStrictEqual(silent.slice(0, 10), [], `the risk summary still reads as a stable history:\n${silent.slice(0, 10).join("\n")}`);
   });
@@ -413,6 +416,19 @@ describe("a page states the reason we withheld, not a reason its own refusal con
       if (!/We rate it /.test(verdict)) moved.push(`/vendor/${subject.slug}: ${verdict.slice(0, 120)}`);
     }
     assert.deepStrictEqual(moved, [], `a published change stopped setting the verdict:\n${moved.join("\n")}`);
+  });
+
+  it("names no single family of refusal on a page that counts both", async () => {
+    const bothFamilies = subjects.some(s => s.onlyTheRefusal && s.measuredNoDifference)
+      && subjects.some(s => s.onlyTheRefusal && !s.measuredNoDifference);
+    assert.ok(bothFamilies, "the withheld population holds one family only, so a page naming it is not yet wrong");
+    const narrow: string[] = [];
+    for (const route of ["/state-of-free-tiers", "/criteria"]) {
+      const page = await (await fetch(`http://localhost:${serverPort}${route}`)).text();
+      if (COULD_NOT_RECONCILE.test(page)) narrow.push(`${route} names only the reads we could not reconcile`);
+      if (NAMED_NO_FIGURE_THAT_MOVED.test(page)) narrow.push(`${route} names only the equality findings`);
+    }
+    assert.deepStrictEqual(narrow, [], `a page counting every refusal describes one kind of them:\n${narrow.join("\n")}`);
   });
 
   it("gives an agent the same reason on either transport", async () => {


### PR DESCRIPTION
Refs #1553.

## What was live

`/vendor/pagertree-com` said *"we found a change we could not reconcile with the terms we publish"* over a refusal whose own detail reads *"every quantity the record compares holds the same value once notation and period are normalised — **5 user against 5 user**"*. We did reconcile it. **32 vendor pages** reported an equality finding as a failure to decide, measured page by page against `main` with both servers up; **0 on this branch**, and the 114 pages holding a refusal we genuinely could not reconcile keep the sentence unchanged.

## The shape

The published refused read is now **the most recent refusal we could not reconcile where one exists, and the most recent equality finding otherwise**. That one selection rule makes the published reason self-describing, so no surface has to re-derive "is every triggering refusal an equality finding" — `refused_read` stays `{reason, refused_date}` and everything downstream branches on the reason it already carries. The vendor page verdict and FAQ, the badge SVG, `/api/offers`, the comparison pages, `agentdeals://vendor/<slug>` on both transports and the LLM index all followed with no list of surfaces to keep.

It also fixes a case the issue does not name. **MDBootstrap** holds `states_no_difference` (2026-09-11) and `unquantified_limit` (2026-08-28). It published *2026-09-11* under *"a change we could not reconcile"* — the date of one refusal under the reason of the other. It now publishes 2026-08-28, the day of the refusal it actually could not reconcile.

## I did not restore any rating, and the measurement is why

AC-1 leaves the mechanism open. Restoring would republish an affirmative stability claim, and **20 of the 32** hold a refusal whose own summary names a term the equality finding does not cover — the comparison matched the quantities it compared and the summary describes something else. The issue names two of them. The other eighteen are listed in a comment on #1553 with the clause that disqualifies each.

So the falsehood is removed by naming the reason correctly, and every withholding stands.

## Blast radius, read off the API on both builds

| | main | branch |
|---|---|---|
| rows | 1,547 | 1,547 |
| `risk_level` changed | — | **0** |
| `refused_read` changed | — | **1** (MDBootstrap) |
| `stable` / `caution` / `risky` | 509 / 139 / 24 | 509 / 139 / 24 |
| `/state-of-free-tiers` vouched | 628 (41%) | 628 (41%) |

AC-2, AC-4 and AC-5 hold over the whole catalogue rather than over a sample: no rating moves in either direction, so `/vendor/pubnub-com`, `/vendor/typeform-com` and `/vendor/lokalise` keep the withholding #1139 put on them, `/vendor/aiven` publishes no stability claim, and Auth0, Dub.co, Hasura Cloud, InfluxDB Cloud and incidenthub.cloud keep the verdict their published change gives them.

## AC-3, before and after

| | before | after |
|---|---|---|
| `/vendor/pagertree-com` | *"…on 2026-09-11, we found a change we could not reconcile with the terms we publish"* | *"…on 2026-09-11, we refused the change we considered recording because it named no figure that had moved"* |
| `/vendor/cloudflare-workers` | same sentence, 2026-09-01 | same correction, 2026-09-01 |
| badge | `unrated — change not reconciled` | `unrated — change refused` |

## Also corrected

`/criteria` and `/state-of-free-tiers` each described the withholding as one family of refusal. Neither renders a record, so no census over rendered record text would have caught them. Both now state it as any change we read and refused to record, with the vendor page carrying the specific reason.
