### PR TITLE
Write the page-dating run's outcome to a path, not through a pipe (#1563)

### DIFF
--- a/.github/workflows/page-lastmod.yml
+++ b/.github/workflows/page-lastmod.yml
@@ -34,12 +34,14 @@ jobs:
       - name: Read every page this commit renders, to date the ones whose output moved
         id: lastmod
         run: |
-          set -o pipefail
-          node scripts/update-page-lastmod.js --json | tee /tmp/page-lastmod.json
-          node -e '
-            const outcome = JSON.parse(require("node:fs").readFileSync("/tmp/page-lastmod.json", "utf-8"));
-            console.log(["moved", "added", "dropped"].map(k => `${k}=${outcome[k].length}`).join("\n"));
-          ' >> "$GITHUB_OUTPUT"
+          set -euo pipefail
+          rm -f "$RUNNER_TEMP/page-lastmod.json" "$RUNNER_TEMP/page-lastmod-settled.json"
+          node scripts/update-page-lastmod.js --json "$RUNNER_TEMP/page-lastmod.json"
+          if ! node scripts/update-page-lastmod.js --check --json "$RUNNER_TEMP/page-lastmod-settled.json"; then
+            echo "::error title=The days this run read were not sent to main::The pages listed above hash differently on two readings of one unchanged build, so dating them from their own output stamps today on pages nothing moved. The ledger stays in this run's workspace and the next push reads every page again."
+            exit 1
+          fi
+          node scripts/report-page-lastmod.js "$RUNNER_TEMP/page-lastmod.json" data/page-lastmod.json >> "$GITHUB_OUTPUT"
 
       - name: Run the suite, then push to main only if it is green
         id: gate

--- a/scripts/report-page-lastmod.js
+++ b/scripts/report-page-lastmod.js
@@ -1,0 +1,90 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { parsePageLastmod } from "../dist/page-lastmod.js";
+
+const GENERATOR = "node scripts/update-page-lastmod.js --json";
+
+const HELP = `Report what a page-dating run did, from the outcome it wrote.
+
+Reads the outcome that ${GENERATOR} <path> wrote and the ledger that run wrote, and prints
+moved=, added= and dropped= for a workflow step's outputs. A run that wrote no ledger update
+fails here rather than reporting success, and every failure names the command whose output it
+could not use, so a truncated payload is never reported as this step's own parse error.
+
+Usage: node scripts/report-page-lastmod.js <outcome-path> <ledger-path>
+`;
+
+function readOutcome(file) {
+  let text;
+  try {
+    text = readFileSync(file, "utf-8");
+  } catch (err) {
+    throw new Error(`${GENERATOR} ${file} left nothing there to read: ${err.message}`);
+  }
+  try {
+    return JSON.parse(text);
+  } catch (err) {
+    throw new Error(
+      `${GENERATOR} ${file} left ${text.length} bytes there that are not JSON: ${err.message}. `
+      + `A payload that stops at a round power of two went through a pipe rather than to a path.`,
+    );
+  }
+}
+
+function countsFor(outcome, file) {
+  const lines = [];
+  for (const key of ["moved", "added", "dropped"]) {
+    if (!Array.isArray(outcome[key])) {
+      throw new Error(`${GENERATOR} ${file} reports ${key} as ${JSON.stringify(outcome[key])}, expected a list of paths`);
+    }
+    lines.push(`${key}=${outcome[key].length}`);
+  }
+  return lines.join("\n");
+}
+
+function ledgerThatRunWrote(outcome, outcomeFile, expected) {
+  if (typeof outcome.wrote !== "string" || outcome.wrote.length === 0) {
+    throw new Error(
+      `${GENERATOR} ${outcomeFile} reports that it wrote no ledger, so this run has no dates to send anywhere and must not report success.`,
+    );
+  }
+  if (resolve(outcome.wrote) !== resolve(expected)) {
+    throw new Error(`${GENERATOR} ${outcomeFile} wrote ${outcome.wrote} and this step reads ${expected}`);
+  }
+  let ledger;
+  try {
+    ledger = parsePageLastmod(readFileSync(expected, "utf-8"), expected);
+  } catch (err) {
+    throw new Error(`${GENERATOR} ${outcomeFile} says it wrote ${expected}, which cannot be read back: ${err.message}`);
+  }
+  if (ledger.generated !== outcome.generated) {
+    throw new Error(
+      `${GENERATOR} ${outcomeFile} reports a run generated ${outcome.generated} and ${expected} says ${ledger.generated}, so what is on disk is not what this run read.`,
+    );
+  }
+  return ledger;
+}
+
+function main(argv) {
+  if (argv.includes("--help") || argv.includes("-h")) {
+    console.log(HELP);
+    return 0;
+  }
+  if (argv.length !== 2) {
+    console.error(HELP);
+    return 2;
+  }
+  const [outcomeFile, ledgerFile] = argv;
+  const outcome = readOutcome(outcomeFile);
+  const counts = countsFor(outcome, outcomeFile);
+  ledgerThatRunWrote(outcome, outcomeFile, ledgerFile);
+  console.log(counts);
+  return 0;
+}
+
+try {
+  process.exitCode = main(process.argv.slice(2));
+} catch (err) {
+  console.error(err.message);
+  process.exitCode = 1;
+}

