### PR TITLE
Stop withholding a rating on a read a later confirmation superseded

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "mutate:1434": "node scripts/mutate-1434.mjs",
     "mutate:1486": "node scripts/mutate-1486.mjs",
     "mutate:1486-round2": "node scripts/mutate-1486-round2.mjs",
+    "mutate:1556": "node scripts/mutate-1556.mjs",
     "test:gated": "node --test --test-concurrency 1 --test-reporter=spec --test-reporter-destination=stdout --test-reporter=./scripts/reporters/failing-test-files.js --test-reporter-destination=$GATE_FAILING_FILES test/**/*.test.ts",
     "ratchet:budgets": "node scripts/ratchet-quality-budgets.js --lower",
     "lastmod:pages": "node scripts/update-page-lastmod.js",

--- a/scripts/mutate-1556.mjs
+++ b/scripts/mutate-1556.mjs
@@ -1,0 +1,100 @@
+import { readFileSync, writeFileSync } from "node:fs";
+import { execFileSync } from "node:child_process";
+
+const SUITE = [
+  "test/refused-change-not-stable.test.ts",
+  "test/vendor-verdict.test.ts",
+  "test/badge-withholding.test.ts",
+];
+
+const MUTANTS = [
+  ["a-refusal-never-clears-again", "src/change-refusal.ts",
+    "  return refusal.refused_date < termsConfirmedOn;",
+    "  return false;"],
+
+  ["a-confirmation-on-the-day-of-the-refusal-clears-it", "src/change-refusal.ts",
+    "  return refusal.refused_date < termsConfirmedOn;",
+    "  return refusal.refused_date <= termsConfirmedOn;"],
+
+  ["the-withholding-set-ignores-the-confirmation", "src/change-refusal.ts",
+    "      r => !refusalConfirmsTheStoredTerms(r) && !refusalPredatesConfirmation(r, termsConfirmedOn),\n    ),\n  );\n}\n\nexport interface StabilityEvidence",
+    "      r => !refusalConfirmsTheStoredTerms(r),\n    ),\n  );\n}\n\nexport interface StabilityEvidence"],
+
+  ["a-confirming-refusal-withholds-the-rating", "src/change-refusal.ts",
+    "      r => !refusalConfirmsTheStoredTerms(r) && !refusalPredatesConfirmation(r, termsConfirmedOn),\n    ),\n  );\n}\n\nexport interface StabilityEvidence",
+    "      r => !refusalPredatesConfirmation(r, termsConfirmedOn),\n    ),\n  );\n}\n\nexport interface StabilityEvidence"],
+
+  ["two-refusals-on-one-day-publish-the-equality-one", "src/change-refusal.ts",
+    "    if (\n      refusal.refused_date === held.refused_date\n      && refusalMeasuredNoDifference(held)\n      && !refusalMeasuredNoDifference(refusal)\n    ) {\n      held = refusal;\n    }",
+    "    if (false) {\n      held = refusal;\n    }"],
+
+  ["the-oldest-live-refusal-is-the-one-we-publish", "src/change-refusal.ts",
+    "    if (held === null || refusal.refused_date > held.refused_date) {\n      held = refusal;\n      continue;\n    }",
+    "    if (held === null || refusal.refused_date < held.refused_date) {\n      held = refusal;\n      continue;\n    }"],
+
+  ["a-superseded-refusal-is-read-as-a-live-one", "src/change-refusal.ts",
+    "      r => !refusalConfirmsTheStoredTerms(r) && refusalPredatesConfirmation(r, termsConfirmedOn),",
+    "      r => !refusalConfirmsTheStoredTerms(r) && !refusalPredatesConfirmation(r, termsConfirmedOn),"],
+
+  ["the-record-is-read-as-never-confirmed", "src/data.ts",
+    "    termsConfirmedOn: offer.verifiedDate,\n    refusals: refusalsForVendor(offer.vendor),",
+    "    termsConfirmedOn: \"\",\n    refusals: refusalsForVendor(offer.vendor),"],
+
+  ["the-vendor-page-is-read-as-never-confirmed", "src/serve.ts",
+    "      termsConfirmedOn: primary.verifiedDate,\n      refusedReads: refusalsFor(vendorName),",
+    "      termsConfirmedOn: \"\",\n      refusedReads: refusalsFor(vendorName),"],
+
+  ["the-cleared-verdict-counts-the-refusal-as-nothing", "src/vendor-verdict.ts",
+    "    const superseded = refusedReadOurConfirmationSupersedes(input);\n    if (superseded) {",
+    "    const superseded = null as RefusedRead | null;\n    if (superseded) {"],
+
+  ["the-cleared-verdict-dates-itself-to-the-refusal", "src/vendor-verdict.ts",
+    "      return `It's stable — ${supersededRefusalClause(superseded.refused_date, input.termsConfirmedOn)}.`;",
+    "      return `It's stable — ${supersededRefusalClause(input.termsConfirmedOn, superseded.refused_date)}.`;"],
+
+  ["the-cleared-faq-answer-counts-the-refusal-as-nothing", "src/serve.ts",
+    "    : supersededRefusal\n    ? supersededRefusalSentence(vendorName, supersededRefusal.refused_date, primary.verifiedDate)\n    : confirmedByRefusal",
+    "    : confirmedByRefusal"],
+
+  ["the-cleared-risk-summary-counts-the-refusal-as-nothing", "src/data.ts",
+    "  } else if (supersededRefusal && vendorChanges.length === 0) {",
+    "  } else if (supersededRefusal && vendorChanges.length < 0) {"],
+
+  ["the-guard-on-the-confirmation-date-is-dropped", "src/change-refusal.ts",
+    "  return refusal.refused_date < termsConfirmedOn;",
+    "  return refusal.refused_date > termsConfirmedOn;"],
+];
+
+function run(cmd, args) {
+  try {
+    execFileSync(cmd, args, { stdio: "pipe", encoding: "utf-8" });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+const survivors = [];
+const uncompiled = [];
+const skipped = [];
+for (const [name, file, from, to] of MUTANTS) {
+  const original = readFileSync(file, "utf-8");
+  if (!original.includes(from)) {
+    console.log(`SKIP  ${name} — the line it mutates is not in ${file}`);
+    skipped.push(name);
+    continue;
+  }
+  writeFileSync(file, original.replace(from, to));
+  const built = run("npm", ["run", "build"]);
+  const green = built && run("node", ["--test", "--test-concurrency", "1", ...SUITE]);
+  writeFileSync(file, original);
+  if (!built) uncompiled.push(name);
+  console.log(`${green ? "SURVIVED" : built ? "killed  " : "DID NOT COMPILE"}  ${name}`);
+  if (green) survivors.push(name);
+}
+run("npm", ["run", "build"]);
+const killed = MUTANTS.length - survivors.length - uncompiled.length - skipped.length;
+console.log(`\n${killed}/${MUTANTS.length} killed`);
+if (survivors.length > 0) console.log("survivors:", survivors.join(", "));
+if (uncompiled.length > 0) console.log("did not compile:", uncompiled.join(", "));
+if (skipped.length > 0) console.log("skipped — target string moved, so these scored nothing:", skipped.join(", "));

--- a/src/change-refusal.ts
+++ b/src/change-refusal.ts
@@ -59,22 +59,64 @@ function mostRecent(refusals: readonly RefusedRead[]): RefusedRead | null {
   return held === null ? null : { reason: held.reason, refused_date: held.refused_date };
 }
 
-export function refusedReadThatWithholds(refusals: readonly RefusedRead[]): RefusedRead | null {
-  const withholding = refusals.filter(r => !refusalConfirmsTheStoredTerms(r));
-  const unreconciled = withholding.filter(r => !refusalMeasuredNoDifference(r));
-  return mostRecent(unreconciled.length > 0 ? unreconciled : withholding);
+export function refusalPredatesConfirmation(
+  refusal: RefusedRead,
+  termsConfirmedOn: string,
+): boolean {
+  return refusal.refused_date < termsConfirmedOn;
+}
+
+function latestRead(refusals: readonly RefusedRead[]): RefusedRead | null {
+  let held: RefusedRead | null = null;
+  for (const refusal of refusals) {
+    if (held === null || refusal.refused_date > held.refused_date) {
+      held = refusal;
+      continue;
+    }
+    if (
+      refusal.refused_date === held.refused_date
+      && refusalMeasuredNoDifference(held)
+      && !refusalMeasuredNoDifference(refusal)
+    ) {
+      held = refusal;
+    }
+  }
+  return held === null ? null : { reason: held.reason, refused_date: held.refused_date };
+}
+
+export function refusedReadThatWithholds(
+  refusals: readonly RefusedRead[],
+  termsConfirmedOn: string,
+): RefusedRead | null {
+  return latestRead(
+    refusals.filter(
+      r => !refusalConfirmsTheStoredTerms(r) && !refusalPredatesConfirmation(r, termsConfirmedOn),
+    ),
+  );
 }
 
 export interface StabilityEvidence {
   historyLevel: string | null;
   publishedChanges: number;
+  termsConfirmedOn: string;
   refusals: readonly RefusedRead[];
 }
 
 export function refusedReadWithholdingStability(state: StabilityEvidence): RefusedRead | null {
   if (state.historyLevel !== "stable") return null;
   if (state.publishedChanges > 0) return null;
-  return refusedReadThatWithholds(state.refusals);
+  return refusedReadThatWithholds(state.refusals, state.termsConfirmedOn);
+}
+
+export function refusedReadTheConfirmationSupersedes(
+  refusals: readonly RefusedRead[],
+  termsConfirmedOn: string,
+): RefusedRead | null {
+  return latestRead(
+    refusals.filter(
+      r => !refusalConfirmsTheStoredTerms(r) && refusalPredatesConfirmation(r, termsConfirmedOn),
+    ),
+  );
 }
 
 export function confirmingRead(refusals: readonly RefusedRead[]): RefusedRead | null {
@@ -94,6 +136,20 @@ export function confirmingReadClause(refusal: RefusedRead): string {
 
 export function confirmingReadSentence(subject: string, refusal: RefusedRead): string {
   return CONFIRMING_REASON_SENTENCES[refusal.reason as ConfirmingRefusalReason](subject);
+}
+
+export function supersededRefusalClause(refusedOn: string, confirmedOn: string): string {
+  return `the change we last considered recording was refused on ${refusedOn},`
+    + ` and we read the page again on ${confirmedOn} and confirmed the terms above`;
+}
+
+export function supersededRefusalSentence(
+  subject: string,
+  refusedOn: string,
+  confirmedOn: string,
+): string {
+  return `We refused the change we last considered recording for ${subject} on ${refusedOn},`
+    + ` then read the page again on ${confirmedOn} and confirmed the terms we publish for it.`;
 }
 
 export const UNRECONCILED_READ_BADGE_LABEL = "unrated — change not reconciled";

--- a/src/data.ts
+++ b/src/data.ts
@@ -32,7 +32,9 @@ import { resolveCategoryName } from "./category-scope.js";
 import { survivingVendorName } from "./vendor-merges.js";
 import {
   refusedReadSentence,
+  refusedReadTheConfirmationSupersedes,
   refusedReadWithholdingStability,
+  supersededRefusalSentence,
   refusalsByVendor as groupRefusalsByVendor,
   type ChangeRefusal,
   type ChangeRefusalIndex,
@@ -1010,6 +1012,7 @@ export function publishedRisk(
   const refused_read = refusedReadWithholdingStability({
     historyLevel: assessment.level,
     publishedChanges: publishedChangeCount(offer.vendor),
+    termsConfirmedOn: offer.verifiedDate,
     refusals: refusalsForVendor(offer.vendor),
   });
   const withheld =
@@ -1067,6 +1070,10 @@ export function checkVendorRisk(
     .sort((a, b) => b.date.localeCompare(a.date));
 
   const published = publishedRisk(offer, vendorChanges);
+  const supersededRefusal = refusedReadTheConfirmationSupersedes(
+    refusalsForVendor(offer.vendor),
+    offer.verifiedDate,
+  );
   const gate = published.gate;
   const assessment = vendorRiskAssessment(changesRatingTheListedTier(offer, vendorChanges));
   const linkUnreachable = published.link_unreachable;
@@ -1124,6 +1131,8 @@ export function checkVendorRisk(
     summary = `${withheldLevelSentence(withheldReason, offer.vendor, withheldSince)} Nothing we have read describes this offer. Treat that as a statement about our records, not as a stable pricing history.`;
   } else if (published.refused_read) {
     summary = `${refusedReadSentence(offer.vendor, published.refused_read)} We publish no change we refused to record, so we are not calling this a stable pricing history.`;
+  } else if (supersededRefusal && vendorChanges.length === 0) {
+    summary = supersededRefusalSentence(offer.vendor, supersededRefusal.refused_date, offer.verifiedDate);
   } else {
     summary = `${vendorHistorySentence(offer.vendor, "stable", cause)} Free tier verified for ${longevityDays} days.`;
   }

--- a/src/llm-api-readme.ts
+++ b/src/llm-api-readme.ts
@@ -212,6 +212,7 @@ export function readmeRow(offer: Offer, allChanges: DealChange[], context: RowCo
     gate: risk.gate?.code ?? null,
     linkUnreachable: Boolean(risk.link_unreachable),
     sourceCheck: offer.source_check?.outcome ?? null,
+    termsConfirmedOn: offer.verifiedDate,
   };
 
   const superseding = supersedingChange(offer, vendorChanges);

--- a/src/serve.ts
+++ b/src/serve.ts
@@ -7,7 +7,7 @@ import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/
 import { createServer, getServerCard } from "./server.js";
 import { oldestVerifiedDateForSlug, vendorRiskAssessment, publishedRisk, levelWithheldStatement, vendorNotIndexedSentence, riskCauseOf, freeTierEndingRecord, NEGATIVE_CHANGE_TYPES, POSITIVE_CHANGE_TYPES, SEVERE_CHANGE_TYPES, loadOffers, getCategories, getNewOffers, getNewestDeals, searchOffers, enrichOffers, gateForOffer, loadDealChanges, getDealChanges, changeContext, DEFAULT_CHANGE_WINDOW_DAYS, getOfferDetails, compareServices, checkVendorRisk, auditStack, getExpiringDeals, getWeeklyDigest, getFormattedWeeklyDigest, getFreshnessMetrics, getStabilityMap, getVendorReferral, sanitizeQuery, getChangeLogFreshness, isEventDated, partitionByDateProvenance } from "./data.js";
 import { loadChangeRefusals } from "./data.js";
-import { confirmingRead, confirmingReadSentence, refusalsByVendor, refusedReadSentence, MEASURED_NO_DIFFERENCE_BADGE_LABEL, UNRECONCILED_READ_BADGE_LABEL, type ChangeRefusal } from "./change-refusal.js";
+import { confirmingRead, confirmingReadSentence, refusalsByVendor, refusedReadSentence, supersededRefusalSentence, MEASURED_NO_DIFFERENCE_BADGE_LABEL, UNRECONCILED_READ_BADGE_LABEL, type ChangeRefusal } from "./change-refusal.js";
 import { getStackRecommendation } from "./stacks.js";
 import { estimateCosts } from "./costs.js";
 import { classifyRequest } from "./client-class.js";
@@ -33,7 +33,7 @@ import { NO_CURRENT_FIGURE, costHeadlineCaveat, limitCellText, mayRecommendAsFre
 import { changesByVendor } from "./superseded-census.js";
 import { buildComparisonMap, comparisonSlug } from "./comparison-pairs.js";
 import { comparisonVerdictText, freeTierFaqAnswer, stabilityFaqAnswer, type ComparisonSide, type FreeTierSide, type SideFreeTier, type StabilityRating } from "./comparison-verdict.js";
-import { publishedVendorLevel, vendorVerdictSentence, vendorBadge, freeTierClaim, statesRiskCause, narrowingSentence, changeKindNoun, refusedReadWeHold, refusedReadWithholdingSentence, withheldForARefusedRead, refusalWithholdsStability, termsUnconfirmedBySource, unconfirmedTermsMetaSentence, type BadgeWithholding, type FreeTierClaim, type VendorVerdictInput } from "./vendor-verdict.js";
+import { publishedVendorLevel, vendorVerdictSentence, vendorBadge, freeTierClaim, statesRiskCause, narrowingSentence, changeKindNoun, refusedReadOurConfirmationSupersedes, refusedReadWeHold, refusedReadWithholdingSentence, withheldForARefusedRead, refusalWithholdsStability, termsUnconfirmedBySource, unconfirmedTermsMetaSentence, type BadgeWithholding, type FreeTierClaim, type VendorVerdictInput } from "./vendor-verdict.js";
 import { tierRecordsAFreeTier } from "./free-tier-record.js";
 import { PAGE_HEAD_OPEN, withLedeBeforeNav } from "./page-lede.js";
 import { freshnessClaimFor, withFreshnessClaim } from "./page-freshness.js";
@@ -979,6 +979,7 @@ function buildVendorVerdictContext(vendorName: string, servedOn: string): Vendor
       gate: gate?.code ?? null,
       linkUnreachable: Boolean(linkUnreachable),
       sourceCheck: primary.source_check?.outcome ?? null,
+      termsConfirmedOn: primary.verifiedDate,
       refusedReads: refusalsFor(vendorName),
     },
   };
@@ -2899,7 +2900,7 @@ ${demeritRows}
   <h3>The risk label is not a rank, and it is never a count</h3>
   <p>Vendor pages carry a <code>stable</code> / <code>caution</code> / <code>risky</code> label. <strong style="color:var(--text)">It moves no order on this site</strong> &mdash; the ranking module cannot read it, and flipping every label leaves every listing we publish in the same order.</p>
   <p>It is decided by the <em>type</em> of a recorded change, never by how many records we hold. A vendor that expanded its free tier, postponed a fee, added a tier or changed its name cannot be labelled <code>caution</code> for any of those. <strong style="color:var(--text)">A <code>caution</code> or <code>risky</code> label always renders together with the single dated record that produced it, on the same page and next to the label. Where we cannot show the reason, we do not show the label.</strong></p>
-  <p>The honest limit: <code>stable</code> means we hold no record of a free tier removal, a limit reduction or a pricing restructure for that vendor, and that no read of its pricing page since has turned up a change we refused to record. A change we read and then refused to record is not evidence that nothing moved, so it takes the label off rather than leaving it on. Each vendor page states the reason we refused the change we hold for it. It is a statement about our records, not a clean bill of health &mdash; a vendor we have never had cause to examine reads the same as one with a long clean history. Until August 2026 the label was derived from a count of records of any type, which inverted that: the vendors we watched most closely were the ones it flagged, and several were flagged for good news. That is fixed, and this paragraph is here so the next version of it is checkable.</p>
+  <p>The honest limit: <code>stable</code> means we hold no record of a free tier removal, a limit reduction or a pricing restructure for that vendor, and that no read of its pricing page since has turned up a change we refused to record without our having read the page again and confirmed the terms afterwards. A change we read and then refused to record is not evidence that nothing moved, so it takes the label off rather than leaving it on, and only a later read that confirms the terms puts it back. Each vendor page states the reason we refused the change we hold for it, or the day we confirmed the terms over it. It is a statement about our records, not a clean bill of health &mdash; a vendor we have never had cause to examine reads the same as one with a long clean history. Until August 2026 the label was derived from a count of records of any type, which inverted that: the vendors we watched most closely were the ones it flagged, and several were flagged for good news. That is fixed, and this paragraph is here so the next version of it is checkable.</p>
 
   <h3>What we publish when the link itself stops resolving</h3>
   <p>Verification asks whether an offer's terms are still right. A separate daily check asks the cheaper question of whether its link still resolves at all, and it runs over every record regardless of how recently that record was verified.</p>
@@ -4647,7 +4648,10 @@ function buildVendorPage(slug: string): string | null {
   const riskCause = enriched.risk_cause;
   const refusedRead = refusedReadWeHold(verdictInput);
   const unreconciled = refusalWithholdsStability(verdictInput);
-  const confirmedByRefusal = refusedRead || vendorChanges.length > 0
+  const supersededRefusal = refusedRead || vendorChanges.length > 0
+    ? null
+    : refusedReadOurConfirmationSupersedes(verdictInput);
+  const confirmedByRefusal = refusedRead || supersededRefusal || vendorChanges.length > 0
     ? null
     : confirmingRead(verdictInput.refusedReads ?? []);
   const riskLevel = publishedVendorLevel(enriched.risk_level ?? null, riskCause);
@@ -5143,6 +5147,8 @@ ${allCompareLinks.join("\n")}
     ? `${refusedReadSentence(vendorName, refusedRead)} We publish no change we refused to record, so we cannot tell you that nothing changed.`
     : levelWithheld
     ? `We hold no recorded pricing changes for ${vendorName}, but ${withheldClause}, so that is a statement about our records rather than a positive signal.`
+    : supersededRefusal
+    ? supersededRefusalSentence(vendorName, supersededRefusal.refused_date, primary.verifiedDate)
     : confirmedByRefusal
     ? confirmingReadSentence(vendorName, confirmedByRefusal)
     : primaryGate

--- a/src/vendor-verdict.ts
+++ b/src/vendor-verdict.ts
@@ -20,7 +20,9 @@ import {
   measuredNoDifferenceSentence,
   refusalMeasuredNoDifference,
   refusedReadClause,
+  refusedReadTheConfirmationSupersedes,
   refusedReadWithholdingStability,
+  supersededRefusalClause,
   unreconciledReadSentence,
   type RefusedRead,
 } from "./change-refusal.js";
@@ -62,6 +64,7 @@ export interface VendorVerdictInput {
   gate?: GateCode | null;
   linkUnreachable?: boolean;
   sourceCheck?: SourceCheckOutcome | null;
+  termsConfirmedOn: string;
   refusedReads?: readonly RefusedRead[];
 }
 
@@ -157,8 +160,13 @@ export function refusedReadWeHold(input: VendorVerdictInput): RefusedRead | null
   return refusedReadWithholdingStability({
     historyLevel: input.historyLevel,
     publishedChanges: input.changes.length,
+    termsConfirmedOn: input.termsConfirmedOn,
     refusals: input.refusedReads ?? [],
   });
+}
+
+export function refusedReadOurConfirmationSupersedes(input: VendorVerdictInput): RefusedRead | null {
+  return refusedReadTheConfirmationSupersedes(input.refusedReads ?? [], input.termsConfirmedOn);
 }
 
 export function refusalWithholdsStability(input: VendorVerdictInput): RefusedRead | null {
@@ -282,6 +290,10 @@ export function vendorVerdictSentence(input: VendorVerdictInput): string {
   }
 
   if (input.changes.length === 0) {
+    const superseded = refusedReadOurConfirmationSupersedes(input);
+    if (superseded) {
+      return `It's stable — ${supersededRefusalClause(superseded.refused_date, input.termsConfirmedOn)}.`;
+    }
     const confirmed = confirmingRead(input.refusedReads ?? []);
     return confirmed
       ? `It's stable — ${confirmingReadClause(confirmed)}.`

--- a/test/badge-withholding.test.ts
+++ b/test/badge-withholding.test.ts
@@ -121,6 +121,7 @@ before(async () => {
       refusedReads: refusalsForVendor(vendor),
       levelWithheld,
       unconfirmableSince: "",
+      termsConfirmedOn: primary.verifiedDate,
       ratingWithheld: e.rating_withheld,
       offerEnded: offerEnded(primary),
       gate: gateFor(primary, servedOn)?.code ?? null,

--- a/test/meta-description-withholding.test.ts
+++ b/test/meta-description-withholding.test.ts
@@ -224,7 +224,7 @@ describe("#1412 the meta description withholds wherever the source check failed"
 
 describe("#1412 the withholding predicate is the one the badge and the body read", () => {
   it("answers only for the outcomes that leave the terms unconfirmed", () => {
-    const base = { vendor: "Example", level: null, cause: null, changes: [], levelWithheld: null, unconfirmableSince: "" };
+    const base = { vendor: "Example", level: null, cause: null, changes: [], levelWithheld: null, unconfirmableSince: "", termsConfirmedOn: "" };
     assert.strictEqual(termsUnconfirmedBySource({ ...base, sourceCheck: "ok" }), null);
     assert.strictEqual(termsUnconfirmedBySource({ ...base, sourceCheck: null }), null);
     assert.strictEqual(termsUnconfirmedBySource(base), null);

--- a/test/refused-change-not-stable.test.ts
+++ b/test/refused-change-not-stable.test.ts
@@ -4,12 +4,13 @@ import { spawn, type ChildProcess } from "node:child_process";
 import { readFileSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import { assertCoversPopulation, assertPopulationFloor, vendorsInTheCatalogue } from "./population-floor.ts";
+import { assertCoversPopulation, assertPopulationFloor, recordsInTheCatalogue, vendorsInTheCatalogue } from "./population-floor.ts";
 import { GATE_REASONS, REJECT_MEASURES_NO_CHANGE, REJECT_NULL_COMPARISON, REJECT_STATES_NO_DIFFERENCE } from "../scripts/change-gate.js";
 import { SUPPRESSED_SAME_TRANSITION_REGRADED } from "../scripts/change-log.js";
-import { refusedReadWithholdingStability, REFUSAL_REASONS_THAT_CONFIRM_THE_STORED_TERMS, REFUSAL_REASONS_THAT_MEASURED_NO_DIFFERENCE, MEASURED_NO_DIFFERENCE_BADGE_LABEL, UNRECONCILED_READ_BADGE_LABEL } from "../dist/change-refusal.js";
-import { checkVendorRisk, enrichOffers, loadChangeRefusals, loadDealChanges, loadOffers } from "../dist/data.js";
+import { refusalsByVendor, refusedReadTheConfirmationSupersedes, refusedReadWithholdingStability, supersededRefusalSentence, REFUSAL_REASONS_THAT_CONFIRM_THE_STORED_TERMS, REFUSAL_REASONS_THAT_MEASURED_NO_DIFFERENCE, MEASURED_NO_DIFFERENCE_BADGE_LABEL, UNRECONCILED_READ_BADGE_LABEL } from "../dist/change-refusal.js";
+import { checkVendorRisk, enrichOffers, loadChangeRefusals, loadDealChanges, loadOffers, publishedChangeCount } from "../dist/data.js";
 import { vendorSlugMap } from "../dist/vendor-slug.js";
+import { vendorVerdictSentence } from "../dist/vendor-verdict.js";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const REPO = path.join(__dirname, "..");
@@ -41,10 +42,24 @@ const NAMED_NO_FIGURE_THAT_MOVED =
   /we refused the change we considered recording because it named no figure that had moved/;
 const WITHHELD_FOR_A_REFUSAL = new RegExp(`${COULD_NOT_RECONCILE.source}|${NAMED_NO_FIGURE_THAT_MOVED.source}`);
 
+interface OfferRead {
+  vendor: string;
+  tier: string;
+  verifiedDate: string;
+  last_read_date: string;
+  risk_level: string | null;
+  gate: { code: string } | null;
+  refused_read: { reason: string; refused_date: string } | null;
+}
+
 interface Subject {
   slug: string;
   vendor: string;
   reasons: string[];
+  refusedRead: { reason: string; refused_date: string } | null;
+  gated: boolean;
+  confirmedOn: string;
+  supersededRefusal: { reason: string; refused_date: string } | null;
   unreconciled: boolean;
   measuredNoDifference: boolean;
   onlyTheRefusal: boolean;
@@ -98,14 +113,15 @@ before(async () => {
   }
 
   const offers = loadOffers();
-  const rowFor = new Map(enrichOffers(offers).map(row => [row.vendor, row]));
+  const rowFor = new Map<string, ReturnType<typeof enrichOffers>[number]>();
+  for (const row of enrichOffers(offers)) if (!rowFor.has(row.vendor)) rowFor.set(row.vendor, row);
 
   subjects = [...vendorSlugMap.entries()].map(([slug, vendor]) => {
     const reasons = held.get(vendor.toLowerCase()) ?? [];
     const count = published.get(vendor.toLowerCase()) ?? 0;
-    const triggering = reasons.filter(r => !CONFIRMING.has(r));
-    const unreconciled = count === 0 && triggering.length > 0;
     const row = rowFor.get(vendor);
+    const refusedRead = row?.refused_read ?? null;
+    const unreconciled = refusedRead !== null;
     const otherwiseWithheld = Boolean(
       row?.gate || row?.rating_withheld || row?.link_unreachable
       || (row?.source_check && row.source_check.outcome !== "ok"),
@@ -115,8 +131,17 @@ before(async () => {
       vendor,
       reasons,
       published: count,
+      refusedRead,
+      gated: Boolean(row?.gate),
+      confirmedOn: row?.verifiedDate ?? "",
+      supersededRefusal: refusedRead === null && count === 0
+        ? refusedReadTheConfirmationSupersedes(
+          refusals.filter(r => r.vendor.toLowerCase() === vendor.toLowerCase()),
+          row?.verifiedDate ?? "",
+        )
+        : null,
       unreconciled,
-      measuredNoDifference: unreconciled && triggering.every(r => MEASURED_NO_DIFFERENCE.has(r)),
+      measuredNoDifference: refusedRead !== null && MEASURED_NO_DIFFERENCE.has(refusedRead.reason),
       onlyTheRefusal: unreconciled && !otherwiseWithheld,
       confirmingOnly: count === 0 && reasons.length > 0 && reasons.every(r => CONFIRMING.has(r)),
     };
@@ -308,6 +333,46 @@ describe("a refused change is not a signal that nothing changed", () => {
     assert.strictEqual(counted, payload.offers.length, "the provenance block counts a record the response does not return");
   });
 
+  it("withholds on no read older than the one it calls our last", async () => {
+    const payload = await (await fetch(`http://localhost:${serverPort}/api/offers?limit=2000`)).json() as {
+      offers: Array<OfferRead>;
+    };
+    const contradicting = payload.offers
+      .filter(row => row.refused_read && row.last_read_date > row.refused_read.refused_date)
+      .map(row => `${row.vendor} (${row.tier}): withholds on ${row.refused_read!.refused_date}, read ${row.last_read_date}`);
+    assert.deepStrictEqual(
+      contradicting.slice(0, 20),
+      [],
+      `records naming two different days as the day we last read the page:\n${contradicting.slice(0, 20).join("\n")}`,
+    );
+    assertCoversPopulation(payload.offers.length, recordsInTheCatalogue(), "records read for the day their verdict dates itself to");
+    assertPopulationFloor(payload.offers.filter(row => row.refused_read).length, 100, "records publish a refused read");
+  });
+
+  it("holds the withholding wherever nothing has confirmed the terms since", async () => {
+    const payload = await (await fetch(`http://localhost:${serverPort}/api/offers?limit=2000`)).json() as {
+      offers: Array<OfferRead>;
+    };
+    const refused = refusalsByVendor(loadChangeRefusals());
+    const stillUnconfirmed = payload.offers.filter(row =>
+      publishedChangeCount(row.vendor) === 0
+      && (refused.get(row.vendor.toLowerCase()) ?? [])
+        .some(r => !CONFIRMING.has(r.reason) && r.refused_date >= row.verifiedDate),
+    );
+    const released = stillUnconfirmed
+      .filter(row => row.risk_level !== null)
+      .map(row => `${row.vendor} (${row.tier}) rates ${row.risk_level} over a refusal we have not confirmed past`);
+    assert.deepStrictEqual(released.slice(0, 20), [], `ratings restored over a live refusal:\n${released.slice(0, 20).join("\n")}`);
+    assertPopulationFloor(stillUnconfirmed.length, 100, "records hold a refusal no later confirmation supersedes");
+
+    for (const vendor of ["pubnub.com", "Typeform.com", "Lokalise"]) {
+      const row = payload.offers.find(o => o.vendor === vendor);
+      assert.ok(row, `${vendor} has left the catalogue this control was written against`);
+      assert.ok(row.refused_read, `${vendor} stopped publishing the refused read it was holding`);
+      assert.strictEqual(row.risk_level, null, `${vendor} recovered a rating over a refusal nothing has confirmed past`);
+    }
+  });
+
   it("publishes none of the records it refused", () => {
     const published = new Set(
       loadDealChanges().map(c => `${c.vendor.toLowerCase()}|${c.change_type}|${(c.summary ?? "").trim()}`),
@@ -392,6 +457,33 @@ describe("a page states the reason we withheld, not a reason its own refusal con
     }
   });
 
+  it("says on every surface why a rating came back, wherever a confirmation cleared a refusal", () => {
+    const cleared = subjects.filter(s => s.supersededRefusal && !s.gated);
+    assert.ok(cleared.length > 0, "no record was confirmed after a refusal, so this reading is untested");
+    const silent: string[] = [];
+    for (const subject of cleared) {
+      const refusedOn = subject.supersededRefusal!.refused_date;
+      const page = pages.get(subject.slug) ?? "";
+      const verdict = verdictParagraphOf(page);
+      const both = new RegExp(`refused on ${refusedOn}, and we read the page again on ${subject.confirmedOn}`);
+      if (!both.test(verdict)) silent.push(`/vendor/${subject.slug}: ${verdict.slice(-160)}`);
+      if (/zero pricing changes recorded/.test(page)) silent.push(`/vendor/${subject.slug} counts the refusal as nothing`);
+      if (/has had no recorded pricing changes/.test(page)) silent.push(`/vendor/${subject.slug} (FAQ) counts the refusal as nothing`);
+      if (!page.includes(supersededRefusalSentence(subject.vendor, refusedOn, subject.confirmedOn))) {
+        silent.push(`/vendor/${subject.slug} answers the pricing-change question without naming the refusal`);
+      }
+      const answer = checkVendorRisk(subject.vendor) as { result?: { summary: string } };
+      if (answer.result && !answer.result.summary.includes(`refused the change we last considered recording for ${subject.vendor} on ${refusedOn}`)) {
+        silent.push(`${subject.vendor} summarises for an agent without naming the refusal`);
+      }
+    }
+    assert.deepStrictEqual(silent.slice(0, 20), [], `a rating came back with nothing saying why:\n${silent.slice(0, 20).join("\n")}`);
+    for (const slug of ["doczilla", "tavily-ai"]) {
+      const subject = subjects.find(s => s.slug === slug);
+      assert.ok(subject?.supersededRefusal, `/vendor/${slug} no longer holds a refusal its own confirmation supersedes`);
+    }
+  });
+
   it("leaves the vendors #1139 was filed on withheld and unrated", () => {
     for (const slug of ["pubnub-com", "typeform-com", "lokalise"]) {
       const subject = subjects.find(s => s.slug === slug);
@@ -431,6 +523,17 @@ describe("a page states the reason we withheld, not a reason its own refusal con
       if (/named no figure that had moved/.test(page)) narrow.push(`${route} names only the equality findings`);
     }
     assert.deepStrictEqual(narrow, [], `a page counting every refusal describes one kind of them:\n${narrow.join("\n")}`);
+  });
+
+  it("does not define stable as a label a refused read takes off for good", async () => {
+    const cleared = subjects.filter(s => s.supersededRefusal);
+    assert.ok(cleared.length > 0, "no record holds a refusal a confirmation superseded, so the definition is not yet wrong");
+    const page = await (await fetch(`http://localhost:${serverPort}/criteria`)).text();
+    assert.match(
+      page,
+      /only a later read that confirms the terms puts it back/,
+      "/criteria tells a reader a refused read removes the stable label for good",
+    );
   });
 
   it("gives an agent the same reason on either transport", async () => {
@@ -516,34 +619,99 @@ describe("the refusal log and the rules that write it read the same vocabulary",
     assert.deepStrictEqual(stray, [], `reasons kept as equality findings that no gate rule writes: ${stray.join(", ")}`);
   });
 
-  it("publishes the reason of the refusal it could not reconcile wherever it holds one of each", () => {
+  it("publishes the reason of the refusal it could not reconcile wherever it holds one of each on the same day", () => {
     const refusals = [
-      { reason: "measures_no_change", refused_date: "2026-09-11" },
-      { reason: "unquantified_limit", refused_date: "2026-08-01" },
+      { reason: "measures_no_change", refused_date: "2026-08-29" },
+      { reason: "states_no_terms", refused_date: "2026-08-29" },
     ];
-    const published = refusedReadWithholdingStability({ historyLevel: "stable", publishedChanges: 0, refusals });
+    const published = refusedReadWithholdingStability({ historyLevel: "stable", publishedChanges: 0, termsConfirmedOn: "2026-07-01", refusals });
     assert.strictEqual(
       published?.reason,
-      "unquantified_limit",
-      "a later equality finding published its own reason over a refusal we could not reconcile",
+      "states_no_terms",
+      "an equality finding published its own reason over a refusal of the same day we could not reconcile",
     );
-    assert.strictEqual(published?.refused_date, "2026-08-01", "the day published is not the day of the reason published");
+    assert.strictEqual(published?.refused_date, "2026-08-29", "the day published is not the day of the reason published");
+  });
+
+  it("publishes the reason of the latest read whenever a later read refused on other grounds", () => {
+    const refusals = [
+      { reason: "unquantified_limit", refused_date: "2026-08-28" },
+      { reason: "states_no_difference", refused_date: "2026-09-11" },
+    ];
+    const published = refusedReadWithholdingStability({ historyLevel: "stable", publishedChanges: 0, termsConfirmedOn: "2026-07-19", refusals });
+    assert.strictEqual(published?.refused_date, "2026-09-11", "the day published is not the day we last read the page");
+    assert.strictEqual(published?.reason, "states_no_difference", "the reason published is not the reason of the day published");
   });
 
   it("leaves a rating the records themselves earned alone", () => {
     const refusals = [{ reason: "unquantified_limit", refused_date: "2026-09-11" }];
     assert.notStrictEqual(
-      refusedReadWithholdingStability({ historyLevel: "stable", publishedChanges: 0, refusals }),
+      refusedReadWithholdingStability({ historyLevel: "stable", publishedChanges: 0, termsConfirmedOn: "2026-07-01", refusals }),
       null,
       "a refused read over an otherwise stable history does not withhold",
     );
     for (const historyLevel of ["caution", "risky"]) {
       assert.strictEqual(
-        refusedReadWithholdingStability({ historyLevel, publishedChanges: 0, refusals }),
+        refusedReadWithholdingStability({ historyLevel, publishedChanges: 0, termsConfirmedOn: "2026-07-01", refusals }),
         null,
         `a refused read takes over a ${historyLevel} the records earned`,
       );
     }
+  });
+
+  it("stops withholding once the terms have been confirmed since the refusal", () => {
+    const refusals = [{ reason: "no_price_signal", refused_date: "2026-08-29" }];
+    const stability = (termsConfirmedOn: string) =>
+      refusedReadWithholdingStability({ historyLevel: "stable", publishedChanges: 0, termsConfirmedOn, refusals });
+    assert.strictEqual(stability("2026-09-10"), null, "a refusal predating the day we confirmed the terms still withholds");
+    assert.strictEqual(
+      stability("2026-08-29")?.refused_date,
+      "2026-08-29",
+      "a confirmation dated the same day as the refusal cleared it",
+    );
+    assert.strictEqual(
+      stability("2026-08-01")?.refused_date,
+      "2026-08-29",
+      "a refusal later than our last confirmation stopped withholding",
+    );
+    assert.strictEqual(stability("")?.refused_date, "2026-08-29", "a record with no confirmation date cleared its refusal");
+  });
+
+  it("names the day it refused before the day it confirmed, on the record it cleared", () => {
+    const sentence = vendorVerdictSentence({
+      vendor: "Doczilla",
+      level: "stable",
+      historyLevel: "stable",
+      cause: null,
+      changes: [],
+      levelWithheld: null,
+      unconfirmableSince: "",
+      termsConfirmedOn: "2026-09-10",
+      refusedReads: [{ reason: "no_price_signal", refused_date: "2026-08-29" }],
+    });
+    assert.strictEqual(
+      sentence,
+      "It's stable — the change we last considered recording was refused on 2026-08-29, and we read the page again on 2026-09-10 and confirmed the terms above.",
+      "the cleared verdict states the day we refused and the day we confirmed in the wrong order",
+    );
+  });
+
+  it("keeps withholding where the later read is itself a refusal and the earlier one confirmed", () => {
+    const refusals = [
+      { reason: "confirmed_unchanged", refused_date: "2026-08-28" },
+      { reason: "measures_the_opposite", refused_date: "2026-09-09" },
+    ];
+    const published = refusedReadWithholdingStability({ historyLevel: "stable", publishedChanges: 0, termsConfirmedOn: "2026-07-24", refusals });
+    assert.strictEqual(
+      published?.reason,
+      "measures_the_opposite",
+      "a confirming refusal older than the withholding one took the withholding with it",
+    );
+    assert.strictEqual(
+      refusedReadTheConfirmationSupersedes(refusals, "2026-07-24"),
+      null,
+      "a refusal later than our last confirmation reads as one the confirmation superseded",
+    );
   });
 
   it("treats a reason it has never seen as one it could not reconcile", () => {

--- a/test/retired-vendor-page.test.ts
+++ b/test/retired-vendor-page.test.ts
@@ -273,6 +273,7 @@ describe("the retirement branch is decided before the withholding branch", () =>
     changes: [],
     levelWithheld: "states_no_terms" as const,
     unconfirmableSince: "",
+    termsConfirmedOn: "",
     offerEnded: true,
   };
 

--- a/test/uncited-change-records.test.ts
+++ b/test/uncited-change-records.test.ts
@@ -110,6 +110,7 @@ describe("the verdict engine, given a withheld rating", () => {
     changes: [record({ source_url: "" })],
     levelWithheld: null,
     unconfirmableSince: "",
+    termsConfirmedOn: "",
     ratingWithheld: { reason: "no_source", records: 1 },
     ...over,
   });

--- a/test/vendor-verdict.test.ts
+++ b/test/vendor-verdict.test.ts
@@ -61,7 +61,7 @@ function causeOf(c: DealChange): RiskCause {
 }
 
 function input(over: Partial<VendorVerdictInput> = {}): VendorVerdictInput {
-  return { vendor: "Vendor A", level: "stable", historyLevel: "stable", cause: null, changes: [], levelWithheld: null, unconfirmableSince: "", ...over };
+  return { vendor: "Vendor A", level: "stable", historyLevel: "stable", cause: null, changes: [], levelWithheld: null, unconfirmableSince: "", termsConfirmedOn: "", ...over };
 }
 
 describe("vendor verdict — one rating word, and it carries its cause", () => {
@@ -346,6 +346,7 @@ function vendorRows(): VendorRow[] {
         changes: vendorChanges,
         levelWithheld: withheld,
         unconfirmableSince,
+        termsConfirmedOn: primary.verifiedDate,
         ratingWithheld: enriched.rating_withheld ?? null,
         offerEnded: ended,
         gate: gate?.code ?? null,


### PR DESCRIPTION
Refs #1556.

`refusedReadThatWithholds` filtered the confirming refusals out of the candidate list and then ranked what was left by date, so a later confirming read could never displace an earlier refusal — it was not in the set being ranked. The only exits from a withholding were a published change or a history that stopped being stable. Reading the page again and confirming the terms was not one of them, and 122 of the 122 vendors refused on 2026-08-31 were still refused eleven days later.

`/vendor/doczilla` published `Verified 2026-09-10 · Last read 2026-09-10` in its fact table and *"When we last read the page we cite for Doczilla, on 2026-08-29, we found a change we could not reconcile"* one screen below it.

## What changed

**A refusal dated before the day we last confirmed the record's terms no longer withholds.** The clearing signal is `verifiedDate` — the field the API already documents as the day we last read the page and confirmed the terms this record publishes. A read that found the terms had moved does not advance it, so a refusal can only be cleared by a confirmation, never by a read.

**The refusal we publish is the latest live read, not the latest one we could not reconcile.** #1554 preferred an unreconciled refusal over an equality finding regardless of date. That preference and the sentence it renders cannot both be true: `/vendor/mdbootstrap` holds `unquantified_limit` (2026-08-28) and `states_no_difference` (2026-09-11), and publishing the older one made the page say *"when we last read the page … on 2026-08-28"* beside a fact table reading 2026-09-11. Two refusals on the same day still resolve in #1554's order, which is the only case where that preference does not contradict the date.

**Where a confirmation cleared a refusal, three surfaces say so** rather than falling back to *"zero pricing changes recorded"* — the verdict paragraph, the FAQ answer an agent and a crawler read, and `check_vendor_risk`. `/vendor/doczilla` now reads *"It's stable — the change we last considered recording was refused on 2026-08-29, and we read the page again on 2026-09-10 and confirmed the terms above."*

`/criteria` defined `stable` as a label a refused read removes, with no way back. Corrected, and a test now ties that sentence to the existence of a record in the cleared state.

## Measured on both builds, over `/api/offers` rather than a sample

| | main | branch |
|---|---|---|
| rows naming two different days as our last read (**AC-1**) | 5 | **0** |
| rows publishing a refused read | 149 | 145 |
| `risk_level` unrated / stable / caution / risky | 875 / 509 / 139 / 24 | 873 / **511** / 139 / 24 |
| `/state-of-free-tiers` vouched | 628 (41%) | **630** (41%) |

**AC-5.** 4 of the 149 clear — Doczilla, Tavily AI, Remote for Startups and Cloudflare Workers (Student Program). 2 regain a rating; the other 2 are `eligibility_restricted` and stay unrated for a reason that is not a refusal. 2 of the 124 free tiers #1552 moved to unconfirmed come back.

**AC-3.** The 145 whose refusal is at or after their confirmation all keep withholding. 144 keep the exact reason #1554 gave them; `/vendor/mdbootstrap` is the one that moves, from `unquantified_limit` (2026-08-28) to `states_no_difference` (2026-09-11), for the reason above. `/vendor/pubnub-com`, `/vendor/typeform-com` and `/vendor/lokalise` keep theirs.

**AC-4.** All eleven vendors holding both kinds of refusal hold the withholding one later than the confirming one, and all eleven still withhold. `/vendor/ably` publishes `measures_the_opposite` (2026-09-09) over `confirmed_unchanged` (2026-08-28).

Verified over a real MCP session as well as HTTP: `agentdeals://vendor/doczilla` reads `**Stability:** stable`, `agentdeals://vendor/lokalise` still names the day and the reason.

## Tests

14 mutants, 14 killed (`npm run mutate:1556`). The two that needed new tests were the argument order of the two dates in the cleared sentence, and dropping the FAQ branch.

Two of them found real gaps in how the test file measured its own population: it keyed the per-vendor row on the *last* offer for a vendor where the page uses the *first*, and it rebuilt the withholding rule by hand instead of reading `refused_read` off the production row.
