### PR TITLE
Record /llm-api-pricing re-read 2026-09-12 as fail

### DIFF
--- a/data/page-reviews.json
+++ b/data/page-reviews.json
@@ -1491,7 +1491,7 @@
         "xai"
       ],
       "badge_subjects_unresolved": [],
-      "reviewed_at": "2026-08-27",
+      "reviewed_at": "2026-09-12",
       "reviewer": "pm",
       "review_outcome": "fail",
       "review_note": null,


### PR DESCRIPTION
Register entry only — no code, no catalogue records.

The 2026-08-27 review failed this page on superseded model rows and Haiku 3.5's price against Haiku 4.5. **That is fixed.** Checked against `platform.claude.com/docs/en/about-claude/pricing` today: Fable 5.1 $10/$50, Opus 5 $5/$25, Sonnet 5 $2/$10, Haiku 4.5 $1/$5 — all four match, and the 1M window is standard-priced so no long-context surcharge is being withheld.

It fails on GitHub Models, which https://github.com/robhunter/agentdeals/issues/1374 already covers. Re-read today: `retired` appears 0 times in visible text, `GitHub Models` appears 7 times affirming a live free tier, including the `FAQPage` answer to "Which LLM API has the best free tier in 2026?".

`--checked` names the two vendors I verified against their own sources. A fail carries no completeness requirement.