### PR TITLE
Caveat the terms on every surface a refused read withholds (#1560)

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,8 @@
     "mutate:1327": "node scripts/mutate-1327.mjs",
     "mutate:1497": "node scripts/mutate-1497.mjs",
     "report:budgets": "node scripts/report-quality-budgets.js",
-    "generate:llm-readme": "node scripts/generate-llm-api-readme.js"
+    "generate:llm-readme": "node scripts/generate-llm-api-readme.js",
+    "mutate:1560": "node scripts/mutate-1560.mjs"
   },
   "dependencies": {
     "@modelcontextprotocol/ext-apps": "^1.5.0",

--- a/scripts/mutate-1560.mjs
+++ b/scripts/mutate-1560.mjs
@@ -1,0 +1,124 @@
+import { readFileSync, writeFileSync } from "node:fs";
+import { execFileSync } from "node:child_process";
+
+const SUITE = [
+  "test/withholding-covers-every-assertive-surface.test.ts",
+  "test/meta-description-withholding.test.ts",
+  "test/gated-vendor-answers.test.ts",
+];
+
+const MUTANTS = [
+  ["the-refused-read-withholds-the-rating-and-not-the-terms", "src/vendor-verdict.ts",
+    "  read_not_reconciled: \"the_terms\",\n  change_measured_no_difference: \"the_terms\",",
+    "  read_not_reconciled: \"the_rating\",\n  change_measured_no_difference: \"the_rating\","],
+
+  ["only-the-unreconciled-family-withholds-the-terms", "src/vendor-verdict.ts",
+    "  change_measured_no_difference: \"the_terms\",",
+    "  change_measured_no_difference: \"the_rating\","],
+
+  ["an-uncited-change-record-withholds-the-terms-as-well-as-the-rating", "src/vendor-verdict.ts",
+    "  no_source: \"the_rating\",",
+    "  no_source: \"the_terms\","],
+
+  ["a-gated-offer-withholds-the-terms-as-well-as-the-listing", "src/vendor-verdict.ts",
+    "  not_a_free_offer: \"the_rating\",",
+    "  not_a_free_offer: \"the_terms\","],
+
+  ["every-withholding-leaves-the-terms-unread", "src/vendor-verdict.ts",
+    "  return WITHHOLDING_SCOPE[withholdingTag(because)] === \"the_terms\";",
+    "  return true;"],
+
+  ["no-withholding-leaves-the-terms-unread", "src/vendor-verdict.ts",
+    "  return WITHHOLDING_SCOPE[withholdingTag(because)] === \"the_terms\";",
+    "  return false;"],
+
+  ["the-reason-a-page-withholds-ignores-the-refusal", "src/vendor-verdict.ts",
+    "  if (input.levelWithheld) return { reason: input.levelWithheld };\n  const refused = refusalWithholdsStability(input);\n  return refused ? refusedReadWithholding(refused) : null;",
+    "  if (input.levelWithheld) return { reason: input.levelWithheld };\n  return null;"],
+
+  ["the-meta-description-states-the-terms-as-verified-over-a-refusal", "src/vendor-verdict.ts",
+    "  if (withheldForARefusedRead(because)) return NOT_VERIFIED(refusedReadWithholdingMetaClause(because));",
+    "  if (withheldForARefusedRead(because)) return null;"],
+
+  ["the-meta-description-drops-the-words-that-withdraw-the-claim", "src/vendor-verdict.ts",
+    "export const NOT_VERIFIED = (clause: string): string => `Not verified — ${clause}.`;",
+    "export const NOT_VERIFIED = (clause: string): string => `${clause}.`;"],
+
+  ["the-meta-description-reads-the-refusal-before-the-source-check", "src/vendor-verdict.ts",
+    "  const bySource = termsUnconfirmedBySource(input);\n  if (bySource) return NOT_VERIFIED(unconfirmedTermsClause(bySource));\n  const unconfirmed = whyWeCannotConfirmTheseTerms(input);",
+    "  const unconfirmed = whyWeCannotConfirmTheseTerms(input);\n  const bySource = unconfirmed ? null : termsUnconfirmedBySource(input);\n  if (bySource) return NOT_VERIFIED(unconfirmedTermsClause(bySource));"],
+
+  ["both-refusal-families-publish-the-same-meta-sentence", "src/vendor-verdict.ts",
+    "    ? measuredNoDifferenceMetaClause(because.refusedOn)\n    : unreconciledReadMetaClause(because.refusedOn);",
+    "    ? measuredNoDifferenceMetaClause(because.refusedOn)\n    : measuredNoDifferenceMetaClause(because.refusedOn);"],
+
+  ["the-caveat-names-the-other-family-of-refusal", "src/vendor-verdict.ts",
+    "    ? measuredNoDifferenceSentence(subject, because.refusedOn)\n    : unreconciledReadSentence(subject, because.refusedOn);",
+    "    ? unreconciledReadSentence(subject, because.refusedOn)\n    : measuredNoDifferenceSentence(subject, because.refusedOn);"],
+
+  ["the-answer-caveats-without-naming-the-day-or-the-vendor", "src/serve.ts",
+    "    ? `We cannot confirm that today. ${termsWeCannotConfirm.sentence} `",
+    "    ? `We cannot confirm that today. `"],
+
+  ["the-free-tier-answer-reads-the-source-check-and-not-the-refusal", "src/serve.ts",
+    "    : termsWeCannotConfirm\n    ? `${eligibilityGateSentence}${unconfirmedTermsPreamble}Our stored record says",
+    "    : levelWithheld\n    ? `${eligibilityGateSentence}${unconfirmedTermsPreamble}Our stored record says"],
+
+  ["the-tier-answer-reads-the-source-check-and-not-the-refusal", "src/serve.ts",
+    "    : eligibilityGateSentence + (termsWeCannotConfirm\n    ? `${unconfirmedTermsPreamble}Our stored record calls",
+    "    : eligibilityGateSentence + (levelWithheld\n    ? `${unconfirmedTermsPreamble}Our stored record calls"],
+
+  ["the-recommendation-line-reads-the-source-check-and-not-the-refusal", "src/serve.ts",
+    "    : alternatives.length > 0 && !termsWeCannotConfirm && !primaryGate",
+    "    : alternatives.length > 0 && !levelWithheld && !primaryGate"],
+
+  ["the-meta-description-ignores-the-withholding-entirely", "src/serve.ts",
+    "  const termsNotVerified = termsNotVerifiedMetaSentence(verdictInput);",
+    "  const termsNotVerified: string | null = null;"],
+
+  ["the-page-is-built-from-a-record-holding-no-refusals", "src/vendor-verdict-input.ts",
+    "      termsConfirmedOn: primary.verifiedDate,\n      refusedReads,",
+    "      termsConfirmedOn: primary.verifiedDate,\n      refusedReads: [],"],
+
+  ["the-badge-names-a-gate-by-the-word-gated-rather-than-its-code", "src/vendor-verdict.ts",
+    "  return because.reason === \"gated\" ? because.gate : because.reason;",
+    "  return because.reason as WithholdingTag;"],
+
+  ["the-empty-history-caveat-reads-the-refusal-as-a-reading-failure", "src/vendor-verdict.ts",
+    "  read_not_reconciled: \"so we cannot tell you that nothing changed\",\n  change_measured_no_difference: \"so we cannot tell you that nothing changed\",",
+    "  read_not_reconciled: \"so nothing we have read describes these terms\",\n  change_measured_no_difference: \"so nothing we have read describes these terms\","],
+];
+
+function run(cmd, args) {
+  try {
+    execFileSync(cmd, args, { stdio: "pipe", encoding: "utf-8" });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+const survivors = [];
+const uncompiled = [];
+const skipped = [];
+for (const [name, file, from, to] of MUTANTS) {
+  const original = readFileSync(file, "utf-8");
+  if (!original.includes(from)) {
+    console.log(`SKIP  ${name} — the line it mutates is not in ${file}`);
+    skipped.push(name);
+    continue;
+  }
+  writeFileSync(file, original.replace(from, to));
+  const built = run("npm", ["run", "build"]);
+  const green = built && run("node", ["--test", "--test-concurrency", "1", ...SUITE]);
+  writeFileSync(file, original);
+  if (!built) uncompiled.push(name);
+  console.log(`${green ? "SURVIVED" : built ? "killed  " : "DID NOT COMPILE"}  ${name}`);
+  if (green) survivors.push(name);
+}
+run("npm", ["run", "build"]);
+const killed = MUTANTS.length - survivors.length - uncompiled.length - skipped.length;
+console.log(`\n${killed}/${MUTANTS.length} killed`);
+if (survivors.length > 0) console.log("survivors:", survivors.join(", "));
+if (uncompiled.length > 0) console.log("did not compile:", uncompiled.join(", "));
+if (skipped.length > 0) console.log("skipped — target string moved, so these scored nothing:", skipped.join(", "));

--- a/scripts/mutate-1560.mjs
+++ b/scripts/mutate-1560.mjs
@@ -5,6 +5,7 @@ const SUITE = [
   "test/withholding-covers-every-assertive-surface.test.ts",
   "test/meta-description-withholding.test.ts",
   "test/gated-vendor-answers.test.ts",
+  "test/growth-limits.test.ts",
 ];
 
 const MUTANTS = [
@@ -84,6 +85,10 @@ const MUTANTS = [
     "  return because.reason === \"gated\" ? because.gate : because.reason;",
     "  return because.reason as WithholdingTag;"],
 
+  ["the-refusal-is-exempted-from-the-scope-at-runtime", "src/vendor-verdict.ts",
+    "  return WITHHOLDING_SCOPE[withholdingTag(because)] === \"the_terms\";\n}",
+    "  return WITHHOLDING_SCOPE[withholdingTag(because)] === \"the_terms\" && !withheldForARefusedRead(because);\n}"],
+
   ["the-empty-history-caveat-reads-the-refusal-as-a-reading-failure", "src/vendor-verdict.ts",
     "  read_not_reconciled: \"so we cannot tell you that nothing changed\",\n  change_measured_no_difference: \"so we cannot tell you that nothing changed\",",
     "  read_not_reconciled: \"so nothing we have read describes these terms\",\n  change_measured_no_difference: \"so nothing we have read describes these terms\","],
@@ -98,10 +103,12 @@ function run(cmd, args) {
   }
 }
 
+const only = process.argv[2] ?? "";
 const survivors = [];
 const uncompiled = [];
 const skipped = [];
 for (const [name, file, from, to] of MUTANTS) {
+  if (only && !name.includes(only)) continue;
   const original = readFileSync(file, "utf-8");
   if (!original.includes(from)) {
     console.log(`SKIP  ${name} — the line it mutates is not in ${file}`);
@@ -117,8 +124,9 @@ for (const [name, file, from, to] of MUTANTS) {
   if (green) survivors.push(name);
 }
 run("npm", ["run", "build"]);
-const killed = MUTANTS.length - survivors.length - uncompiled.length - skipped.length;
-console.log(`\n${killed}/${MUTANTS.length} killed`);
+const ran = MUTANTS.filter(([name]) => !only || name.includes(only)).length;
+const killed = ran - survivors.length - uncompiled.length - skipped.length;
+console.log(`\n${killed}/${ran} killed`);
 if (survivors.length > 0) console.log("survivors:", survivors.join(", "));
 if (uncompiled.length > 0) console.log("did not compile:", uncompiled.join(", "));
 if (skipped.length > 0) console.log("skipped — target string moved, so these scored nothing:", skipped.join(", "));

--- a/src/change-refusal.ts
+++ b/src/change-refusal.ts
@@ -177,6 +177,14 @@ export function measuredNoDifferenceSentence(subject: string, refusedOn: string)
     + ` and refusing a change is not a confirmation of the terms we publish for it.`;
 }
 
+export function unreconciledReadMetaClause(refusedOn: string): string {
+  return `our last read, on ${refusedOn}, found a change we could not reconcile`;
+}
+
+export function measuredNoDifferenceMetaClause(refusedOn: string): string {
+  return `we refused the change we last considered recording, on ${refusedOn}`;
+}
+
 export function refusedReadClause(refusal: RefusedRead): string {
   return refusalMeasuredNoDifference(refusal)
     ? measuredNoDifferenceClause(refusal.refused_date)

--- a/src/serve.ts
+++ b/src/serve.ts
@@ -7,7 +7,7 @@ import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/
 import { createServer, getServerCard } from "./server.js";
 import { oldestVerifiedDateForSlug, vendorRiskAssessment, publishedRisk, levelWithheldStatement, vendorNotIndexedSentence, riskCauseOf, freeTierEndingRecord, NEGATIVE_CHANGE_TYPES, POSITIVE_CHANGE_TYPES, SEVERE_CHANGE_TYPES, loadOffers, getCategories, getNewOffers, getNewestDeals, searchOffers, enrichOffers, gateForOffer, loadDealChanges, getDealChanges, changeContext, DEFAULT_CHANGE_WINDOW_DAYS, getOfferDetails, compareServices, checkVendorRisk, auditStack, getExpiringDeals, getWeeklyDigest, getFormattedWeeklyDigest, getFreshnessMetrics, publishedStabilityIndex, stabilityWithheldDisclosure, UNRATED_STABILITY, type StabilityIndex, type PublishedStabilityClass, getVendorReferral, sanitizeQuery, getChangeLogFreshness, isEventDated, partitionByDateProvenance } from "./data.js";
 import { loadChangeRefusals } from "./data.js";
-import { confirmingRead, confirmingReadSentence, refusalsByVendor, refusedReadSentence, supersededRefusalSentence, MEASURED_NO_DIFFERENCE_BADGE_LABEL, UNRECONCILED_READ_BADGE_LABEL, type ChangeRefusal } from "./change-refusal.js";
+import { confirmingRead, confirmingReadSentence, refusalsByVendor, refusedReadSentence, supersededRefusalSentence, type ChangeRefusal } from "./change-refusal.js";
 import { getStackRecommendation } from "./stacks.js";
 import { estimateCosts } from "./costs.js";
 import { classifyRequest } from "./client-class.js";
@@ -25,6 +25,7 @@ import { retiredCategoryDescription, retiredCategoryNoticeHtml, retiredCategoryT
 import { LINK_GRACE_DAYS, unreachableNoticeForUrl } from "./link-health.js";
 import { offerEnded, offerRetired, recordedTierSentence, endedHeadline, endedHistorySentence, endedReliabilitySentence, endedEmptyChangeHistorySentence, ENDED_BADGE_LABEL, ENDED_SINCE_CHANGES_SENTENCE, type OfferTierAndUrl } from "./retirement.js";
 import { amountUnstatedSentence, LAST_RESOLVED, levelWithheldReason, levelWithheldSince, withheldLevelClause, withheldLevelSentence, type LevelWithheldReason } from "./source-check.js";
+import { vendorVerdictContextFrom, type VendorVerdictContext } from "./vendor-verdict-input.js";
 import { readingIsBehindTheLoop, reverificationIntervalDays } from "./badge-staleness.js";
 import { LAST_READ_LABEL, VERIFICATION_DATES_HEADING, lastReadDate, lastReadNote, verificationDatesCell, verificationDatesSentence } from "./read-date.js";
 import { SUPERSEDED_TERMS_LABEL, readingBehindTheChange, supersededTermsAnswer, supersededTermsMetaSentence, supersededTermsNotice, supersededTermsNoticeHtml, supersededTermsRecord, supersededTermsVerdictSentence, supersedingChange, type SupersededTermsRecord } from "./superseded-description.js";
@@ -33,7 +34,7 @@ import { NO_CURRENT_FIGURE, costHeadlineCaveat, limitCellText, mayRecommendAsFre
 import { changesByVendor } from "./superseded-census.js";
 import { buildComparisonMap, comparisonSlug } from "./comparison-pairs.js";
 import { comparisonVerdictText, freeTierFaqAnswer, stabilityFaqAnswer, type ComparisonSide, type FreeTierSide, type SideFreeTier, type StabilityRating } from "./comparison-verdict.js";
-import { publishedVendorLevel, vendorVerdictSentence, vendorBadge, freeTierClaim, statesRiskCause, narrowingSentence, changeKindNoun, emptyHistoryCaveatSentence, refusedReadOurConfirmationSupersedes, refusedReadWeHold, refusedReadWithholdingSentence, unconfirmedThresholdSentence, whyWeCannotConfirmTheseTerms, withheldForARefusedRead, refusalWithholdsStability, termsUnconfirmedBySource, unconfirmedTermsMetaSentence, type BadgeWithholding, type FreeTierClaim, type VendorVerdictInput } from "./vendor-verdict.js";
+import { publishedVendorLevel, vendorVerdictSentence, vendorBadge, freeTierClaim, statesRiskCause, narrowingSentence, changeKindNoun, emptyHistoryCaveatSentence, refusedReadOurConfirmationSupersedes, refusedReadWeHold, refusedReadWithholdingSentence, unconfirmedThresholdSentence, whyWeCannotConfirmTheseTerms, withheldForARefusedRead, refusalWithholdsStability, termsUnconfirmedBySource, termsNotVerifiedMetaSentence, unconfirmedTermsMetaSentence, withheldBadgeLabel, type BadgeWithholding, type FreeTierClaim, type VendorVerdictInput } from "./vendor-verdict.js";
 import { tierRecordsAFreeTier } from "./free-tier-record.js";
 import { PAGE_HEAD_OPEN, withLedeBeforeNav } from "./page-lede.js";
 import { freshnessClaimFor, withFreshnessClaim } from "./page-freshness.js";
@@ -75,7 +76,7 @@ import { statedFreeTierBasis, unrankedBestAnswer, unrankedListingBasis } from ".
 import { SSE_KEEPALIVE_FRAME, keepaliveIntervalMs, sessionRecoveryBody } from "./mcp-stream.js";
 import { ASSISTANTS_API_SHUTDOWN } from "./assistants-shutdown.js";
 import { discontinuedOnOrBefore, PRODUCT_DEPRECATED } from "./product-deprecation.js";
-import { rankOffers, rankForListing, rotateListing, utcDate, gateFor, notAFreeOfferGateFor, descriptionDeniesFreeTier, classifyTier, CRITERIA_PATH, DEMOTE_ONLY_POLICY, DISCLOSURE_RATIONALE, TIE_BREAK_ALGORITHM, NAMED_SUBSET_RULE, NAMED_SUBSET_FIELD_RULE, GATE_TABLE, DEMERIT_TABLE, NOT_FREE_TIER_RULES, TIME_LIMITED_TIER_RULES, type TieBreak, type Gate, type GateCode } from "./ranking.js";
+import { rankOffers, rankForListing, rotateListing, utcDate, gateFor, notAFreeOfferGateFor, descriptionDeniesFreeTier, classifyTier, CRITERIA_PATH, DEMOTE_ONLY_POLICY, DISCLOSURE_RATIONALE, TIE_BREAK_ALGORITHM, NAMED_SUBSET_RULE, NAMED_SUBSET_FIELD_RULE, GATE_TABLE, DEMERIT_TABLE, NOT_FREE_TIER_RULES, TIME_LIMITED_TIER_RULES, type TieBreak, type Gate } from "./ranking.js";
 import type { RankedEntry, RankingResult } from "./ranking.js";
 import { eligibilityGateAsPublished, gatedShareDescriptionClause, gatedShareLede, publishableEligibilityConditions } from "./eligibility.js";
 import { gateDisclosureFor } from "./gate-disclosure.js";
@@ -876,30 +877,6 @@ interface BadgeReading {
   verifiedDate: string | null;
 }
 
-const WITHHELD_BADGE_LABELS: Record<LevelWithheldReason | "no_source", string> = {
-  no_source: "unrated \u2014 no source",
-  link_unreachable: "unrated \u2014 page unreachable",
-  unreadable: "unrated \u2014 page unreadable",
-  states_no_terms: "unrated \u2014 page states no price",
-  does_not_name_vendor: "unrated \u2014 page omits vendor",
-  does_not_name_product: "unrated \u2014 page omits product",
-};
-
-const GATED_BADGE_LABELS: Record<GateCode, string> = {
-  eligibility_restricted: "unrated \u2014 restricted offer",
-  not_a_free_offer: "unrated \u2014 not a free offer",
-  offer_expired: "unrated \u2014 offer expired",
-  offer_retired: "unrated \u2014 offer ended",
-  verification_lapsed: "unrated \u2014 not re-confirmed",
-};
-
-function withheldBadgeLabel(because: BadgeWithholding): string {
-  if (because.reason === "gated") return GATED_BADGE_LABELS[because.gate];
-  if (because.reason === "read_not_reconciled") return UNRECONCILED_READ_BADGE_LABEL;
-  if (because.reason === "change_measured_no_difference") return MEASURED_NO_DIFFERENCE_BADGE_LABEL;
-  return WITHHELD_BADGE_LABELS[because.reason];
-}
-
 let reverificationInterval: { on: string; days: number } | null = null;
 
 function badgeStaleAfterDays(): number {
@@ -924,17 +901,6 @@ function getBadgeStatus(vendorSlug: string): BadgeReading {
   return reading;
 }
 
-interface VendorVerdictContext {
-  vendorOffers: Offer[];
-  primary: Offer;
-  enriched: EnrichedOfferRow;
-  vendorChanges: DealChange[];
-  gate: Gate | null;
-  levelWithheld: LevelWithheldReason | null;
-  unconfirmableSince: string;
-  input: VendorVerdictInput;
-}
-
 const verdictContexts = new Map<string, { on: string; context: VendorVerdictContext | null }>();
 
 function vendorVerdictContext(vendorName: string, servedOn: string): VendorVerdictContext | null {
@@ -946,43 +912,13 @@ function vendorVerdictContext(vendorName: string, servedOn: string): VendorVerdi
 }
 
 function buildVendorVerdictContext(vendorName: string, servedOn: string): VendorVerdictContext | null {
-  const vendorOffers = offers.filter(o => o.vendor === vendorName);
-  if (vendorOffers.length === 0) return null;
-
-  const primary = vendorOffers[0];
-  const enriched = enrichOffers([primary])[0];
-  const vendorChanges = changesFor(vendorName);
-  const linkUnreachable = enriched.link_unreachable;
-  const levelWithheld = levelWithheldReason(primary, linkUnreachable);
-  const unconfirmableSince = levelWithheldSince(primary, linkUnreachable);
-  const gate = gateFor(primary, servedOn);
-
-  return {
-    vendorOffers,
-    primary,
-    enriched,
-    vendorChanges,
-    gate,
-    levelWithheld,
-    unconfirmableSince,
-    input: {
-      vendor: vendorName,
-      tier: primary.tier,
-      level: enriched.risk_level ?? null,
-      historyLevel: publishedRisk(primary, vendorChanges, servedOn).history_level,
-      cause: enriched.risk_cause,
-      changes: vendorChanges,
-      levelWithheld,
-      unconfirmableSince,
-      ratingWithheld: enriched.rating_withheld,
-      offerEnded: offerEnded(primary),
-      gate: gate?.code ?? null,
-      linkUnreachable: Boolean(linkUnreachable),
-      sourceCheck: primary.source_check?.outcome ?? null,
-      termsConfirmedOn: primary.verifiedDate,
-      refusedReads: refusalsFor(vendorName),
-    },
-  };
+  return vendorVerdictContextFrom({
+    vendor: vendorName,
+    vendorOffers: offers.filter(o => o.vendor === vendorName),
+    vendorChanges: changesFor(vendorName),
+    refusedReads: refusalsFor(vendorName),
+    servedOn,
+  });
 }
 
 function freeTierClaimFor(vendorName: string, servedOn: string): FreeTierClaim | null {
@@ -4783,8 +4719,9 @@ function buildVendorPage(slug: string): string | null {
   const verifiedSentence = discontinuedOn
     ? ` Discontinued ${discontinuedOn}.`
     : enriched.link_unreachable ? "" : ` Verified ${verifiedMonth}.`;
-  const metaVerifiedSentence = termsUnconfirmed && !discontinuedOn
-    ? ` ${unconfirmedTermsMetaSentence(termsUnconfirmed)}`
+  const termsNotVerified = termsNotVerifiedMetaSentence(verdictInput);
+  const metaVerifiedSentence = termsNotVerified && !discontinuedOn
+    ? ` ${termsNotVerified}`
     : verifiedSentence;
   const eligibilityGateSentence = primaryEligibilityGate ? `${primaryEligibilityGate.reason} ` : "";
   const metaDesc = eligibilityGateSentence + (termsSuperseded
@@ -4797,7 +4734,7 @@ function buildVendorPage(slug: string): string | null {
   const verdictLine2 = vendorVerdictSentence(verdictInput);
   const verdictLine3 = discontinuedOn
     ? `${vendorName} was discontinued on ${discontinuedOn}, so it is not a current option${alternatives.length > 0 ? ` — the ${alternatives.length} alternatives below are replacements` : ""}.`
-    : alternatives.length > 0 && !levelWithheld && !primaryGate
+    : alternatives.length > 0 && !termsWeCannotConfirm && !primaryGate
     ? `Best for ${primary.category.toLowerCase()} workloads${alternatives.length >= 5 ? ` — ${alternatives.length} alternatives available` : ""}.`
     : "";
   const verdictSubject = primaryGate ? primaryGate.reason : retiredSentence;
@@ -5087,8 +5024,8 @@ ${allCompareLinks.join("\n")}
   }
 
   const storedTerms = storedTermsOf(primary);
-  const unconfirmedTermsPreamble = levelWithheld
-    ? `We cannot confirm that today. ${withheldLevelSentence(levelWithheld, vendorName, unconfirmableSince)} `
+  const unconfirmedTermsPreamble = termsWeCannotConfirm
+    ? `We cannot confirm that today. ${termsWeCannotConfirm.sentence} `
     : "";
   const withUnconfirmedTermsCaveat = (terms: string) =>
     `${terms}${/[.!?…]$/.test(terms.trim()) ? "" : "."} We have not confirmed these terms against the source we cite, so treat them as unverified.`;
@@ -5101,8 +5038,8 @@ ${allCompareLinks.join("\n")}
     : retiredSentence
     ? `${retiredSentence} ${storedTerms}`
     : primaryGateBeyondEligibility
-    ? `${eligibilityGateSentence}${primaryGateBeyondEligibility.reason} ${levelWithheld ? `${unconfirmedTermsPreamble}${withUnconfirmedTermsCaveat(storedTerms)}` : storedTerms}${eligibilityConditionsSentence}`
-    : levelWithheld
+    ? `${eligibilityGateSentence}${primaryGateBeyondEligibility.reason} ${termsWeCannotConfirm ? `${unconfirmedTermsPreamble}${withUnconfirmedTermsCaveat(storedTerms)}` : storedTerms}${eligibilityConditionsSentence}`
+    : termsWeCannotConfirm
     ? `${eligibilityGateSentence}${unconfirmedTermsPreamble}Our stored record says ${vendorName} offers a free tier: ${primary.tier}. ${withUnconfirmedTermsCaveat(storedTerms)}${eligibilityConditionsSentence}`
     : primaryEligibilityGate
     ? `${eligibilityGateSentence}${vendorName} offers a free tier: ${primary.tier}. ${storedTerms}${eligibilityConditionsSentence}`
@@ -5111,7 +5048,7 @@ ${allCompareLinks.join("\n")}
     ? `${eligibilityGateSentence}${vendorName}'s free tier is called "${primary.tier}". ${supersededTermsNotice(vendorName, termsSuperseded)}`
     : retiredSentence
     ? `${retiredSentence} ${primary.description}`
-    : eligibilityGateSentence + (levelWithheld
+    : eligibilityGateSentence + (termsWeCannotConfirm
     ? `${unconfirmedTermsPreamble}Our stored record calls ${vendorName}'s free tier "${primary.tier}". ${withUnconfirmedTermsCaveat(primary.description)}`
     : `${vendorName}'s free tier is called "${primary.tier}". ${primary.description}`);
   const faqReliableAnswer = offerHasEnded

--- a/src/serve.ts
+++ b/src/serve.ts
@@ -34,7 +34,7 @@ import { NO_CURRENT_FIGURE, costHeadlineCaveat, limitCellText, mayRecommendAsFre
 import { changesByVendor } from "./superseded-census.js";
 import { buildComparisonMap, comparisonSlug } from "./comparison-pairs.js";
 import { comparisonVerdictText, freeTierFaqAnswer, stabilityFaqAnswer, type ComparisonSide, type FreeTierSide, type SideFreeTier, type StabilityRating } from "./comparison-verdict.js";
-import { publishedVendorLevel, vendorVerdictSentence, vendorBadge, freeTierClaim, statesRiskCause, narrowingSentence, changeKindNoun, emptyHistoryCaveatSentence, refusedReadOurConfirmationSupersedes, refusedReadWeHold, refusedReadWithholdingSentence, unconfirmedThresholdSentence, whyWeCannotConfirmTheseTerms, withheldForARefusedRead, refusalWithholdsStability, termsUnconfirmedBySource, termsNotVerifiedMetaSentence, unconfirmedTermsMetaSentence, withheldBadgeLabel, type BadgeWithholding, type FreeTierClaim, type VendorVerdictInput } from "./vendor-verdict.js";
+import { publishedVendorLevel, vendorVerdictSentence, vendorBadge, freeTierClaim, statesRiskCause, narrowingSentence, changeKindNoun, emptyHistoryCaveatSentence, refusedReadOurConfirmationSupersedes, refusedReadWeHold, refusedReadWithholdingSentence, unconfirmedThresholdSentence, whyWeCannotConfirmTheseTerms, withheldForARefusedRead, refusalWithholdsStability, termsUnconfirmedBySource, termsNotVerifiedMetaSentence, withheldBadgeLabel, type BadgeWithholding, type FreeTierClaim, type VendorVerdictInput } from "./vendor-verdict.js";
 import { tierRecordsAFreeTier } from "./free-tier-record.js";
 import { PAGE_HEAD_OPEN, withLedeBeforeNav } from "./page-lede.js";
 import { freshnessClaimFor, withFreshnessClaim } from "./page-freshness.js";

--- a/src/vendor-verdict-input.ts
+++ b/src/vendor-verdict-input.ts
@@ -1,0 +1,67 @@
+import type { DealChange, Offer } from "./types.js";
+import { enrichOffers, publishedRisk } from "./data.js";
+
+type EnrichedOfferRow = ReturnType<typeof enrichOffers>[number];
+import { gateFor, type Gate } from "./ranking.js";
+import { offerEnded } from "./retirement.js";
+import { levelWithheldReason, levelWithheldSince, type LevelWithheldReason } from "./source-check.js";
+import type { RefusedRead } from "./change-refusal.js";
+import type { VendorVerdictInput } from "./vendor-verdict.js";
+
+export interface VendorVerdictContext {
+  vendorOffers: Offer[];
+  primary: Offer;
+  enriched: EnrichedOfferRow;
+  vendorChanges: DealChange[];
+  gate: Gate | null;
+  levelWithheld: LevelWithheldReason | null;
+  unconfirmableSince: string;
+  input: VendorVerdictInput;
+}
+
+export interface VendorVerdictEvidence {
+  vendor: string;
+  vendorOffers: Offer[];
+  vendorChanges: DealChange[];
+  refusedReads: readonly RefusedRead[];
+  servedOn: string;
+}
+
+export function vendorVerdictContextFrom(evidence: VendorVerdictEvidence): VendorVerdictContext | null {
+  const { vendor, vendorOffers, vendorChanges, refusedReads, servedOn } = evidence;
+  if (vendorOffers.length === 0) return null;
+
+  const primary = vendorOffers[0];
+  const enriched = enrichOffers([primary])[0];
+  const linkUnreachable = enriched.link_unreachable;
+  const levelWithheld = levelWithheldReason(primary, linkUnreachable);
+  const unconfirmableSince = levelWithheldSince(primary, linkUnreachable);
+  const gate = gateFor(primary, servedOn);
+
+  return {
+    vendorOffers,
+    primary,
+    enriched,
+    vendorChanges,
+    gate,
+    levelWithheld,
+    unconfirmableSince,
+    input: {
+      vendor,
+      tier: primary.tier,
+      level: enriched.risk_level ?? null,
+      historyLevel: publishedRisk(primary, vendorChanges, servedOn).history_level,
+      cause: enriched.risk_cause,
+      changes: vendorChanges,
+      levelWithheld,
+      unconfirmableSince,
+      ratingWithheld: enriched.rating_withheld,
+      offerEnded: offerEnded(primary),
+      gate: gate?.code ?? null,
+      linkUnreachable: Boolean(linkUnreachable),
+      sourceCheck: primary.source_check?.outcome ?? null,
+      termsConfirmedOn: primary.verifiedDate,
+      refusedReads,
+    },
+  };
+}

--- a/src/vendor-verdict.ts
+++ b/src/vendor-verdict.ts
@@ -8,6 +8,7 @@ import {
   termsUnconfirmedOutcome,
   unconfirmedTermsClause,
   withheldLevelClause,
+  withheldLevelSentence,
   type LevelWithheldReason,
   type TermsUnconfirmedReason,
 } from "./source-check.js";
@@ -17,13 +18,19 @@ import { vendorHistorySentence, type PublishedRiskLevel } from "./vendor-history
 import {
   confirmingRead,
   confirmingReadClause,
+  measuredNoDifferenceClause,
+  measuredNoDifferenceMetaClause,
   measuredNoDifferenceSentence,
   refusalMeasuredNoDifference,
   refusedReadClause,
   refusedReadTheConfirmationSupersedes,
   refusedReadWithholdingStability,
   supersededRefusalClause,
+  unreconciledReadClause,
+  unreconciledReadMetaClause,
   unreconciledReadSentence,
+  MEASURED_NO_DIFFERENCE_BADGE_LABEL,
+  UNRECONCILED_READ_BADGE_LABEL,
   type RefusedRead,
 } from "./change-refusal.js";
 
@@ -84,6 +91,60 @@ export function withheldForARefusedRead(because: BadgeWithholding): because is R
   return because.reason === "read_not_reconciled" || because.reason === "change_measured_no_difference";
 }
 
+export type WithholdingTag = Exclude<BadgeWithholding["reason"], "gated"> | GateCode;
+
+export function withholdingTag(because: BadgeWithholding): WithholdingTag {
+  return because.reason === "gated" ? because.gate : because.reason;
+}
+
+export type WithholdingScope = "the_terms" | "the_rating";
+
+export const WITHHOLDING_SCOPE = {
+  link_unreachable: "the_terms",
+  unreadable: "the_terms",
+  states_no_terms: "the_terms",
+  does_not_name_vendor: "the_terms",
+  does_not_name_product: "the_terms",
+  read_not_reconciled: "the_terms",
+  change_measured_no_difference: "the_terms",
+  no_source: "the_rating",
+  eligibility_restricted: "the_rating",
+  not_a_free_offer: "the_rating",
+  offer_expired: "the_rating",
+  offer_retired: "the_rating",
+  verification_lapsed: "the_rating",
+} as const satisfies Record<WithholdingTag, WithholdingScope>;
+
+export type TermsWithholdingTag = {
+  [K in WithholdingTag]: (typeof WITHHOLDING_SCOPE)[K] extends "the_terms" ? K : never;
+}[WithholdingTag];
+
+export type TermsWithholding = Extract<BadgeWithholding, { reason: TermsWithholdingTag }>;
+
+export function withholdsTheTerms(because: BadgeWithholding): because is TermsWithholding {
+  return WITHHOLDING_SCOPE[withholdingTag(because)] === "the_terms";
+}
+
+export const WITHHOLDING_BADGE_LABELS: Record<WithholdingTag, string> = {
+  no_source: "unrated — no source",
+  link_unreachable: "unrated — page unreachable",
+  unreadable: "unrated — page unreadable",
+  states_no_terms: "unrated — page states no price",
+  does_not_name_vendor: "unrated — page omits vendor",
+  does_not_name_product: "unrated — page omits product",
+  read_not_reconciled: UNRECONCILED_READ_BADGE_LABEL,
+  change_measured_no_difference: MEASURED_NO_DIFFERENCE_BADGE_LABEL,
+  eligibility_restricted: "unrated — restricted offer",
+  not_a_free_offer: "unrated — not a free offer",
+  offer_expired: "unrated — offer expired",
+  offer_retired: "unrated — offer ended",
+  verification_lapsed: "unrated — not re-confirmed",
+};
+
+export function withheldBadgeLabel(because: BadgeWithholding): string {
+  return WITHHOLDING_BADGE_LABELS[withholdingTag(because)];
+}
+
 export function refusedReadWithholdingSentence(
   subject: string,
   because: RefusedReadWithholding,
@@ -93,7 +154,19 @@ export function refusedReadWithholdingSentence(
     : unreconciledReadSentence(subject, because.refusedOn);
 }
 
-export function refusedReadWithholding(refusal: RefusedRead): BadgeWithholding {
+export function refusedReadWithholdingClause(because: RefusedReadWithholding): string {
+  return because.reason === "change_measured_no_difference"
+    ? measuredNoDifferenceClause(because.refusedOn)
+    : unreconciledReadClause(because.refusedOn);
+}
+
+export function refusedReadWithholdingMetaClause(because: RefusedReadWithholding): string {
+  return because.reason === "change_measured_no_difference"
+    ? measuredNoDifferenceMetaClause(because.refusedOn)
+    : unreconciledReadMetaClause(because.refusedOn);
+}
+
+export function refusedReadWithholding(refusal: RefusedRead): RefusedReadWithholding {
   return refusalMeasuredNoDifference(refusal)
     ? { reason: "change_measured_no_difference", refusedOn: refusal.refused_date }
     : { reason: "read_not_reconciled", refusedOn: refusal.refused_date };
@@ -141,7 +214,7 @@ export function termsUnconfirmedBySource(input: VendorVerdictInput): TermsUnconf
 }
 
 export function unconfirmedTermsMetaSentence(reason: TermsUnconfirmedReason): string {
-  return `Not verified — ${unconfirmedTermsClause(reason)}.`;
+  return NOT_VERIFIED(unconfirmedTermsClause(reason));
 }
 
 export function withholdingDecides(input: VendorVerdictInput): boolean {
@@ -177,30 +250,61 @@ export function refusalWithholdsStability(input: VendorVerdictInput): RefusedRea
   return refusedReadWeHold(input);
 }
 
-export type UnconfirmedTerms =
-  | { because: "level_withheld"; clause: string }
-  | { because: "refused_read"; clause: string };
-
-export function whyWeCannotConfirmTheseTerms(input: VendorVerdictInput): UnconfirmedTerms | null {
-  if (input.levelWithheld) {
-    return {
-      because: "level_withheld",
-      clause: withheldLevelClause(input.levelWithheld, input.unconfirmableSince),
-    };
-  }
-  const refused = refusalWithholdsStability(input);
-  return refused ? { because: "refused_read", clause: refusedReadClause(refused) } : null;
+export interface UnconfirmedTerms {
+  because: TermsWithholding;
+  clause: string;
+  sentence: string;
 }
 
-const EMPTY_HISTORY_TAIL: Record<UnconfirmedTerms["because"], string> = {
-  level_withheld: "so nothing we have read describes these terms",
-  refused_read: "so we cannot tell you that nothing changed",
+function termsWithholding(input: VendorVerdictInput): TermsWithholding | null {
+  if (input.levelWithheld) return { reason: input.levelWithheld };
+  const refused = refusalWithholdsStability(input);
+  return refused ? refusedReadWithholding(refused) : null;
+}
+
+export function whyWeCannotConfirmTheseTerms(input: VendorVerdictInput): UnconfirmedTerms | null {
+  const because = termsWithholding(input);
+  if (!because) return null;
+  if (withheldForARefusedRead(because)) {
+    return {
+      because,
+      clause: refusedReadWithholdingClause(because),
+      sentence: refusedReadWithholdingSentence(input.vendor, because),
+    };
+  }
+  return {
+    because,
+    clause: withheldLevelClause(because.reason, input.unconfirmableSince),
+    sentence: withheldLevelSentence(because.reason, input.vendor, input.unconfirmableSince),
+  };
+}
+
+const EMPTY_HISTORY_TAIL: Record<TermsWithholdingTag, string> = {
+  link_unreachable: "so nothing we have read describes these terms",
+  unreadable: "so nothing we have read describes these terms",
+  states_no_terms: "so nothing we have read describes these terms",
+  does_not_name_vendor: "so nothing we have read describes these terms",
+  does_not_name_product: "so nothing we have read describes these terms",
+  read_not_reconciled: "so we cannot tell you that nothing changed",
+  change_measured_no_difference: "so we cannot tell you that nothing changed",
 };
 
 export function emptyHistoryCaveatSentence(subject: string, unconfirmed: UnconfirmedTerms): string {
   return `No recorded pricing changes for ${subject} — but ${unconfirmed.clause},`
-    + ` ${EMPTY_HISTORY_TAIL[unconfirmed.because]}.`
+    + ` ${EMPTY_HISTORY_TAIL[unconfirmed.because.reason]}.`
     + ` Treat the empty history as a statement about our records, not about this vendor's pricing.`;
+}
+
+export const NOT_VERIFIED = (clause: string): string => `Not verified — ${clause}.`;
+
+export function termsNotVerifiedMetaSentence(input: VendorVerdictInput): string | null {
+  const bySource = termsUnconfirmedBySource(input);
+  if (bySource) return NOT_VERIFIED(unconfirmedTermsClause(bySource));
+  const unconfirmed = whyWeCannotConfirmTheseTerms(input);
+  if (!unconfirmed) return null;
+  const because = unconfirmed.because;
+  if (withheldForARefusedRead(because)) return NOT_VERIFIED(refusedReadWithholdingMetaClause(because));
+  return because.reason === "link_unreachable" ? null : NOT_VERIFIED(unconfirmed.clause);
 }
 
 export function unconfirmedThresholdSentence(phrase: string, unconfirmed: UnconfirmedTerms): string {

--- a/test/eligibility-disclosure.test.ts
+++ b/test/eligibility-disclosure.test.ts
@@ -39,6 +39,22 @@ const vendorsHoldingAGatedRecord = [...new Set(offers.filter(o => o.eligibility)
 
 const TODAY = utcDate();
 
+const { refusalsForVendor } = await import("../dist/data.js");
+const { badgeWithholding, withholdsTheTerms } = await import("../dist/vendor-verdict.js");
+const { vendorVerdictContextFrom } = await import("../dist/vendor-verdict-input.js");
+
+function termsWithheldFor(vendor: string): boolean {
+  const context = vendorVerdictContextFrom({
+    vendor,
+    vendorOffers: offers.filter(o => o.vendor === vendor),
+    vendorChanges: dealChanges.filter(c => c.vendor.toLowerCase() === vendor.toLowerCase()),
+    refusedReads: refusalsForVendor(vendor),
+    servedOn: TODAY,
+  });
+  const because = context ? badgeWithholding(context.input) : null;
+  return because !== null && withholdsTheTerms(because);
+}
+
 const publishesARestriction = (offer: Offer) => gateFor(offer, TODAY)?.code === "eligibility_restricted";
 
 let port = 0;
@@ -144,7 +160,9 @@ describe("a vendor page whose record is gated on eligibility says so", () => {
   });
 
   it("still answers yes where the page renders an ungated record for a vendor that also holds a gated one", () => {
-    const controls = rendered.filter(p => !p.offer.eligibility && !gateFor(p.offer, utcDate()));
+    const controls = rendered.filter(
+      p => !p.offer.eligibility && !gateFor(p.offer, utcDate()) && !termsWithheldFor(p.vendor),
+    );
     assert.ok(
       controls.length > 0,
       "every vendor holding a gated record now renders it, so the over-fire control has no subject",

--- a/test/gated-vendor-answers.test.ts
+++ b/test/gated-vendor-answers.test.ts
@@ -20,7 +20,9 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const REPO = path.join(__dirname, "..");
 
 const offers: Offer[] = JSON.parse(readFileSync(path.join(REPO, "data", "index.json"), "utf-8")).offers;
-const { loadDealChanges } = await import("../dist/data.js");
+const { loadDealChanges, refusalsForVendor } = await import("../dist/data.js");
+const { badgeWithholding, withholdsTheTerms } = await import("../dist/vendor-verdict.js");
+const { vendorVerdictContextFrom } = await import("../dist/vendor-verdict-input.js");
 
 const dealChanges: DealChange[] = loadDealChanges();
 const TODAY = utcDate();
@@ -134,13 +136,26 @@ function gateLineOf(html: string): string | null {
   return m ? textOf(m[0]) : null;
 }
 
-type VendorPage = { slug: string; vendor: string; primary: Offer; gate: Gate | null; html: string };
+type VendorPage = { slug: string; vendor: string; primary: Offer; gate: Gate | null; termsWithheld: boolean; html: string };
 
-const primaries: { slug: string; vendor: string; primary: Offer }[] = [];
+const primaries: { slug: string; vendor: string; primary: Offer; termsWithheld: boolean }[] = [];
 for (const [slug, vendor] of vendorSlugMap.entries()) {
   const vendorOffers = offers.filter(o => o.vendor === vendor);
   if (vendorOffers.length === 0) continue;
-  primaries.push({ slug, vendor, primary: vendorOffers[0] });
+  const context = vendorVerdictContextFrom({
+    vendor,
+    vendorOffers,
+    vendorChanges: dealChanges.filter(c => c.vendor.toLowerCase() === vendor.toLowerCase()),
+    refusedReads: refusalsForVendor(vendor),
+    servedOn: TODAY,
+  });
+  const because = context ? badgeWithholding(context.input) : null;
+  primaries.push({
+    slug,
+    vendor,
+    primary: vendorOffers[0],
+    termsWithheld: because !== null && withholdsTheTerms(because),
+  });
 }
 
 const rendered: VendorPage[] = [];
@@ -268,6 +283,7 @@ describe("the ungated pages keep the answer they had", () => {
   it("answers yes on every ungated record nothing else withholds", () => {
     const plainlyFree = publishingItsTerms().filter(
       p => p.primary.source_check?.outcome === "ok"
+        && !p.termsWithheld
         && p.primary.tier.toLowerCase() !== "none"
         && !p.primary.description.toLowerCase().includes("no free tier"),
     );

--- a/test/meta-description-withholding.test.ts
+++ b/test/meta-description-withholding.test.ts
@@ -8,13 +8,21 @@ import { fileURLToPath } from "node:url";
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const REPO = path.join(__dirname, "..");
 
-const { loadOffers, loadDealChanges } = await import("../dist/data.js");
+const { loadOffers, loadDealChanges, refusalsForVendor } = await import("../dist/data.js");
 const { vendorSlugMap } = await import("../dist/vendor-slug.js");
 const { supersedingChange } = await import("../dist/superseded-description.js");
 const { discontinuedOnOrBefore } = await import("../dist/product-deprecation.js");
 const { utcDate } = await import("../dist/ranking.js");
 const { unconfirmedTermsClause, withheldLevelClause } = await import("../dist/source-check.js");
-const { termsUnconfirmedBySource, unconfirmedTermsMetaSentence } = await import("../dist/vendor-verdict.js");
+const {
+  badgeWithholding,
+  refusedReadWithholding,
+  termsNotVerifiedMetaSentence,
+  termsUnconfirmedBySource,
+  unconfirmedTermsMetaSentence,
+  withholdsTheTerms,
+} = await import("../dist/vendor-verdict.js");
+const { vendorVerdictContextFrom } = await import("../dist/vendor-verdict-input.js");
 
 type Outcome = "ok" | "states_no_amount" | "does_not_name_vendor" | "states_no_terms" | "unreadable";
 
@@ -25,6 +33,7 @@ interface Subject {
   verifiedMonth: string;
   termsSuperseded: boolean;
   discontinuedOn: string | null;
+  termsWithheld: boolean;
 }
 
 const MONTHS = [
@@ -82,6 +91,14 @@ before(async () => {
     const primary = offers.find((o: { vendor: string }) => o.vendor === vendor);
     if (!primary) return [];
     const vendorChanges = changesByVendor.get(vendor.toLowerCase()) ?? [];
+    const context = vendorVerdictContextFrom({
+      vendor,
+      vendorOffers: offers.filter((o: { vendor: string }) => o.vendor === vendor),
+      vendorChanges,
+      refusedReads: refusalsForVendor(vendor),
+      servedOn,
+    });
+    const because = context ? badgeWithholding(context.input) : null;
     return [{
       slug,
       vendor,
@@ -89,6 +106,7 @@ before(async () => {
       verifiedMonth: monthLabel(primary.verifiedDate),
       termsSuperseded: supersedingChange(primary, vendorChanges) !== null,
       discontinuedOn: discontinuedOnOrBefore(vendorChanges, servedOn),
+      termsWithheld: because !== null && withholdsTheTerms(because),
     }];
   });
 
@@ -193,9 +211,26 @@ describe("#1412 the meta description withholds wherever the source check failed"
     assert.deepStrictEqual(wrong.slice(0, 20), [], `${wrong.length} of ${population.length} discontinued records`);
   });
 
+  it("withholds the verification claim on a page whose source check passed over a read we refused", async () => {
+    const pages = await everyVendorPage();
+    const population = subjects.filter(s => s.outcome === "ok" && !s.termsSuperseded && s.termsWithheld);
+    assertPopulationFloor(population.length, 40, "records whose terms are withheld over a source check that passed");
+
+    const asserting: string[] = [];
+    for (const subject of population) {
+      const meta = pages.get(subject.slug)!.meta;
+      if (!meta.includes("Not verified")) asserting.push(`${subject.slug}: ${meta.slice(0, 120)}`);
+    }
+    assert.deepStrictEqual(
+      asserting.slice(0, 20),
+      [],
+      `${asserting.length} of ${population.length} meta descriptions state a verification the page withholds`,
+    );
+  });
+
   it("leaves the verification claim standing wherever the source check passed", async () => {
     const pages = await everyVendorPage();
-    const population = subjects.filter(s => s.outcome === "ok" && !s.termsSuperseded);
+    const population = subjects.filter(s => s.outcome === "ok" && !s.termsSuperseded && !s.termsWithheld);
     assertPopulationFloor(population.length, Math.floor(subjects.length / 5), "records passed their source check");
 
     const wrongMonth: string[] = [];
@@ -241,8 +276,25 @@ describe("#1412 the withholding predicate is the one the badge and the body read
 
   it("gives each outcome a sentence a reader can tell apart from the others", () => {
     const outcomes = ["states_no_amount", "does_not_name_vendor", "states_no_terms", "unreadable"] as const;
-    const sentences = outcomes.map(o => unconfirmedTermsMetaSentence(o));
-    assert.strictEqual(new Set(sentences).size, outcomes.length);
+    const refusals = ["measures_no_change", "unquantified_limit"] as const;
+    const withheldForARefusal = refusals.map(reason => termsNotVerifiedMetaSentence({
+      vendor: "Example",
+      level: "stable",
+      historyLevel: "stable",
+      cause: null,
+      changes: [],
+      levelWithheld: null,
+      unconfirmableSince: "",
+      termsConfirmedOn: "2026-08-01",
+      refusedReads: [{ reason, refused_date: "2026-09-01" }],
+    })!);
+    const sentences = [...outcomes.map(o => unconfirmedTermsMetaSentence(o)), ...withheldForARefusal];
+    assert.strictEqual(
+      new Set(refusals.map(reason => refusedReadWithholding({ reason, refused_date: "2026-09-01" }).reason)).size,
+      refusals.length,
+      "both refusal families reduce to one withholding, so one meta sentence covers both",
+    );
+    assert.strictEqual(new Set(sentences).size, outcomes.length + refusals.length);
     for (const sentence of sentences) {
       assert.ok(sentence.startsWith("Not verified"), sentence);
       assert.ok(sentence.endsWith("."), sentence);

--- a/test/retired-records.test.ts
+++ b/test/retired-records.test.ts
@@ -9,6 +9,9 @@ import { fileURLToPath } from "node:url";
 const { offerRetired, recordedTierSentence } = await import("../dist/retirement.js");
 const { gateFor, utcDate } = await import("../dist/ranking.js");
 const { CITATION_CLASSES } = await import("../dist/change-citation.js");
+const { loadDealChanges, refusalsForVendor } = await import("../dist/data.js");
+const { badgeWithholding, withholdsTheTerms } = await import("../dist/vendor-verdict.js");
+const { vendorVerdictContextFrom } = await import("../dist/vendor-verdict-input.js");
 
 type Offer = import("../src/types.ts").Offer;
 
@@ -16,6 +19,20 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const REPO = path.join(__dirname, "..");
 
 const offers: Offer[] = JSON.parse(readFileSync(path.join(REPO, "data", "index.json"), "utf-8")).offers;
+
+const dealChanges = loadDealChanges();
+
+function termsWithheldFor(vendor: string): boolean {
+  const context = vendorVerdictContextFrom({
+    vendor,
+    vendorOffers: offers.filter(o => o.vendor === vendor),
+    vendorChanges: dealChanges.filter((c: { vendor: string }) => c.vendor.toLowerCase() === vendor.toLowerCase()),
+    refusedReads: refusalsForVendor(vendor),
+    servedOn: utcDate(),
+  });
+  const because = context ? badgeWithholding(context.input) : null;
+  return because !== null && withholdsTheTerms(because);
+}
 
 function slugOf(vendor: string): string {
   return vendor.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-+|-+$/g, "");
@@ -234,6 +251,7 @@ describe("a record that is not retired keeps everything the gate would take away
     const plainlyFree = renderedVendorPages.filter(
       p => !offerRetired(p.offer) && !p.offer.eligibility && p.offer.source_check?.outcome === "ok"
         && !gateFor(p.offer, utcDate())
+        && !termsWithheldFor(p.offer.vendor)
         && p.offer.tier.toLowerCase() !== "none"
         && !p.offer.description.toLowerCase().includes("no free tier"),
     );

--- a/test/withholding-covers-every-assertive-surface.test.ts
+++ b/test/withholding-covers-every-assertive-surface.test.ts
@@ -1,0 +1,321 @@
+import { describe, it, before, after } from "node:test";
+import assert from "node:assert";
+import { spawn, type ChildProcess } from "node:child_process";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { assertCoversPopulation, assertSharesPopulation, vendorsInTheCatalogue } from "./population-floor.ts";
+import { loadDealChanges, loadOffers, refusalsForVendor } from "../dist/data.js";
+import { vendorSlugMap } from "../dist/vendor-slug.js";
+import { utcDate } from "../dist/ranking.js";
+import { vendorVerdictContextFrom } from "../dist/vendor-verdict-input.js";
+import {
+  badgeWithholding,
+  termsNotVerifiedMetaSentence,
+  whyWeCannotConfirmTheseTerms,
+  withholdingTag,
+  withholdsTheTerms,
+  WITHHOLDING_BADGE_LABELS,
+  WITHHOLDING_SCOPE,
+  type VendorVerdictInput,
+} from "../dist/vendor-verdict.js";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO = path.join(__dirname, "..");
+
+const WITHHOLDING_TAGS = Object.keys(WITHHOLDING_SCOPE) as Array<keyof typeof WITHHOLDING_SCOPE>;
+const TAGS_THAT_WITHHOLD_THE_TERMS = WITHHOLDING_TAGS.filter(tag => WITHHOLDING_SCOPE[tag] === "the_terms");
+
+interface AssertiveSurface {
+  name: string;
+  asserts: (page: Page) => boolean;
+}
+
+interface Page {
+  slug: string;
+  vendor: string;
+  category: string;
+  html: string;
+  faq: Map<string, string>;
+  meta: string;
+  tag: string | null;
+  unconfirmed: { sentence: string } | null;
+}
+
+const A_MONTH = "(?:January|February|March|April|May|June|July|August|September|October|November|December)";
+const A_BARE_VERIFICATION = new RegExp(`(?<!Not )Verified ${A_MONTH} \\d{4}\\.`);
+
+const SURFACES: AssertiveSurface[] = [
+  {
+    name: "the structured-data answer to whether the vendor is free states the terms flat",
+    asserts: (page) => (page.faq.get(`Is ${page.vendor} free?`) ?? "").startsWith("Yes, "),
+  },
+  {
+    name: "the structured-data answer naming the free tier states it flat",
+    asserts: (page) => (page.faq.get(`What is ${page.vendor}'s free tier?`) ?? "")
+      .includes(`${page.vendor}'s free tier is called "`),
+  },
+  {
+    name: "the visible question-and-answer block states the terms flat",
+    asserts: (page) => page.html.includes(`Yes, ${page.vendor} offers a free tier`),
+  },
+  {
+    name: "the meta description states the terms as verified",
+    asserts: (page) => A_BARE_VERIFICATION.test(page.meta),
+  },
+  {
+    name: "the opening verdict recommends the offer for a workload",
+    asserts: (page) => page.html.includes(`Best for ${page.category.toLowerCase()} workloads`),
+  },
+];
+
+let serverPort = 0;
+let proc: ChildProcess | null = null;
+let pages: Page[] = [];
+
+function startHttpServer(): Promise<{ child: ChildProcess; port: number }> {
+  return new Promise((resolve, reject) => {
+    const child = spawn("node", [path.join(REPO, "dist", "serve.js")], {
+      stdio: ["pipe", "pipe", "pipe"],
+      env: { ...process.env, PORT: "0", BASE_URL: "http://localhost" },
+    });
+    const timeout = setTimeout(() => { child.kill(); reject(new Error("Server startup timeout")); }, 30000);
+    child.stderr!.on("data", (data: Buffer) => {
+      const m = data.toString().match(/running on http:\/\/localhost:(\d+)/);
+      if (m) { clearTimeout(timeout); resolve({ child, port: parseInt(m[1], 10) }); }
+    });
+    child.on("error", (err) => { clearTimeout(timeout); reject(err); });
+  });
+}
+
+function faqAnswersIn(html: string): Map<string, string> {
+  const answers = new Map<string, string>();
+  for (const block of html.matchAll(/<script type="application\/ld\+json">([\s\S]*?)<\/script>/g)) {
+    let parsed: { "@type"?: string; mainEntity?: Array<{ name?: string; acceptedAnswer?: { text?: string } }> };
+    try {
+      parsed = JSON.parse(block[1]);
+    } catch {
+      continue;
+    }
+    if (parsed["@type"] !== "FAQPage") continue;
+    for (const entry of parsed.mainEntity ?? []) {
+      if (entry.name) answers.set(entry.name, entry.acceptedAnswer?.text ?? "");
+    }
+  }
+  return answers;
+}
+
+const metaDescriptionIn = (html: string): string =>
+  html.match(/<meta name="description" content="([\s\S]*?)">/)?.[1] ?? "";
+
+function inputWith(over: Partial<VendorVerdictInput>): VendorVerdictInput {
+  return {
+    vendor: "Vendor A",
+    tier: "Free",
+    level: "stable",
+    historyLevel: "stable",
+    cause: null,
+    changes: [],
+    levelWithheld: null,
+    unconfirmableSince: "",
+    termsConfirmedOn: "2026-08-01",
+    refusedReads: [],
+    ...over,
+  };
+}
+
+before(async () => {
+  const offers = loadOffers();
+  const changes = loadDealChanges();
+  const servedOn = utcDate();
+  const offersByVendor = new Map<string, typeof offers>();
+  for (const offer of offers) {
+    const held = offersByVendor.get(offer.vendor);
+    if (held) held.push(offer);
+    else offersByVendor.set(offer.vendor, [offer]);
+  }
+  const changesByVendor = new Map<string, typeof changes>();
+  for (const change of changes) {
+    const key = change.vendor.toLowerCase();
+    const held = changesByVendor.get(key);
+    if (held) held.push(change);
+    else changesByVendor.set(key, [change]);
+  }
+
+  const subjects = [...vendorSlugMap.entries()].flatMap(([slug, vendor]: [string, string]) => {
+    const context = vendorVerdictContextFrom({
+      vendor,
+      vendorOffers: offersByVendor.get(vendor) ?? [],
+      vendorChanges: changesByVendor.get(vendor.toLowerCase()) ?? [],
+      refusedReads: refusalsForVendor(vendor),
+      servedOn,
+    });
+    if (!context) return [];
+    const because = badgeWithholding(context.input);
+    return [{
+      slug,
+      vendor,
+      category: context.primary.category,
+      tag: because ? withholdingTag(because) : null,
+      unconfirmed: whyWeCannotConfirmTheseTerms(context.input),
+    }];
+  });
+
+  const started = await startHttpServer();
+  proc = started.child;
+  serverPort = started.port;
+
+  const read: Page[] = [];
+  let queue = 0;
+  const worker = async () => {
+    while (queue < subjects.length) {
+      const subject = subjects[queue++];
+      const res = await fetch(`http://localhost:${serverPort}/vendor/${subject.slug}`);
+      assert.strictEqual(res.status, 200, `/vendor/${subject.slug} returned ${res.status}`);
+      const html = await res.text();
+      read.push({ ...subject, html, faq: faqAnswersIn(html), meta: metaDescriptionIn(html) });
+    }
+  };
+  await Promise.all(Array.from({ length: 12 }, worker));
+  pages = read;
+});
+
+after(() => { if (proc) proc.kill(); });
+
+describe("a withholding we publish reaches every surface that states the terms", () => {
+  it("states the terms nowhere on a page whose withholding says we could not read them", () => {
+    const asserting: string[] = [];
+    const cells: Record<string, number> = {};
+    for (const tag of TAGS_THAT_WITHHOLD_THE_TERMS) {
+      const population = pages.filter(page => page.tag === tag);
+      cells[tag] = population.length;
+      for (const surface of SURFACES) {
+        for (const page of population.filter(page => surface.asserts(page))) {
+          asserting.push(`${tag} × ${surface.name} — /vendor/${page.slug}`);
+        }
+      }
+    }
+    assert.deepStrictEqual(
+      asserting.slice(0, 25),
+      [],
+      `a page states the terms under a withholding that says we could not read them:\n${asserting.slice(0, 25).join("\n")}\npages per withholding: ${JSON.stringify(cells)}`,
+    );
+    assertCoversPopulation(pages.length, vendorsInTheCatalogue(), "vendor pages read for a surface that states the terms");
+  });
+
+  it("reads a live population under every withholding it covers", () => {
+    const covered = pages.filter(page => page.tag !== null && TAGS_THAT_WITHHOLD_THE_TERMS.includes(page.tag as never));
+    assertSharesPopulation(
+      covered.length,
+      vendorsInTheCatalogue(),
+      0.2,
+      "vendor pages whose withholding says we could not read the terms",
+    );
+    const empty = TAGS_THAT_WITHHOLD_THE_TERMS.filter(tag => !pages.some(page => page.tag === tag));
+    assert.ok(
+      empty.length < TAGS_THAT_WITHHOLD_THE_TERMS.length,
+      `no page carries any of the withholdings this sweep covers: ${empty.join(", ")}`,
+    );
+  });
+
+  it("still states the terms on a page carrying no withholding at all", () => {
+    const stating = pages.filter(page => page.tag === null && SURFACES.some(surface => surface.asserts(page)));
+    assertSharesPopulation(
+      stating.length,
+      vendorsInTheCatalogue(),
+      0.2,
+      "vendor pages that state the terms with nothing withheld",
+    );
+  });
+
+  it("opens the answer with the reason the page gives for withholding", () => {
+    const carrying = pages.filter(page => {
+      const unconfirmed = page.unconfirmed;
+      if (!unconfirmed) return false;
+      return (page.faq.get(`Is ${page.vendor} free?`) ?? "")
+        .includes(`We cannot confirm that today. ${unconfirmed.sentence} `);
+    });
+    assertSharesPopulation(
+      carrying.length,
+      vendorsInTheCatalogue(),
+      0.3,
+      "vendor pages opening the free-tier answer with the reason they withhold",
+    );
+    const refused = pages.filter(page => page.unconfirmed && page.tag !== null
+      && ["read_not_reconciled", "change_measured_no_difference"].includes(page.tag));
+    const silent = refused.filter(page => !(page.faq.get(`Is ${page.vendor} free?`) ?? "")
+      .includes(page.unconfirmed!.sentence)).map(page => page.slug);
+    assert.deepStrictEqual(
+      silent.slice(0, 20),
+      [],
+      `${silent.length} of ${refused.length} answers name no day for the read they withhold on`,
+    );
+  });
+
+  it("names the day of the refused read wherever it withholds the terms", () => {
+    const refused = inputWith({ refusedReads: [{ reason: "measures_no_change", refused_date: "2026-09-01" }] });
+    const unconfirmed = whyWeCannotConfirmTheseTerms(refused);
+    assert.ok(unconfirmed, "a refused read withholds nothing");
+    assert.strictEqual(unconfirmed.because.reason, "change_measured_no_difference");
+    assert.match(unconfirmed.sentence, /When we last read the page we cite for Vendor A, on 2026-09-01/);
+    assert.match(unconfirmed.clause, /when we last read the page we cite for this offer, on 2026-09-01/);
+    assert.strictEqual(
+      termsNotVerifiedMetaSentence(refused),
+      "Not verified — we refused the change we last considered recording, on 2026-09-01.",
+    );
+
+    const unreconciled = inputWith({ refusedReads: [{ reason: "unquantified_limit", refused_date: "2026-09-02" }] });
+    const second = whyWeCannotConfirmTheseTerms(unreconciled);
+    assert.ok(second, "an unreconciled read withholds nothing");
+    assert.strictEqual(second.because.reason, "read_not_reconciled");
+    assert.match(second.sentence, /we found a change we could not reconcile with the terms we publish/);
+  });
+
+  it("states no verification claim on a page we could confirm and none on one whose page we could not reach", () => {
+    assert.strictEqual(termsNotVerifiedMetaSentence(inputWith({})), null);
+    assert.strictEqual(
+      termsNotVerifiedMetaSentence(inputWith({ levelWithheld: "link_unreachable", linkUnreachable: true })),
+      null,
+    );
+    assert.strictEqual(
+      termsNotVerifiedMetaSentence(inputWith({ levelWithheld: "states_no_terms", sourceCheck: "states_no_terms" })),
+      "Not verified — the page we cite for this offer states no amount, tier or rate we can read.",
+    );
+    assert.strictEqual(
+      termsNotVerifiedMetaSentence(inputWith({ sourceCheck: "states_no_amount" })),
+      "Not verified — the page we cite for this offer names a plan but states no amount.",
+    );
+  });
+
+  it("keeps the refusal out of a page that was read again and confirmed after it", () => {
+    const superseded = inputWith({
+      termsConfirmedOn: "2026-09-05",
+      refusedReads: [{ reason: "measures_no_change", refused_date: "2026-09-01" }],
+    });
+    assert.strictEqual(whyWeCannotConfirmTheseTerms(superseded), null);
+    assert.strictEqual(termsNotVerifiedMetaSentence(superseded), null);
+  });
+
+  it("names a scope for every withholding a page can carry", () => {
+    assert.deepStrictEqual(
+      Object.keys(WITHHOLDING_BADGE_LABELS).sort(),
+      WITHHOLDING_TAGS.slice().sort(),
+      "a withholding the badge can name is missing from the scope this sweep reads",
+    );
+    const unscoped = [...new Set(pages.map(page => page.tag))]
+      .filter(tag => tag !== null && !WITHHOLDING_TAGS.includes(tag as never));
+    assert.deepStrictEqual(unscoped, [], `a page carries a withholding no scope covers: ${unscoped.join(", ")}`);
+    assert.ok(
+      TAGS_THAT_WITHHOLD_THE_TERMS.length > 0 && TAGS_THAT_WITHHOLD_THE_TERMS.length < WITHHOLDING_TAGS.length,
+      "every withholding was given the same scope, so the scope decides nothing",
+    );
+    const silent = pages
+      .filter(page => page.tag !== null && TAGS_THAT_WITHHOLD_THE_TERMS.includes(page.tag as never))
+      .filter(page => page.unconfirmed === null)
+      .map(page => `${page.slug} (${page.tag})`);
+    assert.deepStrictEqual(
+      silent.slice(0, 20),
+      [],
+      `${silent.length} pages withhold the terms and offer no reason the surfaces can publish`,
+    );
+  });
+});

--- a/test/withholding-covers-every-assertive-surface.test.ts
+++ b/test/withholding-covers-every-assertive-surface.test.ts
@@ -317,5 +317,14 @@ describe("a withholding we publish reaches every surface that states the terms",
       [],
       `${silent.length} pages withhold the terms and offer no reason the surfaces can publish`,
     );
+    const exempted = pages
+      .filter(page => page.unconfirmed !== null && page.tag !== null)
+      .filter(page => !TAGS_THAT_WITHHOLD_THE_TERMS.includes(page.tag as never))
+      .map(page => `${page.slug} (${page.tag})`);
+    assert.deepStrictEqual(
+      exempted.slice(0, 20),
+      [],
+      `${exempted.length} pages publish a reason they cannot confirm the terms under a withholding this sweep exempts`,
+    );
   });
 });


### PR DESCRIPTION
Refs #1560

`/vendor/aiven` answered **"Is Aiven free?"** with *"Yes, Aiven offers a free tier: Free. Managed PostgreSQL…"*, shipped `Verified August 2026.` in its meta description and closed its verdict with *"Best for databases workloads — 13 alternatives available."* — on a page whose own reliability answer said *"we refused the change we considered recording because it named no figure that had moved."*

## Population and readings

`/api/offers?limit=2000`, grouped by vendor, first row per vendor, `refused_read` non-null and `risk_level` null: **144 vendors**. All 1,539 vendor pages read as rendered HTML from both builds served side by side, 0 fetch errors.

| surface | before | after |
|---|---|---|
| `FAQPage` answer to *"Is {vendor} free?"* begins `Yes, ` | 127 | **0** |
| the same two answers in the visible FAQ | 127 | **0** |
| `<meta name="description">` carries a bare `Verified {Month} {Year}.` | 115 | **4** |
| `Best for {category} workloads` | 23 | **0** |

The 4 remaining meta descriptions are `/vendor/brex`, `/vendor/svb-silicon-valley-bank`, `/vendor/paddle` and `/vendor/sauce-labs` — all four gated, which #1560 excludes and #1555 owns.

**17 of the 144 pages do not change at all**: 10 whose source check already withholds and therefore already caveated all three surfaces, and 7 gated.

## The fix

Three surfaces read three different predicates, and the refusal was in none of them: the FAQ read `levelWithheld`, the meta read `termsUnconfirmedBySource`, the recommendation line read `!levelWithheld && !primaryGate`. They now read the join that #1558 already built for the growth thresholds and the empty-history caveat — `whyWeCannotConfirmTheseTerms` — which returns the withholding *and* the clause and sentence each surface renders from, so no surface decides for itself what counts.

## AC-5 — the reasons, and what had to move

**They could not be enumerated from a single source, and now they can.** `BadgeWithholding` is the union every surface already branches on, but it is a TypeScript type. At runtime the reasons were spread over `LEVEL_WITHHOLDING_OUTCOMES`, a `link_unreachable` literal inside `levelWithheldReason`, `REFUSAL_REASONS_THAT_MEASURED_NO_DIFFERENCE`, the `rating_withheld` path and `GateCode` — and `serve.ts` held two more maps listing them again to label the badge.

What moved:

- **`WITHHOLDING_SCOPE`**, one constant declared `as const satisfies Record<WithholdingTag, WithholdingScope>`, where `WithholdingTag` is derived from `BadgeWithholding` with `gated` expanded into its five gate codes. Adding a variant to `BadgeWithholding` now fails to compile until it is classified. The two badge-label maps collapse into one `Record<WithholdingTag, string>` on the same key set, so a new reason needs a label too.
- **The scope is what the matrix needed, and it is not a list of surfaces.** A withholding is about **the terms** — we could not read them — or about **the rating** — we hold confirmed terms and publish no verdict. That is the distinction ruled on for `rating_withheld: no_source` on #1558 and for the gate on #1561, written down once. Seven reasons withhold the terms; six withhold only the rating.
- **`src/vendor-verdict-input.ts`.** The verdict input was built inside `serve.ts` and private to it, so `test/badge-withholding.test.ts` and `test/vendor-verdict.test.ts` each rebuilt `VendorVerdictInput` by hand, and both had drifted — the badge fixture passes no `sourceCheck` at all. The builder is now a module, and the sweep computes `badgeWithholding` on exactly the input the page renders from.

`test/withholding-covers-every-assertive-surface.test.ts` takes its rows from `Object.keys(WITHHOLDING_SCOPE)` and its populations from `badgeWithholding`, and fails on any cell where a terms-scoped page states the terms: 7 reasons × 5 surfaces over all 1,539 pages. Reverting only the three surface fixes turns it red on 127 pages; it also asserts that no page withholding the terms leaves the surfaces without a reason to publish.

## The meta wording

`refusedReadClause` is 131–175 characters and `test/meta-description-withholding.test.ts` caps a meta caveat at 90, so the meta gets two short clauses of its own rather than the body's:

- `Not verified — we refused the change we last considered recording, on 2026-08-29.`
- `Not verified — our last read, on 2026-08-29, found a change we could not reconcile.`

That cap test now covers both of them, so the rule holds over every reason rather than over the source-check ones only.

## AC-4 — negative controls, measured over the population

- **2,398 of 2,525 sitemap routes are byte-identical** between the two builds. The 127 that differ are all `/vendor/*`, all in the population; **0 non-vendor pages differ**.
- `/api/offers?limit=2000`, `/api/offers?vendor=Aiven`, `/api/newest`, `/api/changes`, three badge SVGs, `/llms.txt`, `/llms-full.txt`, two MCP `resources/read` calls and three MCP `tools/call` calls are **byte-identical**.
- The 670 source-check-withheld pages: 670 of 670 keep the meta caveat, 0 of 670 publish `Best for`, 669 of 670 answer with a caveat rather than `Yes, ` — unchanged.
- The 674 rated pages: 548 still answer `Yes, `, 115 still publish `Best for` — unchanged.

## Four test controls that encoded the old rule

Each went red on the fix and each rebuilt the withholding rule by hand; all four now read the production predicate.

- `test/gated-vendor-answers.test.ts` — *"answers yes on every ungated record nothing else withholds"* filtered on the gate and the source check only.
- `test/retired-records.test.ts` — *"still answers yes where nothing else withholds the answer"*, same shape and same gap.
- `test/eligibility-disclosure.test.ts` — the over-fire control had the same gap.
- `test/meta-description-withholding.test.ts` — asserted the meta withholds *only* where the source check failed. It now asserts both directions.

Two greps find all four — `outcome === "ok"` and `startsWith("Yes`.

## Mutants

21, all killed — **17 by a test, 4 by the compiler.** The four the compiler stops are the ones that reclassify a reason in `WITHHOLDING_SCOPE`, which is AC-5's property working: removing a tag from the terms scope leaves `termsWithholding` returning a value the narrowed union no longer admits, and adding one leaves `EMPTY_HISTORY_TAIL` short a key and `withheldLevelClause` a reason it has no clause for. Because a `tsc` kill is weaker than a test kill, the runtime equivalent is mutated separately and killed by the sweep: `withholdsTheTerms` lying about the refusal families type-checks, and the sweep catches it by asserting that no page publishing a reason it cannot confirm the terms carries a withholding the matrix exempts.
