### PR TITLE
Read the state off the clock the register publishes (#1571)

### DIFF
--- a/src/page-reviews.ts
+++ b/src/page-reviews.ts
@@ -140,6 +140,20 @@ export type ReviewOutcome = "pass" | "fail";
 
 export const REVIEW_OUTCOMES: ReviewOutcome[] = ["pass", "fail"];
 
+export const OUTCOME_RESTARTS_THE_CLOCK = {
+  pass: true,
+  fail: false,
+} as const satisfies Record<ReviewOutcome, boolean>;
+
+export const A_REVIEW_WHOSE_OUTCOME_WENT_UNRECORDED_RESTARTS_THE_CLOCK = true;
+
+export function restartsTheClock(outcome: ReviewOutcome | null): boolean {
+  if (outcome === null || !REVIEW_OUTCOMES.includes(outcome)) {
+    return A_REVIEW_WHOSE_OUTCOME_WENT_UNRECORDED_RESTARTS_THE_CLOCK;
+  }
+  return OUTCOME_RESTARTS_THE_CLOCK[outcome];
+}
+
 export type PageDataSource = "catalogue" | "editorial" | "unsourced";
 
 export const PAGE_DATA_SOURCES: PageDataSource[] = ["catalogue", "editorial", "unsourced"];
@@ -293,8 +307,8 @@ export function reviewStatus(record: PageReviewRecord, today: string): ReviewSta
   const sla = SLA_DAYS[record.tier];
   const reviewedAt = record.reviewed_at !== null && record.reviewed_at <= today ? record.reviewed_at : null;
   const lastRead = reviewedAt ?? record.published;
-  const clockStarts = reviewedAt !== null && record.review_outcome === "fail" ? record.published : lastRead;
-  const daysSince = Math.max(0, daysBetween(lastRead, today));
+  const clockStarts = reviewedAt !== null && restartsTheClock(record.review_outcome) ? lastRead : record.published;
+  const daysSince = Math.max(0, daysBetween(clockStarts, today));
   const overdue = Math.max(0, daysSince - sla);
   let state: ReviewState;
   if (reviewedAt === null) state = "never_reviewed";

--- a/test/page-freshness.test.ts
+++ b/test/page-freshness.test.ts
@@ -7,8 +7,9 @@ import { fileURLToPath } from "node:url";
 import {
   compiledNotice, dataProvenanceFor, daysBetween, deriveTier, freshnessSegmentFor, indexCitation,
   linkifyVerdictBlocks, overdueReport,
-  parsePageReviews, reviewStatus, verdictBlocks, vendorsAssertedIn, verdictsOutdatedBy,
-  SLA_DAYS, EXPIRY_MULTIPLE, type PageReviewRecord,
+  parsePageReviews, restartsTheClock, reviewStatus, verdictBlocks, vendorsAssertedIn, verdictsOutdatedBy,
+  OUTCOME_RESTARTS_THE_CLOCK, REVIEW_OUTCOMES, SLA_DAYS, EXPIRY_MULTIPLE,
+  type PageReviewRecord, type ReviewOutcome,
 } from "../src/page-reviews.ts";
 import { namedVendorSlug } from "../dist/vendor-slug.js";
 
@@ -84,6 +85,84 @@ describe("#1061 review state is derived from a stored date, never from the clock
     assert.strictEqual(SLA_DAYS.B, SLA_DAYS.A * 3);
     assert.strictEqual(reviewStatus(record({ tier: "B", reviewed_at: "2026-01-01" }), addDays("2026-01-01", 89)).state, "current");
     assert.strictEqual(reviewStatus(record({ tier: "A", reviewed_at: "2026-01-01" }), addDays("2026-01-01", 89)).state, "expired");
+  });
+});
+
+describe("#1571 the state is read off the same clock the register publishes", () => {
+  it("holds a decision for every outcome a review can record, not only the ones written so far", () => {
+    assert.deepStrictEqual(Object.keys(OUTCOME_RESTARTS_THE_CLOCK).sort(), [...REVIEW_OUTCOMES].sort());
+    for (const outcome of REVIEW_OUTCOMES) {
+      assert.strictEqual(typeof restartsTheClock(outcome), "boolean", `${outcome} has no decision about the clock`);
+    }
+  });
+
+  it("counts days from clock_starts whatever outcome the review recorded", () => {
+    const today = "2026-09-12";
+    const outcomes: Array<ReviewOutcome | null> = [...REVIEW_OUTCOMES, null];
+    for (const outcome of outcomes) {
+      const status = reviewStatus(
+        record({ published: "2026-04-08", reviewed_at: "2026-08-27", review_outcome: outcome }),
+        today,
+      );
+      assert.strictEqual(
+        status.days_since,
+        daysBetween(status.clock_starts, today),
+        `an outcome of ${String(outcome)} publishes a clock starting ${status.clock_starts} and counts ${status.days_since} days from somewhere else`,
+      );
+    }
+  });
+
+  it("leaves a page whose review found defects as far past its SLA as the register already said it was", () => {
+    const status = reviewStatus(
+      record({ tier: "A", published: "2026-04-08", reviewed_at: "2026-08-27", review_outcome: "fail" }),
+      "2026-09-12",
+    );
+    assert.strictEqual(status.clock_starts, "2026-04-08");
+    assert.strictEqual(status.days_since, 157);
+    assert.strictEqual(status.days_overdue, 157 - SLA_DAYS.A);
+    assert.strictEqual(status.state, "expired");
+  });
+
+  it("restarts the clock for a review that found nothing wrong, however long ago the page was published", () => {
+    const status = reviewStatus(
+      record({ tier: "A", published: "2026-03-26", reviewed_at: "2026-09-07", review_outcome: "pass" }),
+      "2026-09-12",
+    );
+    assert.strictEqual(status.clock_starts, "2026-09-07");
+    assert.strictEqual(status.days_since, 5);
+    assert.strictEqual(status.days_overdue, 0);
+    assert.strictEqual(status.state, "current");
+  });
+
+  it("still runs a never-reviewed page's clock from publication", () => {
+    const status = reviewStatus(record({ tier: "A", published: "2026-03-31" }), "2026-08-26");
+    assert.strictEqual(status.state, "never_reviewed");
+    assert.strictEqual(status.clock_starts, "2026-03-31");
+    assert.strictEqual(status.days_since, 148);
+    assert.strictEqual(status.days_overdue, 148 - SLA_DAYS.A);
+  });
+
+  it("calls no registered page current once its own clock_starts puts it past its SLA", async () => {
+    const report = await (await fetch(`http://localhost:${serverPort}/api/page-reviews`)).json() as any;
+    for (const page of report.pages) {
+      const elapsed = daysBetween(page.clock_starts, report.generated_for);
+      assert.strictEqual(
+        page.days_since,
+        elapsed,
+        `${page.path} publishes clock_starts ${page.clock_starts} and days_since ${page.days_since}`,
+      );
+      assert.strictEqual(
+        page.days_overdue,
+        Math.max(0, elapsed - page.sla_days),
+        `${page.path} is ${elapsed} days into a ${page.sla_days}-day SLA and reports ${page.days_overdue} overdue`,
+      );
+      if (page.state === "current") {
+        assert.ok(
+          elapsed <= page.sla_days,
+          `${page.path} is called current ${elapsed} days after its clock started on ${page.clock_starts}`,
+        );
+      }
+    }
   });
 });
 

