### PR TITLE
Answer 404 for a docs path that is not a file, rather than exiting (#1574)

### DIFF
--- a/src/serve.ts
+++ b/src/serve.ts
@@ -1,5 +1,5 @@
 import { createServer as createHttpServer } from "node:http";
-import { readFileSync, existsSync, writeFileSync } from "node:fs";
+import { readFileSync, existsSync, statSync, writeFileSync } from "node:fs";
 import { randomUUID } from "node:crypto";
 import { fileURLToPath } from "node:url";
 import { dirname, join } from "node:path";
@@ -310,6 +310,14 @@ const SWAGGER_MIME_TYPES: Record<string, string> = {
   ".png": "image/png",
   ".map": "application/json",
 };
+
+function readSwaggerAsset(filePath: string): Buffer | null {
+  try {
+    return statSync(filePath).isFile() ? readFileSync(filePath) : null;
+  } catch {
+    return null;
+  }
+}
 const SESSION_IDLE_TIMEOUT_MS = 15 * 60 * 1000;
 const CLEANUP_INTERVAL_MS = 60 * 1000;
 
@@ -54776,15 +54784,14 @@ const httpServer = createHttpServer(async (req, res) => {
       res.end(JSON.stringify({ error: "Invalid path" }));
       return;
     }
-    const filePath = join(swaggerUiDistPath, filename);
-    if (!existsSync(filePath)) {
+    const content = readSwaggerAsset(join(swaggerUiDistPath, filename));
+    if (content === null) {
       res.writeHead(404, { "Content-Type": "application/json" });
       res.end(JSON.stringify({ error: "Not found" }));
       return;
     }
     const ext = filename.substring(filename.lastIndexOf("."));
     const contentType = SWAGGER_MIME_TYPES[ext] || "application/octet-stream";
-    const content = readFileSync(filePath);
     res.writeHead(200, { "Content-Type": contentType, "Cache-Control": "public, max-age=86400" });
     res.end(content);
   } else if ((url.pathname === "/feed.xml" || url.pathname === "/api/feed") && isGetOrHead) {

--- a/test/docs-asset-route.test.ts
+++ b/test/docs-asset-route.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, before, after } from "node:test";
+import assert from "node:assert";
+import { spawn, type ChildProcess } from "node:child_process";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO = path.join(__dirname, "..");
+
+let serverPort = 0;
+let proc: ChildProcess | null = null;
+
+function startServer(): Promise<ChildProcess> {
+  return new Promise((resolve, reject) => {
+    const child = spawn("node", [path.join(REPO, "dist", "serve.js")], {
+      stdio: ["pipe", "pipe", "pipe"],
+      env: { ...process.env, PORT: "0", BASE_URL: "http://localhost" },
+    });
+    const timeout = setTimeout(() => { child.kill(); reject(new Error("Server startup timeout")); }, 30000);
+    child.stderr!.on("data", (data: Buffer) => {
+      const m = data.toString().match(/running on http:\/\/localhost:(\d+)/);
+      if (m) { serverPort = parseInt(m[1], 10); clearTimeout(timeout); resolve(child); }
+    });
+    child.on("error", (err) => { clearTimeout(timeout); reject(err); });
+  });
+}
+
+async function status(routePath: string): Promise<number> {
+  const res = await fetch(`http://localhost:${serverPort}${routePath}`);
+  await res.arrayBuffer();
+  return res.status;
+}
+
+async function stillServing(): Promise<boolean> {
+  try {
+    return await status("/health") === 200;
+  } catch {
+    return false;
+  }
+}
+
+before(async () => { proc = await startServer(); });
+after(() => { if (proc) proc.kill(); });
+
+describe("#1574 a request for a docs asset cannot take the server down", () => {
+  it("serves a real asset, so the route is reaching the directory the rest of this file is about", async () => {
+    assert.strictEqual(await status("/api/docs/swagger-ui.css"), 200);
+  });
+
+  it("answers 404 for the directory itself rather than reading it", async () => {
+    assert.strictEqual(await status("/api/docs/"), 404);
+    assert.ok(await stillServing(), "the server stopped answering after a request for /api/docs/");
+  });
+
+  it("answers 404 for an asset that is not there", async () => {
+    assert.strictEqual(await status("/api/docs/no-such-file.js"), 404);
+    assert.ok(await stillServing(), "the server stopped answering after a request for a missing asset");
+  });
+
+  it("keeps refusing a path that climbs out of the directory", async () => {
+    assert.strictEqual(await status("/api/docs/..%2Fpackage.json"), 400);
+    assert.strictEqual(await status("/api/docs/nested/thing.js"), 400);
+    assert.ok(await stillServing(), "the server stopped answering after a refused path");
+  });
+
+  it("is still serving every earlier assertion's traffic at the end", async () => {
+    assert.ok(await stillServing());
+    assert.strictEqual(await status("/api/docs/swagger-ui.css"), 200);
+  });
+});


### PR DESCRIPTION
Refs #1574

`GET /api/docs/` exits the server process. `filename` is empty, so the traversal guard passes it, `join(swaggerUiDistPath, "")` resolves to the directory, `existsSync` is true for a directory, and `readFileSync` throws `EISDIR` inside the request handler. There is no `uncaughtException` handler in `src/serve.ts`, so the throw is terminal.

Against `main` at `146c0ed`: `/health` 200 → `GET /api/docs/` → connection closed with no response → `/health` refused → zero server processes.

`readSwaggerAsset` asks whether the path is a **file** and returns `null` on any failed read, so both the directory and a missing asset answer 404.

## Both halves are load-bearing, and the test is what showed it

I expected the `statSync` check to be the fix and the `catch` to be belt-and-braces. That is backwards in one direction and incomplete in the other:

| implementation | result |
|---|---|
| `existsSync` + no catch — **what is on main** | **4 of 5 red**, server dead after the second test |
| `statSync().isFile()` + no catch | **3 of 5 red** — a missing asset now throws `ENOENT` instead, a *new* crash |
| `existsSync` + catch | 5 of 5 green |
| `statSync().isFile()` + catch — **this PR** | 5 of 5 green |

The naive one-line fix trades `EISDIR` on a directory for `ENOENT` on a typo'd filename, which is strictly worse — a wrong asset name is more likely to be requested than a bare directory. I would not have noticed that from reading the diff.

## Tests

`test/docs-asset-route.test.ts`, 5 assertions. The one that matters is not the status code but `stillServing()` after each request — a `/health` probe that returns `false` rather than throwing, so a dead server reads as a failed assertion rather than a test error. A real asset is fetched first, so the suite fails loudly if the route ever stops reaching the directory and the other four assertions start passing vacuously.

335 passing across this file and `test/http.test.ts`.

## Not fixed here, and on the issue

Any synchronous throw in that handler still exits the process. `/.well-known/glama.json` (`src/serve.ts:54137`) is an unguarded `readFileSync` of the same shape — safe today only because `Dockerfile:23` copies the file into the image. A `try`/`catch` around the dispatch, or a `process.on("uncaughtException")` that logs and keeps serving, is the general answer and is a decision about failure semantics rather than a bug fix, so I have left it to be ranked.

## Production

I did not send this request to `agentdeals.dev`. `swagger-ui-dist` is a production dependency, `https://agentdeals.dev/api/docs/swagger-ui.css` returns 200 at 178,890 bytes, and the route matches on `pathname` alone — so the deployed image has the directory and the same code path. The inference is stated rather than demonstrated on purpose.

Found while sweeping every `"/api/..."` literal across two builds to bound the blast radius of #1571; both servers died at the same route, which is how I know it predates that branch.