--- a/scripts/update-page-lastmod.js
+++ b/scripts/update-page-lastmod.js
@@ -25,11 +25,16 @@ The pages are read with TZ=UTC. Some of them render a date from a timestamp with
 zone, so a machine west of Greenwich renders that date a day earlier and the page hashes
 differently. Pinning the zone is what makes the ledger the same wherever it is generated.
 
+The outcome is written to a path rather than to stdout. Node's stdout is asynchronous when it
+is a pipe, so a payload larger than the 64 KiB pipe buffer arrives truncated at exactly that
+byte; a path is written whole. It is written after the ledger, so an outcome file that exists
+is a run that wrote.
+
 Usage: node scripts/update-page-lastmod.js [options]
 
   --check         Report what would move and exit 1 if anything would, without writing
   --date <date>   Day to stamp changed pages with, YYYY-MM-DD (default: today, UTC)
-  --json          Emit the outcome as JSON on stdout, and nothing else there
+  --json <path>   Write the outcome as JSON to <path>
   --help          This text
 `;
 
@@ -40,12 +45,12 @@ const LEDGER_TIMEZONE = "UTC";
 const A_DAY_IN_MS = 86400000;
 
 function parseArgs(argv) {
-  const opts = { check: false, date: new Date().toISOString().slice(0, 10), json: false };
+  const opts = { check: false, date: new Date().toISOString().slice(0, 10), json: null };
   for (let i = 0; i < argv.length; i++) {
     const arg = argv[i];
     if (arg === "--help" || arg === "-h") return { help: true };
     else if (arg === "--check") opts.check = true;
-    else if (arg === "--json") opts.json = true;
+    else if (arg === "--json") opts.json = argv[++i];
     else if (arg === "--date") opts.date = argv[++i];
     else {
       console.error(`Unknown argument: ${arg}`);
@@ -104,6 +109,12 @@ async function hashEveryPage(base, paths) {
   return hashes;
 }
 
+function writeOutcome(target, outcome) {
+  if (target === null) return;
+  writeFileSync(target, JSON.stringify(outcome, null, 2) + "\n");
+  console.log(`Wrote ${target}`);
+}
+
 function readLedger(file, date) {
   try {
     return parsePageLastmod(readFileSync(file, "utf-8"), file);
@@ -121,6 +132,10 @@ async function main() {
   }
   if (!/^\d{4}-\d{2}-\d{2}$/.test(opts.date)) {
     console.error(`--date needs a YYYY-MM-DD day, got ${opts.date}`);
+    return 2;
+  }
+  if (opts.json !== null && (typeof opts.json !== "string" || opts.json.length === 0 || opts.json.startsWith("-"))) {
+    console.error(`--json needs a path to write the outcome to, got ${String(opts.json)}`);
     return 2;
   }
 
@@ -147,20 +162,23 @@ async function main() {
     const previous = readLedger(file, opts.date);
     const { ledger, moved, added, dropped, daily } = updatePageLastmod(previous, hashes, opts.date, dailyPaths);
 
-    if (opts.json) {
-      console.log(JSON.stringify({ pages: paths.length, moved, added, dropped, daily, seconds: Number(readSeconds), generated: ledger.generated }, null, 2));
-    } else {
-      console.log(`Read ${paths.length} pages twice in ${readSeconds}s: ${moved.length} whose output moved, ${added.length} new, ${dropped.length} gone, ${daily.length} dated from the day they are served.`);
-      for (const pagePath of moved.slice(0, 20)) console.log(`  moved  ${pagePath}`);
-      if (moved.length > 20) console.log(`  ... and ${moved.length - 20} more`);
-      for (const pagePath of added.slice(0, 20)) console.log(`  new    ${pagePath}`);
-      if (added.length > 20) console.log(`  ... and ${added.length - 20} more`);
-      for (const pagePath of dropped.slice(0, 20)) console.log(`  gone   ${pagePath}`);
-    }
+    console.log(`Read ${paths.length} pages twice in ${readSeconds}s: ${moved.length} whose output moved, ${added.length} new, ${dropped.length} gone, ${daily.length} dated from the day they are served.`);
+    for (const pagePath of moved.slice(0, 20)) console.log(`  moved  ${pagePath}`);
+    if (moved.length > 20) console.log(`  ... and ${moved.length - 20} more`);
+    for (const pagePath of added.slice(0, 20)) console.log(`  new    ${pagePath}`);
+    if (added.length > 20) console.log(`  ... and ${added.length - 20} more`);
+    for (const pagePath of dropped.slice(0, 20)) console.log(`  gone   ${pagePath}`);
 
-    if (opts.check) return moved.length + added.length + dropped.length > 0 ? 1 : 0;
+    const outcome = { pages: paths.length, moved, added, dropped, daily, seconds: Number(readSeconds), generated: ledger.generated, wrote: null };
+
+    if (opts.check) {
+      writeOutcome(opts.json, outcome);
+      return moved.length + added.length + dropped.length > 0 ? 1 : 0;
+    }
     writeFileSync(file, serializePageLastmod(ledger));
-    (opts.json ? console.error : console.log)(`Wrote ${file}`);
+    console.log(`Wrote ${file}`);
+    outcome.wrote = file;
+    writeOutcome(opts.json, outcome);
     return 0;
   } finally {
     if (server) server.proc.kill();
@@ -170,9 +188,11 @@ async function main() {
 }
 
 main().then(
-  code => process.exit(code),
+  code => {
+    process.exitCode = code;
+  },
   err => {
     console.error(err.message);
-    process.exit(1);
+    process.exitCode = 1;
   },
 );

--- a/test/page-lastmod.test.ts
+++ b/test/page-lastmod.test.ts
@@ -54,6 +54,12 @@ async function sitemapEntries(name: string): Promise<Array<{ loc: string; lastmo
     .map(m => ({ loc: m[1].replace("http://localhost", ""), lastmod: m[2] }));
 }
 
+const PIPE_BUFFER_BYTES = 65536;
+
+const UPDATER = ["scripts", "update-page-lastmod.js"];
+
+const REPORTER = ["scripts", "report-page-lastmod.js"];
+
 const RETITLED = ["/monitoring-comparison-2026", "/llm-api-pricing"];
 const REPRICED = "/vercel-vs-netlify";
 const THE_DAY_THOSE_PAGES_CHANGED = "2026-09-04";
@@ -754,6 +760,77 @@ describe("the ledger keeps up with the code that renders the pages", () => {
     );
   });
 
+  it("reads the run's outcome from a path the generator wrote, never from its stdout", () => {
+    for (const workflow of workflows().filter(w => readsEveryPageToDateIt(w) && runsOnAPushToMain(w))) {
+      for (const line of workflow.text.split("\n").filter(l => /update-page-lastmod\.js/.test(l))) {
+        assert.doesNotMatch(
+          line,
+          /\|/,
+          `${workflow.file} sends the generator's stdout through a pipe: ${line.trim()}. Node's stdout is asynchronous on a pipe, so a payload past ${PIPE_BUFFER_BYTES} bytes arrives cut off at exactly that byte and the step reports the next command's parse error instead.`,
+        );
+      }
+      assert.match(
+        workflow.text,
+        /update-page-lastmod\.js --json "\$RUNNER_TEMP\/[^"]+"/,
+        `${workflow.file} gives the generator no path to write its outcome to`,
+      );
+      assert.match(
+        workflow.text,
+        /report-page-lastmod\.js "\$RUNNER_TEMP\/[^"]+" data\/page-lastmod\.json/,
+        `${workflow.file} counts the run's outcome without checking that the run wrote a ledger, so a run that wrote nothing reports a push's counts`,
+      );
+      assert.match(
+        workflow.text,
+        /set -euo pipefail/,
+        `${workflow.file} runs the generator in a shell that carries on past a failing command`,
+      );
+    }
+  });
+
+  it("leaves its own stdout to drain rather than exiting out from under it", () => {
+    const updater = readFileSync(path.join(REPO, "scripts", "update-page-lastmod.js"), "utf8");
+    assert.doesNotMatch(
+      updater,
+      /process\.exit\(/,
+      "the generator exits before node has drained what it wrote, which discards everything past the pipe buffer",
+    );
+    assert.match(updater, /process\.exitCode = /, "the generator reports no status at all");
+
+    const piped = spawnSync("sh", ["-c", `node -e 'console.log("x".repeat(200000)); process.exit(0)' | wc -c`], { encoding: "utf8" });
+    assert.equal(piped.status, 0, `this control could not be run: ${piped.stderr}`);
+    assert.equal(
+      piped.stdout.trim(),
+      String(PIPE_BUFFER_BYTES),
+      "this test is pointless if node no longer discards a pending stdout write when a process exits on a pipe",
+    );
+  });
+
+  it("reads every page a second time before the days it read go anywhere", () => {
+    for (const workflow of workflows().filter(w => readsEveryPageToDateIt(w) && runsOnAPushToMain(w))) {
+      const wrote = workflow.text.indexOf("update-page-lastmod.js --json");
+      const settled = workflow.text.indexOf("update-page-lastmod.js --check");
+      assert.notEqual(
+        settled,
+        -1,
+        `${workflow.file} writes a ledger it never reads back, so a build whose pages hash differently on two readings stamps today on every one of them`,
+      );
+      assert.ok(
+        wrote < settled,
+        `${workflow.file} reads the pages a second time before it has a ledger to read them against`,
+      );
+      const reported = workflow.text.indexOf("report-page-lastmod.js");
+      assert.ok(
+        settled < reported,
+        `${workflow.file} reports what this run read before it knows the reading reproduces`,
+      );
+      assert.equal(
+        workflow.text.slice(wrote, reported).includes("- name:"),
+        false,
+        `${workflow.file} reads the pages again in a step of its own, and #1326 holds that nothing which can fail stands between a run's data and the gate`,
+      );
+    }
+  });
+
   it("sends the days it read to main through the one gate that runs the suite first", () => {
     for (const workflow of workflows().filter(w => readsEveryPageToDateIt(w) && runsOnAPushToMain(w))) {
       assert.match(
@@ -766,6 +843,163 @@ describe("the ledger keeps up with the code that renders the pages", () => {
         /data\/page-lastmod\.json/,
         `${workflow.file} does not name the ledger among the paths it may commit, so the days it reads stay in its own workspace`,
       );
+    }
+  });
+});
+
+describe("what a run reports about the days it wrote", () => {
+  let reported = "";
+  let named = 0;
+
+  const GENERATED = "2026-09-12";
+
+  before(() => {
+    reported = mkdtempSync(path.join(tmpdir(), "page-lastmod-report-"));
+  });
+
+  after(() => {
+    if (reported) rmSync(reported, { recursive: true, force: true });
+  });
+
+  function fileHolding(body: string): string {
+    const file = path.join(reported, `run-${named++}.json`);
+    writeFileSync(file, body);
+    return file;
+  }
+
+  function ledgerGeneratedOn(day: string): string {
+    return fileHolding(serializePageLastmod({
+      version: 1,
+      generated: day,
+      pages: { "/privacy": { hash: "6cf1a3b0d4e5f012", changed: "2026-09-09" } },
+    }));
+  }
+
+  function outcomeOf(fields: Record<string, unknown>): string {
+    return fileHolding(JSON.stringify({
+      pages: 2519, moved: ["/stability"], added: [], dropped: [], daily: [], seconds: 26, generated: GENERATED, ...fields,
+    }, null, 2));
+  }
+
+  function report(outcome: string, ledger: string) {
+    return spawnSync("node", [path.join(REPO, ...REPORTER), outcome, ledger], { encoding: "utf8" });
+  }
+
+  it("prints the counts the step reports, from the outcome the run wrote", () => {
+    const ledger = ledgerGeneratedOn(GENERATED);
+    const outcome = outcomeOf({ wrote: ledger, moved: ["/stability", "/privacy"], added: ["/best/free-new"], dropped: [] });
+    const run = report(outcome, ledger);
+    assert.equal(run.status, 0, `${run.stdout}${run.stderr}`);
+    assert.equal(run.stdout, "moved=2\nadded=1\ndropped=0\n");
+  });
+
+  it("refuses an outcome cut off at the pipe buffer, and names the command that left it there", () => {
+    const ledger = ledgerGeneratedOn(GENERATED);
+    const whole = readFileSync(outcomeOf({ wrote: ledger, moved: Array.from({ length: 4000 }, (_, n) => `/vendor/v${n}`) }), "utf-8");
+    assert.ok(PIPE_BUFFER_BYTES < whole.length, "this fixture is not long enough for a pipe to have cut it");
+    const run = report(fileHolding(whole.slice(0, PIPE_BUFFER_BYTES)), ledger);
+    assert.equal(run.status, 1);
+    assert.match(run.stderr, /update-page-lastmod\.js/, "the step blames its own reading rather than the command whose output it could not use");
+    assert.match(run.stderr, new RegExp(`${PIPE_BUFFER_BYTES} bytes`), "the count that names the mechanism is not in the message");
+  });
+
+  it("refuses a run that left no outcome at all", () => {
+    const run = report(path.join(reported, "no-such-run.json"), ledgerGeneratedOn(GENERATED));
+    assert.equal(run.status, 1);
+    assert.match(run.stderr, /update-page-lastmod\.js/);
+    assert.match(run.stderr, /nothing there to read/);
+  });
+
+  it("refuses a run that wrote no ledger, so a reading that only reports cannot report a push's counts", () => {
+    const ledger = ledgerGeneratedOn(GENERATED);
+    const run = report(outcomeOf({ wrote: null }), ledger);
+    assert.equal(run.status, 1);
+    assert.match(run.stderr, /wrote no ledger/);
+    assert.match(run.stderr, /must not report success/);
+  });
+
+  it("refuses a ledger on disk that is not the one the run read", () => {
+    const ledger = ledgerGeneratedOn("2026-09-01");
+    const run = report(outcomeOf({ wrote: ledger }), ledger);
+    assert.equal(run.status, 1);
+    assert.match(run.stderr, /generated 2026-09-12 and .* says 2026-09-01/);
+  });
+
+  it("reads the ledger the run wrote where the step names it relative to the checkout", () => {
+    const ledger = ledgerGeneratedOn(GENERATED);
+    const run = spawnSync("node", [path.join(REPO, ...REPORTER), outcomeOf({ wrote: ledger }), path.relative(reported, ledger)], {
+      encoding: "utf8",
+      cwd: reported,
+    });
+    assert.equal(run.status, 0, `${run.stdout}${run.stderr}`);
+  });
+
+  it("refuses an outcome that wrote some ledger other than the one the step reads", () => {
+    const run = report(outcomeOf({ wrote: ledgerGeneratedOn(GENERATED) }), ledgerGeneratedOn(GENERATED));
+    assert.equal(run.status, 1);
+    assert.match(run.stderr, /and this step reads/);
+  });
+
+  it("refuses an outcome holding no list to count", () => {
+    const ledger = ledgerGeneratedOn(GENERATED);
+    const run = report(outcomeOf({ wrote: ledger, dropped: 0 }), ledger);
+    assert.equal(run.status, 1);
+    assert.match(run.stderr, /reports dropped as 0, expected a list of paths/);
+  });
+});
+
+describe("the generator is told where to put what it read", () => {
+  function run(...args: string[]) {
+    return spawnSync("node", [path.join(REPO, ...UPDATER), ...args], { encoding: "utf8" });
+  }
+
+  it("refuses --json with no path, rather than reading every page and dropping the outcome", () => {
+    const missing = run("--json");
+    assert.equal(missing.status, 2, `${missing.stdout}${missing.stderr}`);
+    assert.match(missing.stderr, /--json needs a path/);
+  });
+
+  it("refuses a flag where a path should be, which is how a path goes missing", () => {
+    const swallowed = run("--json", "--check");
+    assert.equal(swallowed.status, 2, `${swallowed.stdout}${swallowed.stderr}`);
+    assert.match(swallowed.stderr, /--json needs a path to write the outcome to, got --check/);
+  });
+
+  it("says in its own help that the outcome goes to a path", () => {
+    const help = run("--help");
+    assert.equal(help.status, 0);
+    assert.match(help.stdout, /--json <path>/);
+  });
+});
+
+describe("one unchanged build read twice gives the same days twice", () => {
+  it("moves nothing on the second reading, and writes an outcome no pipe would have carried whole", () => {
+    const twice = mkdtempSync(path.join(tmpdir(), "page-lastmod-twice-"));
+    try {
+      const env = { ...process.env, AGENTDEALS_PAGE_LASTMOD_PATH: path.join(twice, "page-lastmod.json") };
+      const opening = path.join(twice, "opening.json");
+      const again = path.join(twice, "again.json");
+
+      const first = spawnSync("node", [path.join(REPO, ...UPDATER), "--json", opening], { encoding: "utf8", env, timeout: 600000 });
+      assert.equal(first.status, 0, `the first reading failed: ${first.stdout}${first.stderr}`);
+      const wrote = readFileSync(opening, "utf-8");
+      assert.ok(
+        PIPE_BUFFER_BYTES < wrote.length,
+        `this run's outcome is ${wrote.length} bytes, which a pipe would have carried whole, so it no longer stands over the truncation it was written to catch`,
+      );
+      assert.equal(JSON.parse(wrote).wrote, env.AGENTDEALS_PAGE_LASTMOD_PATH);
+
+      const second = spawnSync("node", [path.join(REPO, ...UPDATER), "--check", "--json", again], { encoding: "utf8", env, timeout: 600000 });
+      const settled = JSON.parse(readFileSync(again, "utf-8"));
+      assert.deepEqual(
+        { moved: settled.moved.length, added: settled.added.length, dropped: settled.dropped.length },
+        { moved: 0, added: 0, dropped: 0 },
+        `reading one unchanged build twice moved ${settled.moved.length} pages, beginning ${settled.moved.slice(0, 5).join(", ")}. Every page that hashes differently on two readings takes today's date on every push, which is the ledger measuring the deploy rather than the page.`,
+      );
+      assert.equal(second.status, 0, `${second.stdout}${second.stderr}`);
+      assert.equal(settled.wrote, null, "a reading that only reports says it wrote a ledger");
+    } finally {
+      rmSync(twice, { recursive: true, force: true });
     }
   });
 });


### PR DESCRIPTION
Refs #1563

## What was wrong

The `redate` step ran `node scripts/update-page-lastmod.js --json | tee /tmp/page-lastmod.json` and parsed what `tee` caught. Node's `process.stdout` is asynchronous when it is a pipe, so `console.log` followed by `process.exit()` discards everything past the 64 KiB pipe buffer. Reproduced locally against `main`, byte for byte with CI:

```
$ node scripts/update-page-lastmod.js --json | tee /tmp/piped.json | wc -c
65536
$ node -e 'JSON.parse(readFileSync("/tmp/piped.json","utf-8"))'
SyntaxError: Unterminated string in JSON at position 65536 (line 2201 column 24)
```

`set -o pipefail` could not catch it: the generator exited 0. It wrote the ledger correctly every time; only the report of what it wrote was cut off, and the step then failed on the *second* command and said nothing about the first.

## AC-1 — the pipe

`--json` takes a path. The outcome is written there with `writeFileSync`, **after** the ledger, so an outcome file that exists is a run that wrote one. `process.exit(code)` becomes `process.exitCode = code`, so a future large `console.log` cannot reintroduce this; the run still terminates in the same 26s.

`scripts/report-page-lastmod.js` reads that outcome and prints `moved=`, `added=`, `dropped=`. Every failure names the command whose output it could not use, so a truncation can never again be reported as this step's own parse error. The step runs under `set -euo pipefail`.

Running the real step end to end, against this build:

```
Wrote /root/workspaces/agentdeals/data/page-lastmod.json
Wrote $RUNNER_TEMP/page-lastmod.json          69,779 bytes, parses whole
Read 2519 pages twice in 26.5s: 0 whose output moved, 0 new, 0 gone, 535 dated from the day they are served.
$GITHUB_OUTPUT: moved=1816  added=0  dropped=0
step exit: 0
```

## AC-2 — one build read twice

The generator runs a second time with `--check` **inside the same step**, before any count is reported. `main` already passes it — `0 moved, 0 new, 0 gone` — which is a second confirmation that the over-report does not reproduce. It is a regression control, not a fix.

It is not a step of its own on purpose. `#1326 nothing that can fail stands between the day's data and the gate` is enforced by `test/data-push-gate.test.ts`, and a separate step failed it. A failure inside the producing step is indistinguishable from the producer failing, which is the behaviour that already existed, and page dates are re-read in full on every push so holding them costs one cycle rather than a day's data.

`test/page-lastmod.test.ts` runs the generator twice against a temp ledger and asserts the second reading moves nothing. It also asserts the first run's outcome is longer than 65,536 bytes, so the test cannot quietly stop measuring the thing it was written for.

## AC-3 — what a crawler is told

Served against a caught-up ledger, `If-Modified-Since: Fri, 11 Sep 2026 14:30:00 GMT`:

| path | before | after | ledger day |
|---|---|---|---|
| `/stability` | 304 | **200** | 09-11 → 09-12 |
| `/vendor/ably` | 304 | **200** | 09-11 → 09-12 |
| `/vendor/doczilla` | 304 | **200** | 09-11 → 09-12 |
| `/privacy` | 304 | **304** | 09-09, unmoved |
| `/disclosure` | 304 | **304** | 09-10, unmoved |

## AC-4 — a run that wrote nothing does not report success

`report-page-lastmod.js` refuses, with the command named, when the run left no outcome, left a truncated one, reports it wrote no ledger, wrote a different ledger than the step reads, or wrote one whose `generated` day is not the day the run read. Six cases, each with a test.

## Tests

`test/page-lastmod.test.ts` — 88 pass. Four workflow guards (no pipe on the generator's line, a path for the outcome, the reporter present, `set -euo pipefail`), the second reading before anything is reported and inside the producing step, `process.exitCode` over `process.exit(` with a live control that node still truncates 200,000 bytes to 65,536 on a pipe, eight reporter cases, three CLI cases, and the double reading.

All four workflow/generator guards were confirmed red against unfixed `main`. Two mutants on the reporter's guards — drop the `wrote` check, drop the `generated` comparison — were each killed by a test.

`test/data-push-gate.test.ts`, `test/no-private-context.test.ts`, `test/named-subsets.test.ts`, `test/workflow-node-version.test.ts`, `test/population-floor.test.ts`, `test/llm-api-index-publication.test.ts`, `test/model-lineup-currency.test.ts` all pass.

## Not in this PR

Three other workflows pipe a script's stdout into a log and then `grep` a summary line printed at the end of it — `reverify.yml`, `liveness.yml`, `analytics-rollup.yml` — and each of those scripts calls `process.exit()`. Their counts are non-zero on the most recent runs, so none has crossed the buffer, but when one does the summary is discarded and `|| echo 0` substitutes a zero silently rather than going red. Filing separately.
