### PR TITLE
Caveat the limits where the read found the plan and not the amount (#1565)

### DIFF
--- a/src/serve.ts
+++ b/src/serve.ts
@@ -34,7 +34,7 @@ import { NO_CURRENT_FIGURE, costHeadlineCaveat, limitCellText, mayRecommendAsFre
 import { changesByVendor } from "./superseded-census.js";
 import { buildComparisonMap, comparisonSlug } from "./comparison-pairs.js";
 import { comparisonVerdictText, freeTierFaqAnswer, stabilityFaqAnswer, type ComparisonSide, type FreeTierSide, type SideFreeTier, type StabilityRating } from "./comparison-verdict.js";
-import { publishedVendorLevel, vendorVerdictSentence, vendorBadge, freeTierClaim, statesRiskCause, narrowingSentence, changeKindNoun, emptyHistoryCaveatSentence, refusedReadOurConfirmationSupersedes, refusedReadWeHold, refusedReadWithholdingSentence, unconfirmedThresholdSentence, whyWeCannotConfirmTheseTerms, withheldForARefusedRead, refusalWithholdsStability, termsUnconfirmedBySource, termsNotVerifiedMetaSentence, withheldBadgeLabel, type BadgeWithholding, type FreeTierClaim, type VendorVerdictInput } from "./vendor-verdict.js";
+import { publishedVendorLevel, vendorVerdictSentence, vendorBadge, freeTierClaim, statesRiskCause, narrowingSentence, changeKindNoun, emptyHistoryCaveatSentence, refusedReadOurConfirmationSupersedes, refusedReadWeHold, refusedReadWithholdingSentence, nothingWeReadDescribesTheTerms, unconfirmedThresholdSentence, unconfirmedTermsOpening, whyWeCannotConfirmTheseTerms, withheldForARefusedRead, withUnconfirmedTerms, refusalWithholdsStability, termsUnconfirmedBySource, termsNotVerifiedMetaSentence, withheldBadgeLabel, type BadgeWithholding, type FreeTierClaim, type VendorVerdictInput } from "./vendor-verdict.js";
 import { tierRecordsAFreeTier } from "./free-tier-record.js";
 import { PAGE_HEAD_OPEN, withLedeBeforeNav } from "./page-lede.js";
 import { freshnessClaimFor, withFreshnessClaim } from "./page-freshness.js";
@@ -4799,7 +4799,7 @@ function buildVendorPage(slug: string): string | null {
       </div>`;
   }).join("\n") : offerHasEnded
     ? `<p class="no-changes">${escHtmlServer(endedHistorySentence(vendorName))}</p>`
-    : termsWeCannotConfirm
+    : termsWeCannotConfirm && nothingWeReadDescribesTheTerms(termsWeCannotConfirm)
     ? `<p class="no-changes">${escHtmlServer(emptyHistoryCaveatSentence(vendorName, termsWeCannotConfirm))}</p>`
     : primaryGate
     ? `<p class="no-changes">No recorded pricing changes for ${escHtmlServer(vendorName)}.</p>`
@@ -5025,14 +5025,18 @@ ${allCompareLinks.join("\n")}
 
   const storedTerms = storedTermsOf(primary);
   const unconfirmedTermsPreamble = termsWeCannotConfirm
-    ? `We cannot confirm that today. ${termsWeCannotConfirm.sentence} `
+    ? unconfirmedTermsOpening(termsWeCannotConfirm)
     : "";
   const withUnconfirmedTermsCaveat = (terms: string) =>
-    `${terms}${/[.!?…]$/.test(terms.trim()) ? "" : "."} We have not confirmed these terms against the source we cite, so treat them as unverified.`;
+    termsWeCannotConfirm ? withUnconfirmedTerms(terms, termsWeCannotConfirm) : terms;
   const eligibilityConditionsSentence = primaryEligibilityConditions.length > 0
     ? ` Eligibility: ${primaryEligibilityConditions.join("; ")}.`
     : "";
   const gateSentencesBeforeTheTerms = `${eligibilityGateSentence}${primaryGateBeyondEligibility ? `${primaryGateBeyondEligibility.reason} ` : ""}`;
+  const weCanStillSayTheFreeTierExists = !termsWeCannotConfirm || termsWeCannotConfirm.theReadFoundAFreePlan;
+  const freeTierAnswerLead = weCanStillSayTheFreeTierExists
+    ? `${primaryEligibilityGate ? "" : "Yes, "}${vendorName} offers a free tier: ${primary.tier}.`
+    : `Our stored record says ${vendorName} offers a free tier: ${primary.tier}.`;
   const faqFreeAnswer = termsSuperseded
     ? `${gateSentencesBeforeTheTerms}${supersededTermsAnswer(vendorName, termsSuperseded)}`
     : retiredSentence
@@ -5040,10 +5044,10 @@ ${allCompareLinks.join("\n")}
     : primaryGateBeyondEligibility
     ? `${eligibilityGateSentence}${primaryGateBeyondEligibility.reason} ${termsWeCannotConfirm ? `${unconfirmedTermsPreamble}${withUnconfirmedTermsCaveat(storedTerms)}` : storedTerms}${eligibilityConditionsSentence}`
     : termsWeCannotConfirm
-    ? `${eligibilityGateSentence}${unconfirmedTermsPreamble}Our stored record says ${vendorName} offers a free tier: ${primary.tier}. ${withUnconfirmedTermsCaveat(storedTerms)}${eligibilityConditionsSentence}`
+    ? `${eligibilityGateSentence}${unconfirmedTermsPreamble}${freeTierAnswerLead} ${withUnconfirmedTermsCaveat(storedTerms)}${eligibilityConditionsSentence}`
     : primaryEligibilityGate
-    ? `${eligibilityGateSentence}${vendorName} offers a free tier: ${primary.tier}. ${storedTerms}${eligibilityConditionsSentence}`
-    : `Yes, ${vendorName} offers a free tier: ${primary.tier}. ${storedTerms}`;
+    ? `${eligibilityGateSentence}${freeTierAnswerLead} ${storedTerms}${eligibilityConditionsSentence}`
+    : `${freeTierAnswerLead} ${storedTerms}`;
   const faqTierAnswer = termsSuperseded
     ? `${eligibilityGateSentence}${vendorName}'s free tier is called "${primary.tier}". ${supersededTermsNotice(vendorName, termsSuperseded)}`
     : retiredSentence

--- a/src/source-check.ts
+++ b/src/source-check.ts
@@ -74,6 +74,26 @@ export function withheldLevelSentence(
 
 export type TermsUnconfirmedReason = Exclude<SourceCheckOutcome, "ok">;
 
+export type TermsOnlyOutcome = Exclude<TermsUnconfirmedReason, LevelWithheldReason>;
+
+function withholdsTheLevel(outcome: SourceCheckOutcome): outcome is SourceCheckOutcome & LevelWithheldReason {
+  return LEVEL_WITHHOLDING_OUTCOMES.includes(outcome);
+}
+
+export function termsOnlyOutcome(
+  outcome: SourceCheckOutcome | null | undefined,
+): TermsOnlyOutcome | null {
+  const reason = termsUnconfirmedOutcome(outcome);
+  if (!reason) return null;
+  return withholdsTheLevel(reason) ? null : reason;
+}
+
+export const TERMS_ONLY_OUTCOMES: TermsOnlyOutcome[] = SOURCE_CHECK_OUTCOMES
+  .flatMap(outcome => {
+    const termsOnly = termsOnlyOutcome(outcome);
+    return termsOnly ? [termsOnly] : [];
+  });
+
 const UNCONFIRMED_TERMS_CLAUSES: Record<TermsUnconfirmedReason, string> = {
   does_not_name_vendor: WITHHELD_LEVEL_CLAUSES.does_not_name_vendor(""),
   does_not_name_product: WITHHELD_LEVEL_CLAUSES.does_not_name_product(""),
@@ -141,7 +161,7 @@ export function levelWithheldReason(
 ): LevelWithheldReason | null {
   if (linkUnreachable) return "link_unreachable";
   const outcome = offer.source_check?.outcome;
-  if (outcome && LEVEL_WITHHOLDING_OUTCOMES.includes(outcome)) return outcome as LevelWithheldReason;
+  if (outcome && withholdsTheLevel(outcome)) return outcome;
   return null;
 }
 

--- a/src/vendor-verdict.ts
+++ b/src/vendor-verdict.ts
@@ -5,11 +5,14 @@ import { isNoLongerInForce, theEventNeverHappened } from "./change-resolution.js
 import { changeIsUncited, ratingWithheldForNoSourceSentence } from "./change-citation.js";
 import { changeDateClause } from "./change-dates.js";
 import {
+  amountUnstatedSentence,
+  termsOnlyOutcome,
   termsUnconfirmedOutcome,
   unconfirmedTermsClause,
   withheldLevelClause,
   withheldLevelSentence,
   type LevelWithheldReason,
+  type TermsOnlyOutcome,
   type TermsUnconfirmedReason,
 } from "./source-check.js";
 import type { GateCode } from "./ranking.js";
@@ -82,18 +85,24 @@ export type BadgeWithholding =
   | { reason: "change_measured_no_difference"; refusedOn: string }
   | { reason: LevelWithheldReason };
 
+export type Withholding = BadgeWithholding | { reason: TermsOnlyOutcome };
+
 export type RefusedReadWithholding = Extract<
   BadgeWithholding,
   { reason: "read_not_reconciled" | "change_measured_no_difference" }
 >;
 
-export function withheldForARefusedRead(because: BadgeWithholding): because is RefusedReadWithholding {
+export function withheldForARefusedRead(because: Withholding): because is RefusedReadWithholding {
   return because.reason === "read_not_reconciled" || because.reason === "change_measured_no_difference";
 }
 
-export type WithholdingTag = Exclude<BadgeWithholding["reason"], "gated"> | GateCode;
+export type BadgeWithholdingTag = Exclude<BadgeWithholding["reason"], "gated"> | GateCode;
 
-export function withholdingTag(because: BadgeWithholding): WithholdingTag {
+export type WithholdingTag = Exclude<Withholding["reason"], "gated"> | GateCode;
+
+export function withholdingTag(because: BadgeWithholding): BadgeWithholdingTag;
+export function withholdingTag(because: Withholding): WithholdingTag;
+export function withholdingTag(because: Withholding): WithholdingTag {
   return because.reason === "gated" ? because.gate : because.reason;
 }
 
@@ -105,6 +114,7 @@ export const WITHHOLDING_SCOPE = {
   states_no_terms: "the_terms",
   does_not_name_vendor: "the_terms",
   does_not_name_product: "the_terms",
+  states_no_amount: "the_terms",
   read_not_reconciled: "the_terms",
   change_measured_no_difference: "the_terms",
   no_source: "the_rating",
@@ -119,13 +129,13 @@ export type TermsWithholdingTag = {
   [K in WithholdingTag]: (typeof WITHHOLDING_SCOPE)[K] extends "the_terms" ? K : never;
 }[WithholdingTag];
 
-export type TermsWithholding = Extract<BadgeWithholding, { reason: TermsWithholdingTag }>;
+export type TermsWithholding = Extract<Withholding, { reason: TermsWithholdingTag }>;
 
-export function withholdsTheTerms(because: BadgeWithholding): because is TermsWithholding {
+export function withholdsTheTerms(because: Withholding): because is TermsWithholding {
   return WITHHOLDING_SCOPE[withholdingTag(because)] === "the_terms";
 }
 
-export const WITHHOLDING_BADGE_LABELS: Record<WithholdingTag, string> = {
+export const WITHHOLDING_BADGE_LABELS: Record<BadgeWithholdingTag, string> = {
   no_source: "unrated — no source",
   link_unreachable: "unrated — page unreachable",
   unreadable: "unrated — page unreadable",
@@ -254,32 +264,95 @@ export interface UnconfirmedTerms {
   because: TermsWithholding;
   clause: string;
   sentence: string;
+  theReadFoundAFreePlan: boolean;
+}
+
+export type WhatTheReadLeftStanding = "nothing" | "the_free_plan";
+
+export const WHAT_THE_READ_LEFT_STANDING = {
+  link_unreachable: "nothing",
+  unreadable: "nothing",
+  states_no_terms: "nothing",
+  does_not_name_vendor: "nothing",
+  does_not_name_product: "nothing",
+  states_no_amount: "the_free_plan",
+  read_not_reconciled: "nothing",
+  change_measured_no_difference: "nothing",
+} as const satisfies Record<TermsWithholdingTag, WhatTheReadLeftStanding>;
+
+type ReadNothingTag = {
+  [K in TermsWithholdingTag]: (typeof WHAT_THE_READ_LEFT_STANDING)[K] extends "nothing" ? K : never;
+}[TermsWithholdingTag];
+
+export interface TermsNoReadDescribes extends UnconfirmedTerms {
+  because: Extract<TermsWithholding, { reason: ReadNothingTag }>;
+}
+
+export function nothingWeReadDescribesTheTerms(
+  unconfirmed: UnconfirmedTerms,
+): unconfirmed is TermsNoReadDescribes {
+  return !unconfirmed.theReadFoundAFreePlan;
+}
+
+const TERMS_ONLY_SENTENCES: Record<TermsOnlyOutcome, (subject: string) => string> = {
+  states_no_amount: amountUnstatedSentence,
+};
+
+type TermsOnlyWithholding = Extract<TermsWithholding, { reason: TermsOnlyOutcome }>;
+
+function withheldOnAReadWeCouldNotQuantify(because: TermsWithholding): because is TermsOnlyWithholding {
+  return Object.prototype.hasOwnProperty.call(TERMS_ONLY_SENTENCES, because.reason);
 }
 
 function termsWithholding(input: VendorVerdictInput): TermsWithholding | null {
   if (input.levelWithheld) return { reason: input.levelWithheld };
   const refused = refusalWithholdsStability(input);
-  return refused ? refusedReadWithholding(refused) : null;
+  if (refused) return refusedReadWithholding(refused);
+  const termsOnly = termsOnlyOutcome(input.sourceCheck);
+  return termsOnly ? { reason: termsOnly } : null;
 }
 
 export function whyWeCannotConfirmTheseTerms(input: VendorVerdictInput): UnconfirmedTerms | null {
   const because = termsWithholding(input);
   if (!because) return null;
+  const theReadFoundAFreePlan = WHAT_THE_READ_LEFT_STANDING[because.reason] === "the_free_plan";
   if (withheldForARefusedRead(because)) {
     return {
       because,
+      theReadFoundAFreePlan,
       clause: refusedReadWithholdingClause(because),
       sentence: refusedReadWithholdingSentence(input.vendor, because),
     };
   }
+  if (withheldOnAReadWeCouldNotQuantify(because)) {
+    return {
+      because,
+      theReadFoundAFreePlan,
+      clause: unconfirmedTermsClause(because.reason),
+      sentence: TERMS_ONLY_SENTENCES[because.reason](input.vendor),
+    };
+  }
   return {
     because,
+    theReadFoundAFreePlan,
     clause: withheldLevelClause(because.reason, input.unconfirmableSince),
     sentence: withheldLevelSentence(because.reason, input.vendor, input.unconfirmableSince),
   };
 }
 
-const EMPTY_HISTORY_TAIL: Record<TermsWithholdingTag, string> = {
+export const UNVERIFIED_TERMS_CAVEAT =
+  "We have not confirmed these terms against the source we cite, so treat them as unverified.";
+
+export function unconfirmedTermsOpening(unconfirmed: UnconfirmedTerms): string {
+  return unconfirmed.theReadFoundAFreePlan ? "" : `We cannot confirm that today. ${unconfirmed.sentence} `;
+}
+
+export function withUnconfirmedTerms(terms: string, unconfirmed: UnconfirmedTerms): string {
+  const closed = /[.!?…]$/.test(terms.trim()) ? terms : `${terms}.`;
+  return `${closed} ${unconfirmed.theReadFoundAFreePlan ? unconfirmed.sentence : UNVERIFIED_TERMS_CAVEAT}`;
+}
+
+const EMPTY_HISTORY_TAIL: Record<ReadNothingTag, string> = {
   link_unreachable: "so nothing we have read describes these terms",
   unreadable: "so nothing we have read describes these terms",
   states_no_terms: "so nothing we have read describes these terms",
@@ -289,7 +362,7 @@ const EMPTY_HISTORY_TAIL: Record<TermsWithholdingTag, string> = {
   change_measured_no_difference: "so we cannot tell you that nothing changed",
 };
 
-export function emptyHistoryCaveatSentence(subject: string, unconfirmed: UnconfirmedTerms): string {
+export function emptyHistoryCaveatSentence(subject: string, unconfirmed: TermsNoReadDescribes): string {
   return `No recorded pricing changes for ${subject} — but ${unconfirmed.clause},`
     + ` ${EMPTY_HISTORY_TAIL[unconfirmed.because.reason]}.`
     + ` Treat the empty history as a statement about our records, not about this vendor's pricing.`;

--- a/test/withholding-covers-every-assertive-surface.test.ts
+++ b/test/withholding-covers-every-assertive-surface.test.ts
@@ -9,6 +9,12 @@ import { vendorSlugMap } from "../dist/vendor-slug.js";
 import { utcDate } from "../dist/ranking.js";
 import { vendorVerdictContextFrom } from "../dist/vendor-verdict-input.js";
 import {
+  levelWithheldReason,
+  SOURCE_CHECK_OUTCOMES,
+  TERMS_ONLY_OUTCOMES,
+} from "../dist/source-check.js";
+import { supersededTermsNotice, supersedingChange } from "../dist/superseded-description.js";
+import {
   badgeWithholding,
   termsNotVerifiedMetaSentence,
   whyWeCannotConfirmTheseTerms,
@@ -24,6 +30,7 @@ const REPO = path.join(__dirname, "..");
 
 const WITHHOLDING_TAGS = Object.keys(WITHHOLDING_SCOPE) as Array<keyof typeof WITHHOLDING_SCOPE>;
 const TAGS_THAT_WITHHOLD_THE_TERMS = WITHHOLDING_TAGS.filter(tag => WITHHOLDING_SCOPE[tag] === "the_terms");
+const OUTCOMES_THAT_LEAVE_THE_TERMS_UNCONFIRMED = SOURCE_CHECK_OUTCOMES.filter(outcome => outcome !== "ok");
 
 interface AssertiveSurface {
   name: string;
@@ -34,29 +41,48 @@ interface Page {
   slug: string;
   vendor: string;
   category: string;
+  outcome: string | null;
   html: string;
   faq: Map<string, string>;
+  visibleFaq: Map<string, string>;
   meta: string;
-  tag: string | null;
-  unconfirmed: { sentence: string } | null;
+  badgeTag: string | null;
+  termsTag: string | null;
+  caveats: string[];
+  unconfirmed: { sentence: string; theReadFoundAFreePlan: boolean } | null;
 }
 
 const A_MONTH = "(?:January|February|March|April|May|June|July|August|September|October|November|December)";
 const A_BARE_VERIFICATION = new RegExp(`(?<!Not )Verified ${A_MONTH} \\d{4}\\.`);
 
+function statedFlat(page: Page, answer: string, states: (answer: string) => boolean): boolean {
+  return states(answer) && page.caveats.every(caveat => !answer.includes(caveat));
+}
+
 const SURFACES: AssertiveSurface[] = [
   {
     name: "the structured-data answer to whether the vendor is free states the terms flat",
-    asserts: (page) => (page.faq.get(`Is ${page.vendor} free?`) ?? "").startsWith("Yes, "),
+    asserts: (page) => statedFlat(
+      page,
+      page.faq.get(`Is ${page.vendor} free?`) ?? "",
+      answer => answer.startsWith("Yes, "),
+    ),
   },
   {
     name: "the structured-data answer naming the free tier states it flat",
-    asserts: (page) => (page.faq.get(`What is ${page.vendor}'s free tier?`) ?? "")
-      .includes(`${page.vendor}'s free tier is called "`),
+    asserts: (page) => statedFlat(
+      page,
+      page.faq.get(`What is ${page.vendor}'s free tier?`) ?? "",
+      answer => answer.includes(`${page.vendor}'s free tier is called "`),
+    ),
   },
   {
     name: "the visible question-and-answer block states the terms flat",
-    asserts: (page) => page.html.includes(`Yes, ${page.vendor} offers a free tier`),
+    asserts: (page) => statedFlat(
+      page,
+      page.visibleFaq.get(`Is ${page.vendor} free?`) ?? "",
+      answer => answer.includes(`Yes, ${page.vendor} offers a free tier`),
+    ),
   },
   {
     name: "the meta description states the terms as verified",
@@ -100,6 +126,21 @@ function faqAnswersIn(html: string): Map<string, string> {
     for (const entry of parsed.mainEntity ?? []) {
       if (entry.name) answers.set(entry.name, entry.acceptedAnswer?.text ?? "");
     }
+  }
+  return answers;
+}
+
+const unescaped = (text: string): string => text
+  .replace(/&quot;/g, '"')
+  .replace(/&gt;/g, ">")
+  .replace(/&lt;/g, "<")
+  .replace(/&amp;/g, "&");
+
+function visibleFaqAnswersIn(html: string): Map<string, string> {
+  const answers = new Map<string, string>();
+  const item = /<summary class="faq-q">([\s\S]*?)<\/summary>\s*<div class="faq-a">([\s\S]*?)<\/div>/g;
+  for (const block of html.matchAll(item)) {
+    answers.set(unescaped(block[1]), unescaped(block[2]));
   }
   return answers;
 }
@@ -151,12 +192,20 @@ before(async () => {
     });
     if (!context) return [];
     const because = badgeWithholding(context.input);
+    const unconfirmed = whyWeCannotConfirmTheseTerms(context.input);
+    const superseded = supersedingChange(context.primary, context.vendorChanges);
     return [{
       slug,
       vendor,
       category: context.primary.category,
-      tag: because ? withholdingTag(because) : null,
-      unconfirmed: whyWeCannotConfirmTheseTerms(context.input),
+      outcome: context.primary.source_check?.outcome ?? null,
+      badgeTag: because ? withholdingTag(because) : null,
+      termsTag: unconfirmed ? withholdingTag(unconfirmed.because) : null,
+      caveats: [
+        ...(unconfirmed ? [unconfirmed.sentence] : []),
+        ...(superseded ? [supersededTermsNotice(vendor, superseded)] : []),
+      ],
+      unconfirmed,
     }];
   });
 
@@ -172,7 +221,13 @@ before(async () => {
       const res = await fetch(`http://localhost:${serverPort}/vendor/${subject.slug}`);
       assert.strictEqual(res.status, 200, `/vendor/${subject.slug} returned ${res.status}`);
       const html = await res.text();
-      read.push({ ...subject, html, faq: faqAnswersIn(html), meta: metaDescriptionIn(html) });
+      read.push({
+        ...subject,
+        html,
+        faq: faqAnswersIn(html),
+        visibleFaq: visibleFaqAnswersIn(html),
+        meta: metaDescriptionIn(html),
+      });
     }
   };
   await Promise.all(Array.from({ length: 12 }, worker));
@@ -186,7 +241,7 @@ describe("a withholding we publish reaches every surface that states the terms",
     const asserting: string[] = [];
     const cells: Record<string, number> = {};
     for (const tag of TAGS_THAT_WITHHOLD_THE_TERMS) {
-      const population = pages.filter(page => page.tag === tag);
+      const population = pages.filter(page => page.termsTag === tag);
       cells[tag] = population.length;
       for (const surface of SURFACES) {
         for (const page of population.filter(page => surface.asserts(page))) {
@@ -203,14 +258,14 @@ describe("a withholding we publish reaches every surface that states the terms",
   });
 
   it("reads a live population under every withholding it covers", () => {
-    const covered = pages.filter(page => page.tag !== null && TAGS_THAT_WITHHOLD_THE_TERMS.includes(page.tag as never));
+    const covered = pages.filter(page => page.termsTag !== null);
     assertSharesPopulation(
       covered.length,
       vendorsInTheCatalogue(),
       0.2,
       "vendor pages whose withholding says we could not read the terms",
     );
-    const empty = TAGS_THAT_WITHHOLD_THE_TERMS.filter(tag => !pages.some(page => page.tag === tag));
+    const empty = TAGS_THAT_WITHHOLD_THE_TERMS.filter(tag => !pages.some(page => page.termsTag === tag));
     assert.ok(
       empty.length < TAGS_THAT_WITHHOLD_THE_TERMS.length,
       `no page carries any of the withholdings this sweep covers: ${empty.join(", ")}`,
@@ -218,13 +273,58 @@ describe("a withholding we publish reaches every surface that states the terms",
   });
 
   it("still states the terms on a page carrying no withholding at all", () => {
-    const stating = pages.filter(page => page.tag === null && SURFACES.some(surface => surface.asserts(page)));
+    const stating = pages.filter(page => page.termsTag === null && page.badgeTag === null
+      && SURFACES.some(surface => surface.asserts(page)));
     assertSharesPopulation(
       stating.length,
       vendorsInTheCatalogue(),
       0.2,
       "vendor pages that state the terms with nothing withheld",
     );
+  });
+
+  it("takes a withholding from every source-check outcome that is not a clean read", () => {
+    const unclassified = OUTCOMES_THAT_LEAVE_THE_TERMS_UNCONFIRMED.filter(outcome => {
+      const input = inputWith({
+        sourceCheck: outcome,
+        levelWithheld: levelWithheldReason({ source_check: { outcome, checked: "2026-09-01", detail: "" } }, null),
+      });
+      const unconfirmed = whyWeCannotConfirmTheseTerms(input);
+      return unconfirmed === null || !withholdsTheTerms(unconfirmed.because);
+    });
+    assert.deepStrictEqual(
+      unclassified,
+      [],
+      `a source-check outcome states no reason the surfaces can publish: ${unclassified.join(", ")}`,
+    );
+    assert.ok(
+      OUTCOMES_THAT_LEAVE_THE_TERMS_UNCONFIRMED.length < SOURCE_CHECK_OUTCOMES.length,
+      "every source-check outcome leaves the terms unconfirmed, so the outcome decides nothing",
+    );
+
+    const silent = pages
+      .filter(page => page.outcome !== null && page.outcome !== "ok" && page.unconfirmed === null)
+      .map(page => `${page.slug} (${page.outcome})`);
+    assert.deepStrictEqual(
+      silent.slice(0, 20),
+      [],
+      `${silent.length} live pages carry a source check that is not a clean read and publish no reason for it`,
+    );
+    const read = pages.filter(page => page.outcome !== null && page.outcome !== "ok").length;
+    assertSharesPopulation(read, vendorsInTheCatalogue(), 0.2, "vendor pages whose source check is not a clean read");
+  });
+
+  it("leaves the rating standing where the read found the plan and not the amount", () => {
+    const ratedOnAReadWeCouldNotQuantify = TERMS_ONLY_OUTCOMES.filter(outcome => {
+      const input = inputWith({ sourceCheck: outcome });
+      return badgeWithholding(input) === null && whyWeCannotConfirmTheseTerms(input) !== null;
+    });
+    assert.deepStrictEqual(
+      ratedOnAReadWeCouldNotQuantify,
+      TERMS_ONLY_OUTCOMES,
+      "an outcome that withholds only the terms is withholding the rating as well",
+    );
+    assert.ok(TERMS_ONLY_OUTCOMES.length > 0, "no source-check outcome withholds the terms alone");
   });
 
   it("opens the answer with the reason the page gives for withholding", () => {
@@ -240,8 +340,8 @@ describe("a withholding we publish reaches every surface that states the terms",
       0.3,
       "vendor pages opening the free-tier answer with the reason they withhold",
     );
-    const refused = pages.filter(page => page.unconfirmed && page.tag !== null
-      && ["read_not_reconciled", "change_measured_no_difference"].includes(page.tag));
+    const refused = pages.filter(page => page.unconfirmed && page.termsTag !== null
+      && ["read_not_reconciled", "change_measured_no_difference"].includes(page.termsTag));
     const silent = refused.filter(page => !(page.faq.get(`Is ${page.vendor} free?`) ?? "")
       .includes(page.unconfirmed!.sentence)).map(page => page.slug);
     assert.deepStrictEqual(
@@ -249,6 +349,53 @@ describe("a withholding we publish reaches every surface that states the terms",
       [],
       `${silent.length} of ${refused.length} answers name no day for the read they withhold on`,
     );
+  });
+
+  it("still answers yes where the read found the free plan and could not read the amount", () => {
+    const affirming = pages.filter(page => page.unconfirmed?.theReadFoundAFreePlan);
+    const answersOf = (page: Page) => [
+      page.faq.get(`Is ${page.vendor} free?`) ?? "",
+      page.visibleFaq.get(`Is ${page.vendor} free?`) ?? "",
+    ];
+    const denying = affirming
+      .filter(page => answersOf(page).some(answer => answer.includes("We cannot confirm that today.")))
+      .map(page => page.slug);
+    assert.deepStrictEqual(
+      denying.slice(0, 20),
+      [],
+      `${denying.length} pages say they cannot confirm a free tier their own read found`,
+    );
+    const uncaveated = affirming
+      .filter(page => answersOf(page)
+        .some(answer => answer !== "" && page.caveats.every(caveat => !answer.includes(caveat))))
+      .map(page => page.slug);
+    assert.deepStrictEqual(
+      uncaveated.slice(0, 20),
+      [],
+      `${uncaveated.length} pages state the limits without saying the page we cite does not carry them`,
+    );
+    assertSharesPopulation(
+      affirming.length,
+      vendorsInTheCatalogue(),
+      0.03,
+      "vendor pages whose read found the free plan and not the amount",
+    );
+    assertSharesPopulation(
+      affirming.filter(page => answersOf(page).every(answer => answer.startsWith(`Yes, ${page.vendor} offers`))).length,
+      vendorsInTheCatalogue(),
+      0.025,
+      "vendor pages answering yes over a read that found the plan and not the amount",
+    );
+
+    const control = pages.find(page => page.slug === "jsdelivr");
+    assert.strictEqual(control?.outcome, "states_no_amount", "/vendor/jsdelivr is no longer the control this was written against");
+    for (const answer of answersOf(control)) {
+      assert.ok(answer.startsWith("Yes, jsDelivr offers a free tier: Free."), answer.slice(0, 120));
+      assert.ok(
+        answer.includes("The page we cite for jsDelivr names a plan but states no amount, so these limits come from our own record rather than from that page."),
+        answer.slice(0, 400),
+      );
+    }
   });
 
   it("names the day of the refused read wherever it withholds the terms", () => {
@@ -297,11 +444,11 @@ describe("a withholding we publish reaches every surface that states the terms",
 
   it("names a scope for every withholding a page can carry", () => {
     assert.deepStrictEqual(
-      Object.keys(WITHHOLDING_BADGE_LABELS).sort(),
-      WITHHOLDING_TAGS.slice().sort(),
+      WITHHOLDING_TAGS.filter(tag => !(tag in WITHHOLDING_BADGE_LABELS)).sort(),
+      TERMS_ONLY_OUTCOMES.slice().sort(),
       "a withholding the badge can name is missing from the scope this sweep reads",
     );
-    const unscoped = [...new Set(pages.map(page => page.tag))]
+    const unscoped = [...new Set(pages.flatMap(page => [page.badgeTag, page.termsTag]))]
       .filter(tag => tag !== null && !WITHHOLDING_TAGS.includes(tag as never));
     assert.deepStrictEqual(unscoped, [], `a page carries a withholding no scope covers: ${unscoped.join(", ")}`);
     assert.ok(
@@ -309,18 +456,18 @@ describe("a withholding we publish reaches every surface that states the terms",
       "every withholding was given the same scope, so the scope decides nothing",
     );
     const silent = pages
-      .filter(page => page.tag !== null && TAGS_THAT_WITHHOLD_THE_TERMS.includes(page.tag as never))
+      .filter(page => page.badgeTag !== null && TAGS_THAT_WITHHOLD_THE_TERMS.includes(page.badgeTag as never))
       .filter(page => page.unconfirmed === null)
-      .map(page => `${page.slug} (${page.tag})`);
+      .map(page => `${page.slug} (${page.badgeTag})`);
     assert.deepStrictEqual(
       silent.slice(0, 20),
       [],
       `${silent.length} pages withhold the terms and offer no reason the surfaces can publish`,
     );
     const exempted = pages
-      .filter(page => page.unconfirmed !== null && page.tag !== null)
-      .filter(page => !TAGS_THAT_WITHHOLD_THE_TERMS.includes(page.tag as never))
-      .map(page => `${page.slug} (${page.tag})`);
+      .filter(page => page.termsTag !== null)
+      .filter(page => !TAGS_THAT_WITHHOLD_THE_TERMS.includes(page.termsTag as never))
+      .map(page => `${page.slug} (${page.termsTag})`);
     assert.deepStrictEqual(
       exempted.slice(0, 20),
       [],


### PR DESCRIPTION
Refs #1565.

`/vendor/jsdelivr` said in its own body that the limits come from our record rather than from the page we cite, and answered **"Is jsDelivr free?"** with *"Yes, jsDelivr offers a free tier: … unlimited bandwidth and requests"* two paragraphs below. It answers this now:

> Yes, jsDelivr offers a free tier: Free. Free CDN for open-source — unlimited bandwidth and requests, serves npm packages and GitHub repos, multi-provider redundancy. **The page we cite for jsDelivr names a plan but states no amount, so these limits come from our own record rather than from that page.**

## What changed

`states_no_amount` is one entry in `WITHHOLDING_SCOPE`, scoped to the terms (**AC-1**). `whyWeCannotConfirmTheseTerms` — the join #1564 built — returns it, so the FAQ answer, the visible FAQ, the `Best for` line, the growth thresholds and the meta all read one object rather than five predicates.

It does not reach the rating. `LEVEL_WITHHOLDING_OUTCOMES` is untouched, so `badgeWithholding` still returns null and the verdict still publishes.

**The answer still says yes** (**AC-4**). `WHAT_THE_READ_LEFT_STANDING` records, for every withholding that reaches the terms, whether the read left the free plan standing; `states_no_amount` is the one that does. Where it does, the answer affirms the tier and names the limits as unconfirmed instead of opening *"We cannot confirm that today."*

**And the empty history keeps its meaning.** `test/refused-change-not-stable.test.ts` went red on the first draft: 20 rated vendors had lost *"This is a good sign — stable pricing"* to *"Treat the empty history as a statement about our records, not about this vendor's pricing."* That sentence withholds the rating, which this outcome leaves standing. `EMPTY_HISTORY_TAIL` is now typed over the withholdings where the read described nothing, so one cannot reach that sentence without saying so.

## Measured, both builds served side by side

All 1,539 vendor pages read as rendered HTML.

| `source_check.outcome` | pages | FAQ answers `Yes, {terms}` flat | visible FAQ | tier answer flat | `Best for … workloads` | bare `Verified {Month}` |
|---|---|---|---|---|---|---|
| `states_no_amount` | 85 | 62 → **0** | 62 → **0** | 69 → **6** | 7 → **0** | 0 → 0 |
| `states_no_terms` | 449 | 0 → 0 | 0 → 0 | 0 → 0 | 0 → 0 | 0 → 0 |
| `unreadable` | 135 | 0 → 0 | 0 → 0 | 0 → 0 | 0 → 0 | 0 → 0 |
| `does_not_name_vendor` | 104 | 0 → 0 | 0 → 0 | 1 → 1 | 0 → 0 | 0 → 0 |
| `does_not_name_product` | 7 | 0 → 0 | 0 → 0 | 0 → 0 | 0 → 0 | 0 → 0 |
| `ok` | 759 | 499 → 499 | 499 → 499 | 633 → 633 | 108 → 108 | 533 → 533 |

62 pages still open *"Yes, …"* — every one of them now carries the sentence saying the page we cite does not carry those limits, which is what **AC-2** and **AC-3** measure. The 7 that still state the tier flat publish a superseding read of the vendor's own page in place of our stored terms, which is a stronger disclosure than the one this issue asks for; 1 of them is on `does_not_name_vendor` and already behaved that way.

**AC-5, unchanged.** 0 of 1,547 API rows moved on `risk_level` or `stability`. The 85 read 58 `stable`/`stable`, 5 `caution`/`watch`, 2 `stable`/`improving`, 2 `risky`/`volatile`, 18 unrated — the issue's own figures. `risk_level` over the catalogue is 873 / 511 / 139 / 24.

**2,465 of 2,529 sitemap routes byte-identical.** The 63 that differ are all vendor pages on this outcome; 0 non-vendor pages. `/api/offers`, `/api/newest`, `/api/changes`, `/llms.txt`, `/llms-full.txt`, three badges, `resources/list`, two `resources/read` and five MCP tool calls are byte-identical over a real MCP session.

## AC-6 and the tests

`test/withholding-covers-every-assertive-surface.test.ts` takes its population from `whyWeCannotConfirmTheseTerms` rather than from the badge, and asserts over `SOURCE_CHECK_OUTCOMES` that every outcome which is not a clean read produces a terms withholding. Two holes closed on the way:

- The old sweep keyed on `badgeWithholding`, which returns null on a page carrying an adverse rating, so a `does_not_name_vendor` page with a `caution` rating was never read.
- A surface counted as stating the terms flat whether or not the answer carried the page's own caveat. It now subtracts the caveats the page's joins produce — the withholding sentence and the superseded notice — so a caveated answer is not a violation and an uncaveated one cannot hide behind a caveat printed elsewhere on the page. The visible FAQ is read out of its own rendered block rather than by searching the whole page.

Six mutants, all killed:

| mutant | killed by |
|---|---|
| `termsWithholding` stops reading the source check (main's behaviour) | 3 tests |
| the answer stops affirming the free tier | 1 test |
| the read that found a plan is graded as having found nothing | 2 tests |
| the caveat is dropped from the terms the answer states | 2 tests |
| one source-check outcome escapes classification at runtime | 4 tests |
| `states_no_amount` loses its `WITHHOLDING_SCOPE` entry | `tsc` |