--- a/test/stale-page-facts.test.ts
+++ b/test/stale-page-facts.test.ts
@@ -5,7 +5,7 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { assertPopulationFloor } from "./population-floor.ts";
 import {
-  QUALITY_BUDGET_NAMES, STALE_FACT_PAGES_BASELINE, UNSOURCED_TIER_A_BASELINE, factsOutdatedBy,
+  QUALITY_BUDGET_NAMES, STALE_FACT_PAGES_BASELINE, UNSOURCED_TIER_A_BASELINE, daysBetween, factsOutdatedBy,
   newestChangeBySlug, parsePageReviews, parseQualityBudgets, qualityBudgetsPath, readQualityBudgets,
   dateModifiedFor, reviewStatus, serializeQualityBudgets, staleFactPages, staleFactViolations,
   unsourcedTierAPaths,
@@ -263,11 +263,17 @@ describe("#1327 a review that found defects does not restart the staleness clock
     }
   });
 
-  it("still measures the review cadence from the day the page was last read", () => {
+  it("measures the review cadence off that same clock, so recording defects cannot mark a page reviewed", () => {
     const failed = reviewStatus(reviewed("fail"), "2026-09-02");
     assert.strictEqual(failed.reviewed_at, "2026-08-27");
-    assert.strictEqual(failed.days_since, 6);
-    assert.strictEqual(failed.state, "current");
+    assert.strictEqual(failed.clock_starts, "2026-04-03");
+    assert.strictEqual(failed.days_since, daysBetween("2026-04-03", "2026-09-02"));
+    assert.strictEqual(failed.state, "expired");
+
+    const passed = reviewStatus(reviewed("pass"), "2026-09-02");
+    assert.strictEqual(passed.clock_starts, "2026-08-27");
+    assert.strictEqual(passed.days_since, daysBetween("2026-08-27", "2026-09-02"));
+    assert.strictEqual(passed.state, "current");
   });
 
   it("counts a fact the review read past, where a passing review would have cleared it", () => {


### PR DESCRIPTION
Refs #1571

`reviewStatus` computed `clock_starts` correctly and then computed the state from somewhere else. `days_since`, `days_overdue` and `state` came off `lastRead`; `clock_starts` reached only `dateModifiedFor` and the stale-fact joins. One line moves the count onto the published clock.

`#1327` fixed this same inversion on the staleness clock and scoped itself to that clock — its test was named *"still measures the review cadence from the day the page was last read"*. That test now records the new rule, and the pass counterpart sits beside the fail one so the pair is visible. **This reverses a scope boundary `#1327` drew on purpose**, which is the one judgement in this PR worth a second opinion.

Which outcome restarts the clock is a map over `ReviewOutcome` rather than a comparison against one literal (AC-5), so an outcome cannot be added without a decision about the SLA. A review whose outcome went unrecorded restarts it — that is what shipped before, and it leaves the three rows in that state where they were.

## Measured, both builds served side by side

| | main | branch |
|---|---:|---:|
| `totals.current` | 7 | **1** |
| `totals.expired` | 3 | **9** |
| `totals.overdue` | 0 | 0 |
| `totals.never_reviewed` | 61 | 61 |

The six pages whose last review found defects move to `expired`, `days_since` 16 → 152–162:

| path | `clock_starts` | `days_since` | `days_overdue` | `state` |
|---|---|---:|---:|---|
| `/ai-coding-tools-pricing` | 2026-04-08 | 16 → 157 | 0 → 127 | current → **expired** |
| `/email-comparison-2026` | 2026-04-03 | 7 → 162 | 0 → 132 | current → **expired** |
| `/llm-api-pricing` | 2026-04-13 | 16 → 152 | 0 → 122 | current → **expired** |
| `/monitoring-comparison-2026` | 2026-04-03 | 16 → 162 | 0 → 132 | current → **expired** |
| `/openai-assistants-migration` | 2026-04-09 | 16 → 156 | 0 → 126 | current → **expired** |
| `/storage-comparison-2026` | 2026-04-03 | 16 → 162 | 0 → 132 | current → **expired** |

**AC-2, the negative control.** `/supabase-vs-firebase` — reviewed 2026-09-07, outcome `pass` — stays `current` at `days_since: 5`, and is the only `current` row. **AC-4.** All 61 `never_reviewed` rows are byte-identical, including their 7,712 overdue days. `clock_starts` moves on **no page**, so `dateModified`, `verdict_records_changed_since_review` and `records_changed_since_read` are unchanged at 54 / 58 / 357.

65 of the 71 register rows are byte-identical. Only `days_since`, `days_overdue` and `state` move anywhere. The `pages` array reorders, because it sorts by `days_overdue` and these six no longer sit at 0.

## Blast radius

- **2,519 of 2,519 sitemap routes byte-identical**, walking the sitemap index's children. No rendered page changes: `freshnessSegmentFor` answers `fail` before it answers `expired`, so those six still print *"Reviewed 2026-08-27, corrections outstanding"*.
- **56 API routes compared.** 7 differ under a **main-versus-main control** as well (per-process counters: `/api/metrics`, `/api/pageviews`, `/api/query-log`, `/api/referral-health`, `/api/signals`, `/api/stats`, `/api/traffic`). `/api/analytics/history` differs only in `coverage.path`, which is the worktree directory — every figure in it is identical. That leaves `/api/page-reviews` as the only route the change moves.
- **`/api/offers`: all 1,547 rows identical.**
- The MCP server does not read the register on either builder, so there is no second surface for this claim.

## Tests

219 passing across the six suites that load `page-reviews`, plus 127 across the seven that read the register indirectly. Five mutants, **all five killed by a test**:

| mutation | killed by |
|---|---|
| `days_since` counts from `lastRead` again | 3 tests |
| every outcome restarts the clock | 2, one of them the pre-existing `dateModified` guard |
| an outcome added with no decision about the clock | the coverage test — **and `tsc`, independently** |
| an unrecorded outcome stops restarting the clock | 4 tests |
| the clock always runs from publication, so a pass buys nothing | 2, including the AC-2 control |

The register-wide test asserts `days_since == daysBetween(clock_starts, generated_for)` and `days_overdue == max(0, elapsed - sla_days)` on every row, and that nothing is `current` past its own SLA — a property rather than today's counts, so a page being reviewed tomorrow does not turn it red.

## One number in the issue

The issue says 64 pages carry `days_overdue > 0` "summing to 7,712 days". 7,712 is the sum over the **61 `never_reviewed`** rows; all 64 sum to **8,094**, the extra 382 being the three already-expired pages. Both figures are from `/api/page-reviews` on production and on main locally, which agree exactly.
