### PR TITLE
Withhold an empty history and a recorded threshold on a read we refused (#1558)

### DIFF
--- a/src/serve.ts
+++ b/src/serve.ts
@@ -33,7 +33,7 @@ import { NO_CURRENT_FIGURE, costHeadlineCaveat, limitCellText, mayRecommendAsFre
 import { changesByVendor } from "./superseded-census.js";
 import { buildComparisonMap, comparisonSlug } from "./comparison-pairs.js";
 import { comparisonVerdictText, freeTierFaqAnswer, stabilityFaqAnswer, type ComparisonSide, type FreeTierSide, type SideFreeTier, type StabilityRating } from "./comparison-verdict.js";
-import { publishedVendorLevel, vendorVerdictSentence, vendorBadge, freeTierClaim, statesRiskCause, narrowingSentence, changeKindNoun, refusedReadOurConfirmationSupersedes, refusedReadWeHold, refusedReadWithholdingSentence, withheldForARefusedRead, refusalWithholdsStability, termsUnconfirmedBySource, unconfirmedTermsMetaSentence, type BadgeWithholding, type FreeTierClaim, type VendorVerdictInput } from "./vendor-verdict.js";
+import { publishedVendorLevel, vendorVerdictSentence, vendorBadge, freeTierClaim, statesRiskCause, narrowingSentence, changeKindNoun, emptyHistoryCaveatSentence, refusedReadOurConfirmationSupersedes, refusedReadWeHold, refusedReadWithholdingSentence, unconfirmedThresholdSentence, whyWeCannotConfirmTheseTerms, withheldForARefusedRead, refusalWithholdsStability, termsUnconfirmedBySource, unconfirmedTermsMetaSentence, type BadgeWithholding, type FreeTierClaim, type VendorVerdictInput } from "./vendor-verdict.js";
 import { tierRecordsAFreeTier } from "./free-tier-record.js";
 import { PAGE_HEAD_OPEN, withLedeBeforeNav } from "./page-lede.js";
 import { freshnessClaimFor, withFreshnessClaim } from "./page-freshness.js";
@@ -4665,6 +4665,7 @@ function buildVendorPage(slug: string): string | null {
   const offerHasEnded = offerEnded(primary);
   const primaryGate = context.gate;
   const withheldClause = levelWithheld ? withheldLevelClause(levelWithheld, unconfirmableSince) : "";
+  const termsWeCannotConfirm = whyWeCannotConfirmTheseTerms(verdictInput);
   const ratingWithheld = enriched.rating_withheld;
 
   const riskCauseLine = statesRiskCause(verdictInput) && riskCause
@@ -4825,8 +4826,8 @@ function buildVendorPage(slug: string): string | null {
 
   const growthBullets: string[] = [];
   for (const phrase of growthLimitPhrases(publishableTerms)) {
-    growthBullets.push(levelWithheld
-      ? `We record ${phrase} as the limit, but ${withheldClause}, so we cannot confirm that threshold today.`
+    growthBullets.push(termsWeCannotConfirm
+      ? unconfirmedThresholdSentence(phrase, termsWeCannotConfirm)
       : `At ${phrase}, you'll need to upgrade.`);
   }
   if (growthBullets.length === 0 && hasFree && !termsSuperseded) {
@@ -4861,8 +4862,8 @@ function buildVendorPage(slug: string): string | null {
       </div>`;
   }).join("\n") : offerHasEnded
     ? `<p class="no-changes">${escHtmlServer(endedHistorySentence(vendorName))}</p>`
-    : levelWithheld
-    ? `<p class="no-changes">No recorded pricing changes for ${escHtmlServer(vendorName)} — but ${escHtmlServer(withheldClause)}, so nothing we have read describes these terms. Treat the empty history as a statement about our records, not about this vendor's pricing.</p>`
+    : termsWeCannotConfirm
+    ? `<p class="no-changes">${escHtmlServer(emptyHistoryCaveatSentence(vendorName, termsWeCannotConfirm))}</p>`
     : primaryGate
     ? `<p class="no-changes">No recorded pricing changes for ${escHtmlServer(vendorName)}.</p>`
     : `<p class="no-changes">No recorded pricing changes for ${escHtmlServer(vendorName)}. This is a good sign — stable pricing.</p>`;

--- a/src/vendor-verdict.ts
+++ b/src/vendor-verdict.ts
@@ -177,6 +177,37 @@ export function refusalWithholdsStability(input: VendorVerdictInput): RefusedRea
   return refusedReadWeHold(input);
 }
 
+export type UnconfirmedTerms =
+  | { because: "level_withheld"; clause: string }
+  | { because: "refused_read"; clause: string };
+
+export function whyWeCannotConfirmTheseTerms(input: VendorVerdictInput): UnconfirmedTerms | null {
+  if (input.levelWithheld) {
+    return {
+      because: "level_withheld",
+      clause: withheldLevelClause(input.levelWithheld, input.unconfirmableSince),
+    };
+  }
+  const refused = refusalWithholdsStability(input);
+  return refused ? { because: "refused_read", clause: refusedReadClause(refused) } : null;
+}
+
+const EMPTY_HISTORY_TAIL: Record<UnconfirmedTerms["because"], string> = {
+  level_withheld: "so nothing we have read describes these terms",
+  refused_read: "so we cannot tell you that nothing changed",
+};
+
+export function emptyHistoryCaveatSentence(subject: string, unconfirmed: UnconfirmedTerms): string {
+  return `No recorded pricing changes for ${subject} — but ${unconfirmed.clause},`
+    + ` ${EMPTY_HISTORY_TAIL[unconfirmed.because]}.`
+    + ` Treat the empty history as a statement about our records, not about this vendor's pricing.`;
+}
+
+export function unconfirmedThresholdSentence(phrase: string, unconfirmed: UnconfirmedTerms): string {
+  return `We record ${phrase} as the limit, but ${unconfirmed.clause},`
+    + ` so we cannot confirm that threshold today.`;
+}
+
 export function badgeWithholding(input: VendorVerdictInput): BadgeWithholding | null {
   if (withholdingDecides(input)) {
     return { reason: input.levelWithheld ?? "no_source" };

--- a/test/growth-limits.test.ts
+++ b/test/growth-limits.test.ts
@@ -201,15 +201,64 @@ const A_RATE_FROM_A_PAGE_STATING_NO_TERMS = {
   source_check: { checked: "2026-08-28", outcome: "states_no_terms", detail: "no amount, tier or rate" },
 };
 
+const A_RATE_ON_A_PAGE_WE_READ_AND_REFUSED = {
+  ...A_RATE_WE_CONFIRMED,
+  vendor: "Refusedcorp",
+  url: "https://refusedcorp.example/pricing",
+  description: "Free tier with 250 GB bandwidth",
+};
+
+const A_RATE_ON_A_PAGE_WHOSE_READ_MOVED_NOTHING = {
+  ...A_RATE_WE_CONFIRMED,
+  vendor: "Equalcorp",
+  url: "https://equalcorp.example/pricing",
+  description: "Free tier with 40 projects",
+};
+
+const refusalOf = (vendor: string, reason: string, refused_date: string) => ({
+  vendor,
+  change_type: "limits_reduced",
+  reason,
+  detail: "the page states a limit we could not quantify",
+  summary: `${vendor} may have narrowed its free tier`,
+  previous_state: null,
+  current_state: null,
+  source_url: `https://${vendor.toLowerCase()}.example/pricing`,
+  category: "Databases",
+  refused_date,
+});
+
+const READS_WE_REFUSED = {
+  refusals: [
+    refusalOf("Refusedcorp", "unquantified_limit", "2026-08-29"),
+    refusalOf("Equalcorp", "measures_no_change", "2026-08-30"),
+  ],
+};
+
+const A_READ_WE_COULD_NOT_RECONCILE =
+  "when we last read the page we cite for this offer, on 2026-08-29,"
+  + " we found a change we could not reconcile with the terms we publish";
+
+const A_READ_THAT_MOVED_NO_FIGURE =
+  "when we last read the page we cite for this offer, on 2026-08-30,"
+  + " we refused the change we considered recording because it named no figure that had moved,"
+  + " and refusing a change is not a confirmation of the terms above";
+
 let fixtureDir = "";
 let serverPort = 0;
 let proc: ChildProcess | null = null;
 
-function startServer(indexPath: string): Promise<ChildProcess> {
+function startServer(indexPath: string, refusalsPath: string): Promise<ChildProcess> {
   return new Promise((resolve, reject) => {
     const child = spawn("node", [path.join(REPO, "dist", "serve.js")], {
       stdio: ["pipe", "pipe", "pipe"],
-      env: { ...process.env, PORT: "0", BASE_URL: "http://localhost", AGENTDEALS_INDEX_PATH: indexPath },
+      env: {
+        ...process.env,
+        PORT: "0",
+        BASE_URL: "http://localhost",
+        AGENTDEALS_INDEX_PATH: indexPath,
+        AGENTDEALS_REFUSALS_PATH: refusalsPath,
+      },
     });
     const timeout = setTimeout(() => { child.kill(); reject(new Error("Server startup timeout")); }, 20000);
     child.stderr!.on("data", (data: Buffer) => {
@@ -244,13 +293,21 @@ function outgrowAnswer(body: string): string {
 before(async () => {
   fixtureDir = mkdtempSync(path.join(tmpdir(), "growth-limits-"));
   const indexPath = path.join(fixtureDir, "index.json");
+  const refusalsPath = path.join(fixtureDir, "change_refusals.json");
   writeFileSync(
     indexPath,
     JSON.stringify({
-      offers: [A_RATE_WE_CONFIRMED, A_PER_MINUTE_RATE_WE_CONFIRMED, A_RATE_FROM_A_PAGE_STATING_NO_TERMS],
+      offers: [
+        A_RATE_WE_CONFIRMED,
+        A_PER_MINUTE_RATE_WE_CONFIRMED,
+        A_RATE_FROM_A_PAGE_STATING_NO_TERMS,
+        A_RATE_ON_A_PAGE_WE_READ_AND_REFUSED,
+        A_RATE_ON_A_PAGE_WHOSE_READ_MOVED_NOTHING,
+      ],
     }, null, 2)
   );
-  proc = await startServer(indexPath);
+  writeFileSync(refusalsPath, JSON.stringify(READS_WE_REFUSED, null, 2));
+  proc = await startServer(indexPath, refusalsPath);
 });
 
 after(() => {
@@ -296,5 +353,88 @@ describe("the outgrow block on a vendor page", () => {
     const answer = outgrowAnswer(body);
     assert.doesNotMatch(answer, /^At 100 requests\/day/);
     assert.match(answer, /we cannot confirm that threshold today/);
+  });
+});
+
+function emptyHistoryParagraph(body: string): string {
+  const paragraph = body.match(/<p class="no-changes">([\s\S]*?)<\/p>/)?.[1];
+  assert.ok(paragraph, "the page must carry an empty-history paragraph for the assertion to mean anything");
+  return paragraph;
+}
+
+describe("a page whose last read we refused states neither a threshold nor an empty history as fact", () => {
+  it("renders both pages, so the assertions below are about real pages", async () => {
+    for (const slug of ["refusedcorp", "equalcorp"]) {
+      const res = await get(`/vendor/${slug}`);
+      assert.equal(res.status, 200);
+      assert.match(res.body, /we are not rating this offer today/);
+    }
+  });
+
+  it("states no threshold as fact on a read it could not reconcile", async () => {
+    const { body } = await get("/vendor/refusedcorp");
+    const block = growthBlock(body);
+    assert.doesNotMatch(block, /At 250 GB bandwidth, you'll need to upgrade/);
+    assert.equal(
+      block.match(/<li>([^<]*)<\/li>/)?.[1],
+      `We record 250 GB bandwidth as the limit, but ${A_READ_WE_COULD_NOT_RECONCILE},`
+      + ` so we cannot confirm that threshold today.`,
+    );
+  });
+
+  it("states no threshold as fact on a read that moved no figure", async () => {
+    const { body } = await get("/vendor/equalcorp");
+    assert.equal(
+      growthBlock(body).match(/<li>([^<]*)<\/li>/)?.[1],
+      `We record 40 projects as the limit, but ${A_READ_THAT_MOVED_NO_FIGURE},`
+      + ` so we cannot confirm that threshold today.`,
+    );
+  });
+
+  it("withholds the same threshold in structured data as on the page", async () => {
+    const { body } = await get("/vendor/refusedcorp");
+    const answer = outgrowAnswer(body);
+    assert.doesNotMatch(answer, /^At 250 GB bandwidth/);
+    assert.match(answer, /we cannot confirm that threshold today/);
+  });
+
+  it("calls an empty history a statement about our records on a read it could not reconcile", async () => {
+    const { body } = await get("/vendor/refusedcorp");
+    assert.equal(
+      emptyHistoryParagraph(body),
+      `No recorded pricing changes for Refusedcorp — but ${A_READ_WE_COULD_NOT_RECONCILE},`
+      + ` so we cannot tell you that nothing changed.`
+      + ` Treat the empty history as a statement about our records, not about this vendor's pricing.`,
+    );
+  });
+
+  it("calls an empty history a statement about our records on a read that moved no figure", async () => {
+    const { body } = await get("/vendor/equalcorp");
+    assert.equal(
+      emptyHistoryParagraph(body),
+      `No recorded pricing changes for Equalcorp — but ${A_READ_THAT_MOVED_NO_FIGURE},`
+      + ` so we cannot tell you that nothing changed.`
+      + ` Treat the empty history as a statement about our records, not about this vendor's pricing.`,
+    );
+  });
+
+  it("leaves both sentences on a vendor whose page we read and confirmed", async () => {
+    const { body } = await get("/vendor/controlcorp");
+    assert.match(growthBlock(body), /At 100K requests\/day, you'll need to upgrade\./);
+    assert.equal(
+      emptyHistoryParagraph(body),
+      "No recorded pricing changes for Controlcorp. This is a good sign — stable pricing.",
+    );
+  });
+
+  it("leaves the source-check sentence the way the source check writes it", async () => {
+    const { body } = await get("/vendor/prosecorp");
+    assert.equal(
+      emptyHistoryParagraph(body),
+      "No recorded pricing changes for Prosecorp — but the page we cite for this offer states no amount,"
+      + " tier or rate we can read when we last looked, on 2026-08-28, so nothing we have read describes"
+      + " these terms. Treat the empty history as a statement about our records, not about this vendor's"
+      + " pricing.",
+    );
   });
 });

--- a/test/refused-change-not-stable.test.ts
+++ b/test/refused-change-not-stable.test.ts
@@ -9,6 +9,8 @@ import { GATE_REASONS, REJECT_MEASURES_NO_CHANGE, REJECT_NULL_COMPARISON, REJECT
 import { SUPPRESSED_SAME_TRANSITION_REGRADED } from "../scripts/change-log.js";
 import { refusalsByVendor, refusedReadTheConfirmationSupersedes, refusedReadWithholdingStability, supersededRefusalSentence, REFUSAL_REASONS_THAT_CONFIRM_THE_STORED_TERMS, REFUSAL_REASONS_THAT_MEASURED_NO_DIFFERENCE, MEASURED_NO_DIFFERENCE_BADGE_LABEL, UNRECONCILED_READ_BADGE_LABEL } from "../dist/change-refusal.js";
 import { checkVendorRisk, enrichOffers, loadChangeRefusals, loadDealChanges, loadOffers, publishedChangeCount } from "../dist/data.js";
+import { LEVEL_WITHHOLDING_OUTCOMES } from "../dist/source-check.js";
+import { offerEnded } from "../dist/retirement.js";
 import { vendorSlugMap } from "../dist/vendor-slug.js";
 import { vendorVerdictSentence } from "../dist/vendor-verdict.js";
 
@@ -22,9 +24,21 @@ const STABILITY_CLAIMS: Array<{ name: string; pattern: RegExp }> = [
   { name: "rated stable", pattern: /We rate it stable/ },
   { name: "considered stable", pattern: /is considered stable/ },
   { name: "stable badge", pattern: /class="risk-badge"[^>]*>stable</ },
+  { name: "empty history is a good sign", pattern: /This is a good sign — stable pricing/ },
 ];
 
 const A_STABLE_HISTORY = /has a stable pricing history/;
+
+const A_BARE_THRESHOLD = /<li>At [^<]*?, you'll need to upgrade\.<\/li>/;
+const A_THRESHOLD_WE_CANNOT_CONFIRM = /we cannot confirm that threshold today/;
+const AN_EMPTY_HISTORY_ABOUT_OUR_RECORDS =
+  /Treat the empty history as a statement about our records, not about this vendor's pricing/;
+
+const growthBlockOf = (html: string): string =>
+  html.match(/<div class="section growth-section">[\s\S]*?<\/div>/)?.[0] ?? "";
+
+const emptyHistoryParagraphOf = (html: string): string =>
+  html.match(/<p class="no-changes">([\s\S]*?)<\/p>/)?.[1] ?? "";
 
 const verdictParagraphOf = (html: string): string =>
   html.match(/<div class="quick-verdict">\s*<p>([\s\S]*?)<\/p>/)?.[1] ?? "";
@@ -64,6 +78,9 @@ interface Subject {
   measuredNoDifference: boolean;
   onlyTheRefusal: boolean;
   confirmingOnly: boolean;
+  rated: string | null;
+  ended: boolean;
+  withheldBySourceCheck: boolean;
   published: number;
 }
 
@@ -144,6 +161,12 @@ before(async () => {
       measuredNoDifference: refusedRead !== null && MEASURED_NO_DIFFERENCE.has(refusedRead.reason),
       onlyTheRefusal: unreconciled && !otherwiseWithheld,
       confirmingOnly: count === 0 && reasons.length > 0 && reasons.every(r => CONFIRMING.has(r)),
+      rated: row?.risk_level ?? null,
+      ended: offerEnded(row),
+      withheldBySourceCheck: Boolean(
+        row?.link_unreachable
+        || (row?.source_check && LEVEL_WITHHOLDING_OUTCOMES.includes(row.source_check.outcome)),
+      ),
     };
   });
 
@@ -406,6 +429,118 @@ describe("a refused change is not a signal that nothing changed", () => {
       }
     }
     assert.deepStrictEqual(ended, [], `a free tier the page still offers is published as removed:\n${ended.join("\n")}`);
+  });
+});
+
+describe("an empty history and a recorded threshold are claims a refused read withholds too", () => {
+  it("states no threshold as fact on a page whose last read we refused", () => {
+    const stating: string[] = [];
+    for (const subject of subjects.filter(s => s.unreconciled)) {
+      const block = growthBlockOf(pages.get(subject.slug) ?? "");
+      if (A_BARE_THRESHOLD.test(block)) stating.push(`/vendor/${subject.slug}: ${block.match(A_BARE_THRESHOLD)?.[0]}`);
+    }
+    assert.deepStrictEqual(stating.slice(0, 20), [], `thresholds stated as fact over a read we refused:\n${stating.slice(0, 20).join("\n")}`);
+
+    const withheld = subjects.filter(
+      s => s.unreconciled && A_THRESHOLD_WE_CANNOT_CONFIRM.test(growthBlockOf(pages.get(s.slug) ?? "")),
+    );
+    assertPopulationFloor(withheld.length, 25, "vendor pages hold a recorded threshold behind a refused read");
+  });
+
+  it("ships the withheld threshold to an agent as well as to a reader", () => {
+    const stating: string[] = [];
+    for (const subject of subjects.filter(s => s.unreconciled)) {
+      const page = pages.get(subject.slug) ?? "";
+      if (!A_THRESHOLD_WE_CANNOT_CONFIRM.test(growthBlockOf(page))) continue;
+      const answer = page.match(/"name":"When will I outgrow[^"]*","acceptedAnswer":\{"@type":"Answer","text":"((?:[^"\\]|\\.)*)"/)?.[1] ?? "";
+      if (!A_THRESHOLD_WE_CANNOT_CONFIRM.test(answer)) stating.push(`/vendor/${subject.slug}: ${answer.slice(0, 80)}`);
+    }
+    assert.deepStrictEqual(stating.slice(0, 20), [], `structured data states a threshold the page withholds:\n${stating.slice(0, 20).join("\n")}`);
+  });
+
+  it("names the refusal and its date where an empty history is all we hold", () => {
+    const silent: string[] = [];
+    let named = 0;
+    for (const subject of subjects.filter(s => s.onlyTheRefusal && s.published === 0)) {
+      const paragraph = emptyHistoryParagraphOf(pages.get(subject.slug) ?? "");
+      if (paragraph === "") continue;
+      named++;
+      if (!AN_EMPTY_HISTORY_ABOUT_OUR_RECORDS.test(paragraph)) silent.push(`/vendor/${subject.slug}: no statement about our records`);
+      else if (!reasonWePublish(subject).test(paragraph)) silent.push(`/vendor/${subject.slug}: ${paragraph.slice(0, 120)}`);
+      else if (!paragraph.includes(subject.refusedRead?.refused_date ?? "")) silent.push(`/vendor/${subject.slug}: names no date`);
+    }
+    assert.deepStrictEqual(silent.slice(0, 20), [], `empty histories that do not say why we cannot read them:\n${silent.slice(0, 20).join("\n")}`);
+    assertPopulationFloor(named, 80, "vendor pages hold an empty history and a refused read as the only reason");
+  });
+
+  it("leaves the empty history of a gated page exactly as the gate leaves it", () => {
+    const moved: string[] = [];
+    let bare = 0;
+    for (const subject of subjects.filter(s => s.gated && !s.withheldBySourceCheck && !s.ended)) {
+      const paragraph = emptyHistoryParagraphOf(pages.get(subject.slug) ?? "");
+      if (paragraph === "") continue;
+      if (WITHHELD_FOR_A_REFUSAL.test(paragraph) || /good sign/.test(paragraph)) {
+        moved.push(`/vendor/${subject.slug}: ${paragraph.slice(0, 140)}`);
+        continue;
+      }
+      if (/^No recorded pricing changes for .*\.$/.test(paragraph)) bare++;
+    }
+    assert.deepStrictEqual(moved.slice(0, 20), [], `a gate's empty history no longer reads as the gate leaves it:\n${moved.slice(0, 20).join("\n")}`);
+    assertPopulationFloor(bare, 10, "gated vendor pages publish the bare empty-history sentence");
+    assert.ok(
+      subjects.some(s => s.gated && s.unreconciled && !s.withheldBySourceCheck),
+      "no gated page holds a refused read, so the gate is not what is keeping the refusal off it",
+    );
+  });
+
+  it("leaves the source check's sentence on a gated page the source check also withholds", () => {
+    const moved: string[] = [];
+    let read = 0;
+    for (const subject of subjects.filter(s => s.gated && s.withheldBySourceCheck && !s.ended)) {
+      const paragraph = emptyHistoryParagraphOf(pages.get(subject.slug) ?? "");
+      if (paragraph === "" || subject.published > 0) continue;
+      read++;
+      if (!/so nothing we have read describes these terms/.test(paragraph)) {
+        moved.push(`/vendor/${subject.slug}: ${paragraph.slice(0, 140)}`);
+      }
+    }
+    assert.deepStrictEqual(moved.slice(0, 20), [], `a gated page no longer says why nothing we read describes its terms:\n${moved.slice(0, 20).join("\n")}`);
+    assertPopulationFloor(read, 60, "gated vendor pages are withheld by the source check as well");
+  });
+
+  it("leaves the empty history the source check writes exactly as the source check writes it", () => {
+    const moved: string[] = [];
+    let read = 0;
+    for (const subject of subjects.filter(s => s.withheldBySourceCheck && !s.ended)) {
+      const paragraph = emptyHistoryParagraphOf(pages.get(subject.slug) ?? "");
+      if (paragraph === "" || !AN_EMPTY_HISTORY_ABOUT_OUR_RECORDS.test(paragraph)) continue;
+      read++;
+      if (!/so nothing we have read describes these terms/.test(paragraph)) {
+        moved.push(`/vendor/${subject.slug}: ${paragraph.slice(0, 140)}`);
+      }
+    }
+    assert.deepStrictEqual(moved.slice(0, 20), [], `the source check's empty-history sentence has changed:\n${moved.slice(0, 20).join("\n")}`);
+    assertPopulationFloor(read, 400, "vendor pages carry the empty-history sentence the source check writes");
+  });
+
+  it("keeps both sentences on a vendor we rate", () => {
+    const lost: string[] = [];
+    let claiming = 0;
+    for (const subject of subjects.filter(s => s.rated === "stable" && s.published === 0)) {
+      const paragraph = emptyHistoryParagraphOf(pages.get(subject.slug) ?? "");
+      if (paragraph === "") continue;
+      claiming++;
+      if (!/This is a good sign — stable pricing/.test(paragraph)) lost.push(`/vendor/${subject.slug}: ${paragraph.slice(0, 120)}`);
+    }
+    assert.deepStrictEqual(lost.slice(0, 20), [], `a rated vendor lost the sentence its empty history earns:\n${lost.slice(0, 20).join("\n")}`);
+    assertPopulationFloor(claiming, 250, "rated vendor pages call an empty history a good sign");
+
+    for (const slug of ["ahasend", "appsmith", "browserless"]) {
+      const subject = subjects.find(s => s.slug === slug);
+      assert.ok(subject?.rated === "stable", `/vendor/${slug} is no longer the rated control this was written against`);
+      assert.match(pages.get(slug) ?? "", /This is a good sign — stable pricing/);
+    }
+    assert.match(growthBlockOf(pages.get("ahasend") ?? ""), A_BARE_THRESHOLD);
   });
 });
 


### PR DESCRIPTION
Refs #1558

`/vendor/ably` published *"This is a good sign — stable pricing"* one screen below *"we cannot tell you that nothing changed"*. 127 unrated pages did, and all 127 also carried the FAQ line. 33 stated a threshold as fact under the same withholding.

## What was wrong

Both surfaces asked `levelWithheldReason`, which reads `link_unreachable` and `source_check.outcome` and nothing else. **111 of the 127 have `source_check.outcome: "ok"`** — the source check passed and the refusal was the only thing withholding the rating, so neither surface could see it.

`whyWeCannotConfirmTheseTerms` composes the two withholdings and returns the clause that explains whichever one applies. Both sentences are built at that join rather than at the render site, so the empty-history paragraph and the growth bullet read one predicate instead of two.

A refused read gets its own tail on the empty history. We *did* read the page, so *"nothing we have read describes these terms"* is not the honest sentence; *"we cannot tell you that nothing changed"* is — the same claim the FAQ answer has been making since #1552.

## Measured on both builds, served side by side, page by page

All 1,539 vendor pages fetched from a server on `main` and a server on this branch, read as rendered HTML.

| | main | branch |
|---|---|---|
| publish *"This is a good sign — stable pricing"* | 493 | **366** |
| publish *"we are not rating this offer today"* | 127 | 127 |
| **publish both** | **127** | **0** |
| bare `<li>At X, you'll need to upgrade.</li>` on a refused read | **33** | **0** |
| carry the caveated empty-history sentence | 652 | **779** |
| pages whose empty-history paragraph changed | — | **127**, every one holding a refused read, none gated |
| pages whose growth block changed | — | **33**, every one holding a refused read |

**AC-1** — 0. **AC-2** — 0 on the page and 0 in the `FAQPage` structured data, where 33 of 33 now carry the caveat. `/vendor/abstractapi` reads:

> We record 1,000 requests/mo per API as the limit, but when we last read the page we cite for this offer, on 2026-08-28, we found a change we could not reconcile with the terms we publish, so we cannot confirm that threshold today.

**AC-3** — `/vendor/ably`:

> No recorded pricing changes for Ably — but when we last read the page we cite for this offer, on 2026-09-09, we found a change we could not reconcile with the terms we publish, so we cannot tell you that nothing changed. Treat the empty history as a statement about our records, not about this vendor's pricing.

An equality finding gets its own clause, as it does on every other surface: *"…we refused the change we considered recording because it named no figure that had moved, and refusing a change is not a confirmation of the terms above, so we cannot tell you that nothing changed."*

**AC-4** — 652 → 779 carry the caveated sentence, the 652 byte-identical. **All 128 gated no-changes paragraphs are byte-identical to main**, including the 99 that a failing source check also withholds. **AC-5** — 366 pages keep the good-sign sentence and all 366 are rated `stable`; `/vendor/ahasend`, `/vendor/appsmith` and `/vendor/browserless` keep both sentences; 119 stable and 7 caution pages keep a bare threshold.

## AC-6 — a separate predicate, not an absorption

`levelWithheldReason` should not absorb `refused_read`.

1. It takes `Pick<Offer, "source_check">` and link health. It has no access to the refusal index, so absorbing means changing its signature at every call site.
2. Its return type keys `WITHHELD_LEVEL_CLAUSES`, whose five sentences are all forms of *"we could not read the page"* or *"the page does not name it"*. None is true of a refused read.
3. `levelWithheld` feeds `withholdingDecides`, which returns early in `vendorVerdictWord`, `badgeWithholding` and `vendorVerdictSentence` **before** `refusalWithholdsStability` is consulted. Absorbing it would send every refused-read page down the `withholdingDecides` path and take away the `unrated — change refused` / `unrated — change not reconciled` badge labels and the verdict sentence — undoing #1139, #1552 and #1554.

`serve.ts:4799` and `serve.ts:5089` **are unchanged**, and so is everything else. Fetching all 1,539 vendor pages from both builds and comparing the bytes with the host normalised: **1,412 are byte-identical, 127 differ, and inside those 127 the only changed lines are the empty-history paragraph and the growth bullets.** What 4799 and 5089 publish on `/vendor/ably` today, and still publish after this change, is in the census below.

## AC-7 — the census, as a list

Swept the rendered HTML of all 127, against 60 pages withheld by the source check as a positive control. The source-check path already caveats three of these surfaces and the refusal path does not — the same `levelWithheld`-only predicate, three more times.

| surface | on the 127 | on 60 withheld by the source check |
|---|---|---|
| meta description and page lede: *"X free tier includes {terms}… **Verified July 2026**"* | **111 state a verification month**; 16 carry *"Not verified — …"* because their source check also fails | 60 of 60 carry *"Not verified — {clause}"* |
| FAQ *"Is X free?"* (`serve.ts:5089`) | **127 publish a bare *"Yes, X offers a free tier: …"*** | 60 of 60 carry *"We cannot confirm that today. … treat them as unverified."* |
| FAQ *"What is X's free tier?"* (`serve.ts:5089`) | **127 state the tier and terms with no caveat** | 60 of 60 carry the same caveat |
| quick-verdict line 3 (`serve.ts:4799`) | **23 publish *"Best for {category} workloads — N alternatives available."*** | 0 |
| quick-verdict opening | 127 publish *"X's free tier offers {terms}."* | 60 also do — neither path caveats this one |
| generic growth bullet | **94 of the 127** publish *"When your usage exceeds the free tier limits, you'll need to upgrade."*, which is what a page with no parseable threshold phrase gets — it names no figure | 1,035 pages catalogue-wide publish it |

The meta description is the sharpest of these: `/vendor/ably` ships `<meta name="description" content="… Verified July 2026.">` over a read we refused on 2026-09-09, because `metaVerifiedSentence` reads `termsUnconfirmedBySource` and nothing else.

## One finding beyond the issue's population, deliberately not built

AC-2 says *0 vendor pages **whose rating is withheld*** publish a bare threshold. **6 more do**, and they are not refused reads: `/vendor/onesignal`, `/vendor/imgix`, `/vendor/stoplight`, `/vendor/pocket-alert`, `/vendor/maileroo`, `/vendor/maildroppa`, each withheld by `rating_withheld` and each with `source_check.outcome: "ok"`.

**I left them stating their thresholds, and the reason is that `rating_withheld` withholds the rating and not the terms.** Its sentence is *"The only record that would rate OneSignal cites no source"* — a statement about a change record, not about whether we have confirmed 100 emails/day. The other two withholdings are statements about the page the terms came from: the source check could not read it, or we read it and could not reconcile what we found. Writing *"We record 100 emails/day as the limit, but the only record that would rate it cites no source, so we cannot confirm that threshold today"* would be a non-sequitur. If you read AC-2 as the broader criterion, say so and it is one more branch.

## Tests

- `test/refused-change-not-stable.test.ts` — the census that should have caught this listed six stability claims and not this one. **`This is a good sign — stable pricing` is now in `STABILITY_CLAIMS`**, so the existing catalogue-wide sweep fails on it. Six new assertions: no bare threshold on any page holding a refused read, on the page and in structured data; the empty history names the refusal's reason and its date; and four negative controls — gated pages, gated-and-source-check-withheld pages, source-check pages, and rated pages.
- `test/growth-limits.test.ts` — two fixture vendors, one per refusal family, pinning both sentences exactly, with the confirmed vendor and the source-check vendor as controls.

**10 tests fail on `main` with these test files and pass here**, measured in a worktree at `main` carrying only the test changes.

**14 mutants, 13 killed.** The survivor is equivalent and worth naming: reversing the precedence inside `whyWeCannotConfirmTheseTerms` so the refusal outranks the source check changes no page, because `refusalWithholdsStability` returns null whenever `withholdingDecides` is true, which is true whenever `levelWithheld` is set and no adverse level is published. The ordering is load-bearing only for a page with a withheld level, an adverse rating and a withholding refusal — and `refusedReadWeHold` requires a stable history and zero published changes, so that population is empty and cannot be built from `publishedRisk`.