### PR TITLE
Refuse a hardcoded comparison row that sells a tier its own record has retired

### DIFF
--- a/data/page-reviews.json
+++ b/data/page-reviews.json
@@ -647,9 +647,9 @@
       "reviewer": null,
       "review_outcome": null,
       "review_note": null,
-      "reads_index": false,
+      "reads_index": true,
       "reads_changes": true,
-      "data_source": "unsourced",
+      "data_source": "catalogue",
       "data_source_reason": null
     },
     {
@@ -1495,9 +1495,9 @@
       "reviewer": "pm",
       "review_outcome": "fail",
       "review_note": null,
-      "reads_index": false,
+      "reads_index": true,
       "reads_changes": true,
-      "data_source": "unsourced",
+      "data_source": "catalogue",
       "data_source_reason": null
     },
     {

--- a/data/quality_budgets.json
+++ b/data/quality_budgets.json
@@ -2,7 +2,7 @@
   "version": 1,
   "budgets": {
     "stale_fact_pages": 58,
-    "unsourced_tier_a": 22,
+    "unsourced_tier_a": 20,
     "uncited_change_records": 98,
     "source_checks_ok_without_quoted_evidence": 279,
     "faq_answers": 166,

--- a/src/retirement.ts
+++ b/src/retirement.ts
@@ -16,6 +16,15 @@ export function offerEnded(offer: Pick<Offer, "tier"> | null | undefined): boole
   return ENDED_TIER_SET.has((offer?.tier ?? "").trim().toLowerCase());
 }
 
+export type OfferTierAndDescription = Pick<Offer, "tier" | "description">;
+
+export function detailForEndedOffer(
+  record: OfferTierAndDescription | null | undefined,
+  writtenForALiveOffer: string,
+): string {
+  return record && offerRetired(record) ? record.description : writtenForALiveOffer;
+}
+
 export function listEndedTiers(): string {
   const all = [...ENDED_TIERS];
   const last = all.pop()!;

--- a/src/serve.ts
+++ b/src/serve.ts
@@ -23,7 +23,7 @@ import { openapiSpec } from "./openapi.js";
 import { CATEGORY_ALIASES, CATEGORY_RETIREMENTS, EXAMPLE_MEMBERS_BASIS, buildCategoryDirectory, categoryHolds, familySiblings, publishedScopeFor, resolveCategoryName, retiredCategoryNames, retirementFor, scopeFor } from "./category-scope.js";
 import { retiredCategoryDescription, retiredCategoryNoticeHtml, retiredCategoryTitle } from "./category-retirement.js";
 import { LINK_GRACE_DAYS, unreachableNoticeForUrl } from "./link-health.js";
-import { offerEnded, offerRetired, recordedTierSentence, endedHeadline, endedHistorySentence, endedReliabilitySentence, endedEmptyChangeHistorySentence, ENDED_BADGE_LABEL, ENDED_SINCE_CHANGES_SENTENCE, type OfferTierAndUrl } from "./retirement.js";
+import { offerEnded, offerRetired, recordedTierSentence, endedHeadline, endedHistorySentence, endedReliabilitySentence, endedEmptyChangeHistorySentence, detailForEndedOffer, ENDED_BADGE_LABEL, ENDED_SINCE_CHANGES_SENTENCE, type OfferTierAndUrl } from "./retirement.js";
 import { amountUnstatedSentence, LAST_RESOLVED, levelWithheldReason, levelWithheldSince, withheldLevelClause, withheldLevelSentence, type LevelWithheldReason } from "./source-check.js";
 import { vendorVerdictContextFrom, type VendorVerdictContext } from "./vendor-verdict-input.js";
 import { readingIsBehindTheLoop, reverificationIntervalDays } from "./badge-staleness.js";
@@ -23914,7 +23914,7 @@ function buildOpenaiAssistantsAlternativesPage(): string {
     { name: "OpenAI (Responses API)", slug: "openai", toolUse: "Native (function calling)", codeExec: "Code interpreter tool", fileHandling: "File search tool", bestFor: "Direct migration — least code changes" },
     { name: "Anthropic Claude API", slug: "anthropic-api", toolUse: "Native (tool use)", codeExec: "Computer use, code execution", fileHandling: "PDF + document processing", bestFor: "Best reasoning, long context" },
     { name: "Google Gemini API", slug: "google-gemini-api", toolUse: "Native (function calling)", codeExec: "Code execution tool", fileHandling: "Multimodal (images, audio, video)", bestFor: "Free tier available, multimodal input" },
-    { name: "GitHub Models", slug: "github-models", toolUse: "Via hosted models", codeExec: "No built-in", fileHandling: "Model-dependent", bestFor: "Free access to multiple models" },
+    { name: "GitHub Models", slug: "github-models", toolUse: "Via hosted models", codeExec: "No built-in", fileHandling: "Model-dependent", bestFor: "Retired — no longer available to any customer" },
     { name: "OpenRouter", slug: "openrouter", toolUse: "Model-dependent", codeExec: "Model-dependent", fileHandling: "Model-dependent", bestFor: "Multi-provider abstraction, price comparison" },
     { name: "Cohere", slug: "cohere", toolUse: "Native (tool use)", codeExec: "No built-in", fileHandling: "Document parsing", bestFor: "RAG and enterprise search" },
     { name: "Groq", slug: "groq", toolUse: "Native (function calling)", codeExec: "No built-in", fileHandling: "No built-in", bestFor: "Fastest inference, open-source models" },
@@ -29911,14 +29911,14 @@ function buildDatabasePricingPage(): string {
       dbType: "Cache + Topics (Serverless)",
       freeStorage: "N/A (cache)",
       freeConnections: "N/A (HTTP)",
-      freeCompute: "5 GiB transfer/mo",
+      freeCompute: "None free",
       paidFrom: "$0.50/GiB transfer",
       pricingModel: "Per-transfer",
-      freeDetails: "5 GiB data transfer/month free. Serverless caching (Cache) and pub/sub messaging (Topics). No connections to manage — HTTP-based. Compatible with Redis and Memcached protocols. Instant provisioning, no clusters to configure.",
-      freeType: "limited",
-      monthlyCostSmall: "$0",
-      monthlyCostTeam: "$0\u201310+",
-      hiddenCosts: "5 GiB transfer can be consumed quickly with chatty applications. Per-transfer pricing differs from Redis per-operation model. Limited ecosystem compared to Redis. Topics is newer and less battle-tested.",
+      freeDetails: "No free tier. The offer was retired.",
+      freeType: "removed",
+      monthlyCostSmall: "Paid only",
+      monthlyCostTeam: "Paid only",
+      hiddenCosts: "Every plan on the vendor's pricing page is priced. Per-transfer pricing differs from the Redis per-operation model. Limited ecosystem compared to Redis. Topics is newer and less battle-tested.",
     },
     {
       name: "Hasura Cloud",
@@ -29993,7 +29993,7 @@ function buildDatabasePricingPage(): string {
       return '<div class="diff-card" style="border-left-color:' + borderColor + '">' +
         '<h3><a href="/vendor/' + escHtmlServer(s.slug) + '" style="color:var(--text)">' + escHtmlServer(s.name) + '</a> ' +
         '<span style="font-size:.75rem;color:var(--text-dim);font-weight:400">' + escHtmlServer(s.dbType) + ' \u00b7 ' + escHtmlServer(freeTypeLabels[s.freeType]) + '</span></h3>' +
-        '<p class="diff-desc">' + escHtmlServer(s.freeDetails) + '</p>' +
+        '<p class="diff-desc">' + escHtmlServer(detailForEndedOffer(offerForSlug(s.slug), s.freeDetails)) + '</p>' +
         '</div>';
     }).join("\n    ");
     return '<h3 id="cat-' + cat + '">' + escHtmlServer(categoryLabels[cat]) + '</h3>' +
@@ -32040,15 +32040,15 @@ function buildLlmApiPricingPage(): string {
       name: "GitHub Models",
       slug: "github-models",
       category: "specialized",
-      freeTier: "50-150 req/day",
+      freeTier: "Retired",
       flagshipModel: "GPT-4o, Llama, Mistral",
-      inputPrice: "Free (rate-limited)",
-      outputPrice: "Free (rate-limited)",
+      inputPrice: "Unavailable",
+      outputPrice: "Unavailable",
       contextWindow: "Varies",
-      rateLimit: "10-15 RPM, 50-150 req/day",
-      freeDetails: "10-15 RPM, 50-150 requests/day depending on model tier. OpenAI-compatible API endpoint. 100+ models including GPT-4o, Llama, Mistral, Phi. Free for GitHub users.",
-      freeType: "generous",
-      differentiator: "Free access to 100+ models for GitHub users; OpenAI-compatible; great for prototyping",
+      rateLimit: "None — the offer was retired",
+      freeDetails: "No free tier — the offer was retired.",
+      freeType: "none",
+      differentiator: "Retired — the playground, model catalog, inference API and bring-your-own-key access are no longer available to any customer",
     },
     {
       name: "LLM7.io",
@@ -32115,6 +32115,33 @@ function buildLlmApiPricingPage(): string {
   const generousCount = providers.filter(p => p.freeType === "generous").length;
   const creditsCount = providers.filter(p => p.freeType === "credits" || p.freeType === "limited" || p.freeType === "trial").length;
 
+  const stillOffered = (slugs: string[]): LlmProvider[] =>
+    slugs
+      .map(slug => providers.find(p => p.slug === slug))
+      .filter((p): p is LlmProvider => p !== undefined && !offerRetired(offerForSlug(p.slug)));
+
+  const namedWithTheirFreeTier = (slugs: string[]): string =>
+    stillOffered(slugs)
+      .map(p => escHtmlServer(p.name) + " &mdash; " + escHtmlServer(p.freeTier))
+      .join(" &middot; ");
+
+  const namedPlainly = (slugs: string[]): string =>
+    stillOffered(slugs).map(p => escHtmlServer(p.name)).join(", ");
+
+  const detailOf = (p: LlmProvider): string => detailForEndedOffer(offerForSlug(p.slug), p.freeDetails);
+
+  const freeTiersThisPageStandsBehind = "The other free tiers on this page are "
+    + stillOffered(["openrouter", "cerebras", "cloudflare-workers-ai", "llm7-io"])
+      .map(p => p.name + " (" + p.freeTier + ")")
+      .join(", ")
+    + ".";
+
+  const thirdChoiceForPrototyping = stillOffered(["cerebras", "cloudflare-workers-ai", "llm7-io"])[0] ?? null;
+  const thirdForPrototyping = thirdChoiceForPrototyping === null
+    ? ""
+    : ' <a href="/vendor/' + escHtmlServer(thirdChoiceForPrototyping.slug) + '">' + escHtmlServer(thirdChoiceForPrototyping.name)
+      + '</a> for ' + escHtmlServer(thirdChoiceForPrototyping.freeTier) + ' without a credit card.';
+
   const frontierReads = providers.filter(p => p.readOn && p.readFrom);
   const frontierReadOn = frontierReads.map(p => p.readOn as string).sort()[0] ?? null;
   const rowsWithNoReadDate = providers.length - frontierReads.length;
@@ -32144,7 +32171,7 @@ function buildLlmApiPricingPage(): string {
       return '<div class="diff-card" style="border-left-color:' + borderColor + '">' +
         '<h3><a href="/vendor/' + escHtmlServer(p.slug) + '" style="color:var(--text)">' + escHtmlServer(p.name) + '</a> ' +
         '<span style="font-size:.75rem;color:var(--text-dim);font-weight:400">' + escHtmlServer(freeTypeLabels[p.freeType]) + '</span></h3>' +
-        '<p class="diff-desc">' + escHtmlServer(p.freeDetails) + '</p>' +
+        '<p class="diff-desc">' + escHtmlServer(detailOf(p)) + '</p>' +
         '<p class="diff-desc" style="margin-top:.5rem"><strong style="color:var(--text)">Key differentiator:</strong> ' + escHtmlServer(p.differentiator) + '</p>' +
         '</div>';
     }).join("\n    ");
@@ -32169,7 +32196,7 @@ function buildLlmApiPricingPage(): string {
   );
 
   const faqEntries = [
-    { q: "Which LLM API has the best free tier in 2026?", a: "Groq's free tier is 30 RPM with 100K-500K tokens/day, no credit card required, with fast LPU-accelerated inference. GitHub Models gives free access to 100+ models (GPT-4o, Llama, Mistral) for GitHub users. OpenRouter provides ~30 free open-source models. For frontier models specifically, Mistral's Experiment tier gives 1B tokens/month at 2 RPM." },
+    { q: "Which LLM API has the best free tier in 2026?", a: "Groq's free tier is 30 RPM with 100K-500K tokens/day, no credit card required, with fast LPU-accelerated inference. " + freeTiersThisPageStandsBehind + " For frontier models specifically, Mistral's Experiment tier gives 1B tokens/month at 2 RPM." },
     { q: "How much does GPT-4o cost per token?", a: "GPT-4o costs $2.50 per million input tokens and $10 per million output tokens. For reference, 1 million tokens is roughly 750,000 words. The batch API offers 50% discount ($1.25/$5 per M tokens). GPT-4o-mini is significantly cheaper at $0.15/$0.60 per M tokens." },
     { q: "How much does Claude cost per token?", a: "Claude Fable 5.1 costs $10/M input and $50/M output tokens. Opus 5 is $5/$25 per M tokens, Sonnet 5 is $2/$10, and Haiku 4.5 is the budget option at $1/$5. The Batch API offers 50% discount on all models." },
     { q: "What is the cheapest LLM API for production use?", a: "For frontier-quality models: xAI Grok 4.1 Fast at $0.20/M input, $0.50/M output. For open-source models: DeepSeek V4 at $0.30/M input, $0.50/M output with cache-hit discounts up to 90%. Groq and Cerebras offer free tiers that can handle moderate production traffic. Google Gemini Flash models are free with rate limits." },
@@ -32310,7 +32337,7 @@ function buildLlmApiPricingPage(): string {
     '\n' +
     '  <div class="highlight-box">\n' +
     '    <h3>Best Free Tiers</h3>\n' +
-    '    <p><strong>Most generous:</strong> Groq (30 RPM, 500K tok/day) &middot; GitHub Models (100+ models free) &middot; Mistral (1B tok/month) &middot; <strong>Best for prototyping:</strong> OpenRouter (~30 free models) &middot; Cerebras (1M tok/day) &middot; <strong>Completely free:</strong> LLM7.io (donor-supported) &middot; Ollama (self-hosted)</p>\n' +
+    '    <p><strong>Most generous:</strong> ' + namedWithTheirFreeTier(["groq", "mistral-ai", "cerebras"]) + ' &middot; <strong>Best for prototyping:</strong> ' + namedWithTheirFreeTier(["openrouter", "cloudflare-workers-ai"]) + ' &middot; <strong>Completely free:</strong> ' + namedWithTheirFreeTier(["llm7-io", "ollama"]) + '</p>\n' +
     '  </div>\n' +
     '\n' +
     '  <div class="toc">\n' +
@@ -32357,7 +32384,7 @@ function buildLlmApiPricingPage(): string {
     '  ' + categorySections + '\n' +
     '\n' +
     '  <h2 id="free-tiers">What You Actually Get for Free</h2>\n' +
-    '  <p class="section-intro">Free tiers range from genuinely production-viable (Groq, GitHub Models) to token giveaways that run out in hours. Here\'s the honest breakdown.</p>\n' +
+    '  <p class="section-intro">Free tiers range from genuinely production-viable (' + namedPlainly(["groq", "cerebras"]) + ') to token giveaways that run out in hours. Here\'s the honest breakdown.</p>\n' +
     '\n' +
     '  <div style="overflow-x:auto">\n' +
     '  <table class="pricing-table">\n' +
@@ -32446,7 +32473,7 @@ function buildLlmApiPricingPage(): string {
     '\n' +
     '    <div class="verdict-item">\n' +
     '      <strong>Best for prototyping</strong>\n' +
-    '      <p><a href="/vendor/groq">Groq</a> (free, fast, no credit card) or <a href="/vendor/openrouter">OpenRouter</a> (~30 free models, try different providers). <a href="/vendor/github-models">GitHub Models</a> for accessing GPT-4o free with a GitHub account.</p>\n' +
+    '      <p><a href="/vendor/groq">Groq</a> (free, fast, no credit card) or <a href="/vendor/openrouter">OpenRouter</a> (~30 free models, try different providers).' + thirdForPrototyping + '</p>\n' +
     '    </div>\n' +
     '\n' +
     '    <div class="verdict-item">\n' +

--- a/test/hardcoded-row-agrees-with-the-record.test.ts
+++ b/test/hardcoded-row-agrees-with-the-record.test.ts
@@ -1,0 +1,324 @@
+import { describe, it, before, after } from "node:test";
+import assert from "node:assert";
+import { spawn, type ChildProcess } from "node:child_process";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  arraysHoldingASlug,
+  buildersHoldingASlug,
+  fieldsDenyingTheFreeTier,
+  freeTierClaimsIn,
+  hardcodedRowsCarryingASlug,
+  statesThereIsNoFreeTier,
+  rowAt,
+  type HardcodedRow,
+} from "./hardcoded-vendor-rows.ts";
+import { assertCoversPopulation, assertSharesPopulation, rowsCarryingAVendorSlug } from "./population-floor.ts";
+
+const { resolveVendorSlug } = await import("../dist/vendor-slug.js");
+const { toSlug } = await import("../dist/slug.js");
+const { loadOffers } = await import("../dist/data.js");
+
+type Offer = import("../src/types.ts").Offer;
+type Resolution = ReturnType<typeof resolveVendorSlug>;
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO = path.join(__dirname, "..");
+
+const offers: Offer[] = loadOffers();
+const firstRecordFor = new Map<string, Offer>();
+for (const offer of offers) {
+  const slug = toSlug(offer.vendor);
+  if (slug && !firstRecordFor.has(slug)) firstRecordFor.set(slug, offer);
+}
+
+const RETIRED = "Retired";
+
+const rows = hardcodedRowsCarryingASlug();
+
+interface JoinedRow {
+  row: HardcodedRow;
+  resolution: Resolution;
+  record: Offer | null;
+}
+
+const joined: JoinedRow[] = rows.map(row => {
+  const resolution = resolveVendorSlug(row.slug);
+  const record = resolution.type === "exact" ? firstRecordFor.get(resolution.slug) ?? null : null;
+  return { row, resolution, record };
+});
+
+const namingARecord = joined.filter(j => j.resolution.type === "exact");
+const joiningARetiredRecord = joined.filter(j => j.record?.tier === RETIRED);
+
+function siteOf(row: HardcodedRow): string {
+  return `${row.builder ?? "module"}.${row.array ?? "anonymous"}:${row.line} (${row.slug})`;
+}
+
+describe("a hardcoded comparison row does not sell a tier its own record has retired", () => {
+  it("reads every row in the page source that carries a vendor slug", () => {
+    assertCoversPopulation(joined.length, rowsCarryingAVendorSlug(), "hardcoded rows this check read");
+    assert.ok(
+      arraysHoldingASlug(rows).length > 1 && buildersHoldingASlug(rows).length > 1,
+      `${arraysHoldingASlug(rows).length} arrays across ${buildersHoldingASlug(rows).length} page builders carry a slug, which is too few to be the whole source`,
+    );
+  });
+
+  it("resolves most of those rows to a record, so the join is worth asking about", () => {
+    assertSharesPopulation(
+      namingARecord.length,
+      rowsCarryingAVendorSlug(),
+      0.5,
+      "hardcoded rows whose slug names a record exactly",
+    );
+  });
+
+  it("finds rows standing on a retired record, so the rule reads a population and not an empty set", () => {
+    assert.ok(
+      joiningARetiredRecord.length > 0,
+      `no hardcoded row resolves to a record recorded as ${RETIRED}, so this check read an empty population`,
+    );
+  });
+
+  it("affirms no free tier on any row whose record is retired", () => {
+    const affirming = joiningARetiredRecord
+      .map(j => ({ site: siteOf(j.row), vendor: j.record!.vendor, fields: freeTierClaimsIn(j.row) }))
+      .filter(j => j.fields.length > 0);
+    assert.deepStrictEqual(
+      affirming,
+      [],
+      `${affirming.length} of ${joiningARetiredRecord.length} rows standing on a retired record still affirm a free tier:\n`
+        + affirming.map(a => `  ${a.site} — ${a.vendor} — ${a.fields.join(", ")}`).join("\n"),
+    );
+  });
+
+  it("says on every such row that there is no free tier, rather than only withholding the old one", () => {
+    const silent = joiningARetiredRecord
+      .filter(j => fieldsDenyingTheFreeTier(j.row).length === 0)
+      .map(j => `  ${siteOf(j.row)} — ${j.record!.vendor}`);
+    assert.deepStrictEqual(
+      silent,
+      [],
+      `${silent.length} rows stand on a retired record and no field of theirs says so:\n${silent.join("\n")}`,
+    );
+  });
+});
+
+describe("the rows this rule must leave alone", () => {
+  const accepted: Array<{ builder: string; array: string; slug: string; because: string }> = [
+    {
+      builder: "buildAiCodingPricing2026Page",
+      array: "tools",
+      slug: "augment-code",
+      because: "its record is retired and the row already says there is no free tier",
+    },
+    {
+      builder: "buildAiCodingToolsPricingPage",
+      array: "tools",
+      slug: "augment-code",
+      because: "its record is retired and the row already says there is no free tier",
+    },
+    {
+      builder: "buildHostingPricingPage",
+      array: "services",
+      slug: "heroku",
+      because: "the slug reaches a record only by redirect, and that record is a different product",
+    },
+    {
+      builder: "buildLlmApiPricingPage",
+      array: "providers",
+      slug: "openai",
+      because: "its record is not retired",
+    },
+  ];
+
+  for (const fixture of accepted) {
+    it(`accepts ${fixture.builder}.${fixture.array} for ${fixture.slug} because ${fixture.because}`, () => {
+      const row = rowAt(rows, fixture.builder, fixture.array, fixture.slug);
+      assert.ok(row !== null, `${fixture.builder}.${fixture.array} no longer holds a row for ${fixture.slug}`);
+      const resolution = resolveVendorSlug(row.slug);
+      const record = resolution.type === "exact" ? firstRecordFor.get(resolution.slug) ?? null : null;
+      const inScope = record?.tier === RETIRED;
+      assert.ok(
+        !inScope || freeTierClaimsIn(row).length === 0,
+        `${siteOf(row)} is read by this rule and refused by it: ${freeTierClaimsIn(row).join(", ")}`,
+      );
+    });
+  }
+
+  it("reads the Heroku row against no record, because the only record its slug reaches is another product", () => {
+    const row = rowAt(rows, "buildHostingPricingPage", "services", "heroku");
+    assert.ok(row !== null, "the hosting comparison no longer holds a row for heroku");
+    const resolution = resolveVendorSlug(row.slug);
+    assert.strictEqual(resolution.type, "redirect");
+    assert.ok(
+      freeTierClaimsIn(row).length > 0,
+      "the heroku row no longer states a free allowance, so it no longer shows what widening this rule to redirects would cost",
+    );
+  });
+
+  it("reads the OpenAI row against a record that is not retired, so its free tier stands", () => {
+    const row = rowAt(rows, "buildLlmApiPricingPage", "providers", "openai");
+    assert.ok(row !== null, "the LLM pricing comparison no longer holds a row for openai");
+    const resolution = resolveVendorSlug(row.slug);
+    assert.strictEqual(resolution.type, "exact");
+    assert.notStrictEqual(firstRecordFor.get("openai")?.tier, RETIRED);
+    assert.ok(
+      freeTierClaimsIn(row).length > 0,
+      "the openai row no longer states a free tier, so it no longer shows what scoping this rule on a removal record would cost",
+    );
+  });
+});
+
+const STATES_FREENESS = /\bfree\b|\bno cost\b|\$0(?![.,\d])/i;
+const SENTENCE = /[^.!?]+[.!?]?/g;
+
+interface PublishedPair {
+  page: string;
+  slug: string;
+  vendor: string;
+}
+
+function pairsTheRegisterRecords(): PublishedPair[] {
+  const at = process.env.AGENTDEALS_PAGE_REVIEWS_PATH || path.join(REPO, "data", "page-reviews.json");
+  const register: Array<{ path: string; vendors_tabulated?: string[]; vendors_asserted?: string[] }> =
+    JSON.parse(readFileSync(at, "utf-8")).pages;
+  const found: PublishedPair[] = [];
+  for (const page of register) {
+    const named = new Set([...(page.vendors_tabulated ?? []), ...(page.vendors_asserted ?? [])]);
+    for (const slug of named) {
+      const record = firstRecordFor.get(slug);
+      if (record?.tier === RETIRED) found.push({ page: page.path, slug, vendor: record.vendor });
+    }
+  }
+  return found;
+}
+
+function decodeEntities(html: string): string {
+  return html
+    .replace(/&nbsp;/g, " ")
+    .replace(/&middot;/g, "·")
+    .replace(/&mdash;/g, "—")
+    .replace(/&ndash;/g, "–")
+    .replace(/&rarr;/g, "→")
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;|&apos;/g, "'")
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&amp;/g, "&");
+}
+
+function visibleText(html: string): string {
+  return decodeEntities(
+    html
+      .replace(/<script[\s\S]*?<\/script>/gi, " ")
+      .replace(/<style[\s\S]*?<\/style>/gi, " ")
+      .replace(/<\/(?:td|th|li|p|div|h[1-6]|dd|dt|tr)>/gi, ". ")
+      .replace(/<[^>]+>/g, " "),
+  )
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+function structuredStrings(html: string): string[] {
+  const found: string[] = [];
+  for (const block of html.matchAll(/<script type="application\/ld\+json">([\s\S]*?)<\/script>/g)) {
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(block[1]);
+    } catch {
+      found.push(block[1]);
+      continue;
+    }
+    const walk = (value: unknown): void => {
+      if (typeof value === "string") found.push(value);
+      else if (Array.isArray(value)) value.forEach(walk);
+      else if (value !== null && typeof value === "object") Object.values(value).forEach(walk);
+    };
+    walk(parsed);
+  }
+  return found;
+}
+
+function claimsNaming(text: string, vendor: string): string[] {
+  return (text.match(SENTENCE) ?? []).filter(sentence => sentence.includes(vendor)).map(s => s.trim());
+}
+
+let port = 0;
+let server: ChildProcess | null = null;
+
+function startServer(): Promise<ChildProcess> {
+  return new Promise((resolve, reject) => {
+    const child = spawn("node", [path.join(REPO, "dist", "serve.js")], {
+      stdio: ["pipe", "pipe", "pipe"],
+      env: { ...process.env, PORT: "0", BASE_URL: "http://localhost", TZ: "UTC" },
+    });
+    const timeout = setTimeout(() => {
+      child.kill();
+      reject(new Error("Server startup timeout"));
+    }, 30000);
+    child.stderr!.on("data", (data: Buffer) => {
+      const running = data.toString().match(/running on http:\/\/localhost:(\d+)/);
+      if (running) {
+        port = parseInt(running[1], 10);
+        clearTimeout(timeout);
+        resolve(child);
+      }
+    });
+    child.on("error", error => {
+      clearTimeout(timeout);
+      reject(error);
+    });
+  });
+}
+
+describe("a page naming a vendor whose offer has ended does not present it as free", () => {
+  const pairs = pairsTheRegisterRecords();
+
+  before(async () => {
+    server = await startServer();
+  });
+
+  after(() => {
+    server?.kill();
+  });
+
+  it("has pages to read, and reads every page the register says names one", async () => {
+    assert.ok(
+      pairs.length > 0,
+      "the review register records no page tabulating a vendor whose record is retired, so this sweep read nothing",
+    );
+    let read = 0;
+    for (const pair of pairs) {
+      const response = await fetch(`http://localhost:${port}${pair.page}`, { redirect: "manual" });
+      assert.strictEqual(response.status, 200, `${pair.page} answered ${response.status}`);
+      await response.text();
+      read++;
+    }
+    assert.strictEqual(read, pairs.length);
+  });
+
+  it("publishes no claim of a free tier for one, in the page text or in its structured data", async () => {
+    const affirming: string[] = [];
+    for (const pair of pairs) {
+      const html = await (await fetch(`http://localhost:${port}${pair.page}`, { redirect: "manual" })).text();
+      const surfaces: Array<{ where: string; claim: string }> = [
+        ...claimsNaming(visibleText(html), pair.vendor).map(claim => ({ where: "page text", claim })),
+        ...structuredStrings(html).flatMap(value =>
+          claimsNaming(value, pair.vendor).map(claim => ({ where: "structured data", claim })),
+        ),
+      ];
+      for (const surface of surfaces) {
+        if (!STATES_FREENESS.test(surface.claim)) continue;
+        if (statesThereIsNoFreeTier(surface.claim)) continue;
+        affirming.push(`  ${pair.page} — ${pair.vendor} — ${surface.where}: ${surface.claim.slice(0, 200)}`);
+      }
+    }
+    assert.deepStrictEqual(
+      affirming,
+      [],
+      `${affirming.length} published claims present a retired offer as free, over ${pairs.length} page and vendor pairs the register records:\n${affirming.join("\n")}`,
+    );
+  });
+});

--- a/test/hardcoded-vendor-rows.ts
+++ b/test/hardcoded-vendor-rows.ts
@@ -1,0 +1,138 @@
+import ts from "typescript";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const REPO = path.join(path.dirname(fileURLToPath(import.meta.url)), "..");
+
+export const PAGE_SOURCE = path.join(REPO, "src", "serve.ts");
+
+export interface HardcodedRow {
+  array: string | null;
+  builder: string | null;
+  line: number;
+  slug: string;
+  fields: Record<string, string>;
+}
+
+function declaredName(node: ts.Node): string | null {
+  let at: ts.Node | undefined = node.parent;
+  while (at) {
+    if (ts.isVariableDeclaration(at) && ts.isIdentifier(at.name)) return at.name.text;
+    if (ts.isPropertyAssignment(at) && (ts.isIdentifier(at.name) || ts.isStringLiteral(at.name))) return at.name.text;
+    at = at.parent;
+  }
+  return null;
+}
+
+function enclosingBuilder(node: ts.Node): string | null {
+  let at: ts.Node | undefined = node.parent;
+  while (at) {
+    if (ts.isFunctionDeclaration(at) && at.name) return at.name.text;
+    at = at.parent;
+  }
+  return null;
+}
+
+function stringFields(object: ts.ObjectLiteralExpression): Record<string, string> {
+  const fields: Record<string, string> = {};
+  for (const property of object.properties) {
+    if (!ts.isPropertyAssignment(property)) continue;
+    const named = ts.isIdentifier(property.name) || ts.isStringLiteral(property.name) ? property.name.text : null;
+    if (!named) continue;
+    if (ts.isStringLiteralLike(property.initializer)) fields[named] = property.initializer.text;
+  }
+  return fields;
+}
+
+export function hardcodedRowsCarryingASlug(source?: string): HardcodedRow[] {
+  const text = source ?? readFileSync(PAGE_SOURCE, "utf-8");
+  const parsed = ts.createSourceFile("serve.ts", text, ts.ScriptTarget.ES2022, true);
+  const rows: HardcodedRow[] = [];
+
+  const read = (node: ts.Node): void => {
+    if (ts.isArrayLiteralExpression(node)) {
+      for (const element of node.elements) {
+        if (!ts.isObjectLiteralExpression(element)) continue;
+        const fields = stringFields(element);
+        if (!fields.slug) continue;
+        rows.push({
+          array: declaredName(node),
+          builder: enclosingBuilder(node),
+          line: parsed.getLineAndCharacterOfPosition(element.getStart(parsed)).line + 1,
+          slug: fields.slug,
+          fields,
+        });
+      }
+    }
+    ts.forEachChild(node, read);
+  };
+  read(parsed);
+
+  return rows;
+}
+
+export function arraysHoldingASlug(rows: HardcodedRow[]): string[] {
+  return [...new Set(rows.map(row => `${row.builder ?? "module"}.${row.array ?? "anonymous"}`))].sort();
+}
+
+export function buildersHoldingASlug(rows: HardcodedRow[]): string[] {
+  return [...new Set(rows.map(row => row.builder).filter((name): name is string => name !== null))].sort();
+}
+
+const NAMES_THE_FREE_TIER = /^free/i;
+
+const DENIES_IT = /^\s*(?:no\b|non-existent|none\b|n\/?a\b|not\b|never\b|zero\b|removed\b|retired\b|ended\b|discontinued\b|withdrawn\b|unavailable\b|[—–-]\s*$)/i;
+
+const STATES_FREENESS = /\bfree\b|\bno cost\b|\$0(?![.,\d])/i;
+
+const ENDED = "removed|retired|retirement|ended|withdrawn|discontinued|eliminated|sunset";
+
+const STATES_THERE_IS_NO_FREE_TIER = new RegExp(
+  [
+    "\\bno free (?:tier|plan|allowance)\\b",
+    "\\bnone free\\b",
+    `\\bfree\\b[^.]{0,30}\\b(?:${ENDED})\\b`,
+    `\\b(?:${ENDED})\\b[^.]{0,30}\\bfree\\b`,
+    "\\bno longer\\b[^.]{0,30}\\bfree\\b",
+    "\\b(?:retired|discontinued|sunset|withdrawn)\\b",
+  ].join("|"),
+  "i",
+);
+
+export function fieldNamesTheFreeTier(field: string): boolean {
+  return NAMES_THE_FREE_TIER.test(field);
+}
+
+export function deniesTheFreeTier(value: string): boolean {
+  return DENIES_IT.test(value) || STATES_THERE_IS_NO_FREE_TIER.test(value);
+}
+
+export function statesThereIsNoFreeTier(value: string): boolean {
+  return STATES_THERE_IS_NO_FREE_TIER.test(value);
+}
+
+export function affirmsAFreeTier(field: string, value: string): boolean {
+  if (field === "slug" || field === "name" || value.trim() === "") return false;
+  if (deniesTheFreeTier(value)) return false;
+  if (fieldNamesTheFreeTier(field)) return true;
+  return STATES_FREENESS.test(value);
+}
+
+export function freeTierClaimsIn(row: HardcodedRow): string[] {
+  return Object.entries(row.fields)
+    .filter(([field, value]) => affirmsAFreeTier(field, value))
+    .map(([field]) => field)
+    .sort();
+}
+
+export function fieldsDenyingTheFreeTier(row: HardcodedRow): string[] {
+  return Object.entries(row.fields)
+    .filter(([, value]) => statesThereIsNoFreeTier(value))
+    .map(([field]) => field)
+    .sort();
+}
+
+export function rowAt(rows: HardcodedRow[], builder: string, array: string, slug: string): HardcodedRow | null {
+  return rows.find(row => row.builder === builder && row.array === array && row.slug === slug) ?? null;
+}

--- a/test/population-floor.ts
+++ b/test/population-floor.ts
@@ -2,6 +2,7 @@ import assert from "node:assert";
 import { appendFileSync, readFileSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+import { hardcodedRowsCarryingASlug } from "./hardcoded-vendor-rows.ts";
 
 export const HEADROOM = 0.25;
 
@@ -132,6 +133,13 @@ export function pagesOnTheReviewRegister(): Population {
   const REPO = path.join(path.dirname(fileURLToPath(import.meta.url)), "..");
   const at = process.env.AGENTDEALS_PAGE_REVIEWS_PATH || path.join(REPO, "data", "page-reviews.json");
   return { size: JSON.parse(readFileSync(at, "utf-8")).pages.length, read: "pages the review register holds" };
+}
+
+export function rowsCarryingAVendorSlug(): Population {
+  return {
+    size: hardcodedRowsCarryingASlug().length,
+    read: "hardcoded comparison rows in the page source carrying a vendor slug",
+  };
 }
 
 const POPULATION_READER = /^[A-Za-z_$][\w$]*\(\s*\)$/;


### PR DESCRIPTION
Refs #1374.

`/llm-api-pricing` published GitHub Models as a live free tier on six surfaces, one of them a `FAQPage` answer, 44 days after our own record said `GitHub retired GitHub Models on 2026-07-30, so there is no free tier.` `/database-pricing` published a 5 GiB monthly allowance for Momento, whose record reads `Retired`. Both are fixed, and the mechanism the issue asked for is in the suite.

## The population, measured rather than quoted

The check censuses `src/serve.ts` with the TypeScript parser instead of naming arrays. Every object literal in an array literal that carries a string `slug`:

| | |
|---|---|
| rows carrying a slug | **552** (4 more set `slug: ""` and name nothing) |
| arrays holding them | **40**, in **24** page builders |
| resolve exactly to a record | **395** |
| resolve by redirect | **46** |
| resolve to nothing | **111** |

No array is named in the check, so a new comparison table is read the day it is written. `assertCoversPopulation` reads the census through a new `rowsCarryingAVendorSlug()` population, so the sweep cannot silently skip rows; the exact resolvers are asserted as a share of it rather than as a count that drifts.

## The rule, and why it is two-sided

Scoped to rows resolving **exactly** to a record recorded `Retired` — the narrow version the issue recommended. **5 rows** stand on one. For each, the check asserts:

1. no field affirms a free tier, and
2. at least one field says there is none.

The second half is what makes the fix say something true rather than merely delete a claim, and it is what catches a row that quietly omits. A field affirms if it is named `free…` and does not deny, or if its value states freeness (`free`, `no cost`, a bare `$0`). On `main`, 3 of the 5 rows affirm and the same 3 say nothing about the retirement.

## What the rule must leave alone

Four rows are pinned as fixtures, two in scope and two out, each for a different stated reason. The two out-of-scope ones carry the measured cost of widening:

| row | verdict | if the rule were wider |
|---|---|---|
| `buildAiCodingPricing2026Page.tools` `augment-code` | in scope, accepted | — |
| `buildAiCodingToolsPricingPage.tools` `augment-code` | in scope, accepted | — |
| `buildHostingPricingPage.services` `heroku` | out of scope | `heroku` resolves **only by redirect**, to `heroku-for-startups-program` — a different product that is also `Retired`. A redirect-accepting rule would refuse this row over `freeBandwidth` and `freeBuildMinutes`, which describe the platform. |
| `buildLlmApiPricingPage.providers` `openai` | out of scope | its record is `Free`. A rule scoped on an unretracted `free_tier_removed` change would refuse it over `freeTier`, `freeType` and `rateLimit` — the false positive the issue predicted for this vendor. |

Those last two assert they still state a free allowance, so if someone makes them stop, the fixture goes red rather than passing for the wrong reason.

## The published surfaces, from the register rather than from this issue

`data/page-reviews.json` already records which vendors each page tabulates, so the page-level check needs no map of its own: **8 page-and-vendor pairs** where a registered page names a vendor whose record is `Retired`. It reads each page and refuses any sentence naming the vendor that states freeness without stating the retirement, in the visible text **and** in every `application/ld+json` block.

On `main`, **7 such claims** on 2 pages:

- `/llm-api-pricing` — 6, including the `FAQPage` answer in structured data
- `/database-pricing` — 1, the card heading `Limited free tier`

On this branch, **0 over the same 8 pairs**. The register found two pages no slug-carrying row reaches — `/database-free-tier-comparison-2026` and `/google-developer-program-2026` — and both were already clean; that is the negative half of the same sweep.

## What the pages say instead

`detailForEndedOffer` in `src/retirement.ts` renders the record's own description wherever a card would have described a live offer, so `/llm-api-pricing` now reads `GitHub retired GitHub Models on 2026-07-30, so there is no free tier.` verbatim from the catalogue, and the row's `freeType: "none"` drives the heading, the colour and the `When You Hit the Wall` column.

The three hand-written prose surfaces and the FAQ answer are no longer hand-written lists of names. Each is built from the providers array filtered by `offerRetired(offerForSlug(...))`, so a vendor whose record is retired drops out of the summary box, the section intro, the prototyping verdict and the structured answer without anyone editing prose. The editorial choice of which providers to hold up stays editorial; the claim that they have a free tier, and the figure quoted for it, come from the row and the record.

## Two pages stopped being unsourced

Joining these rows to the catalogue means `/llm-api-pricing` and `/database-pricing` now read it. `test/page-data-provenance.test.ts` measures that by perturbing the index rather than trusting the register, and it caught the register saying otherwise. Both are now `reads_index: true` and `data_source: "catalogue"`, and `unsourced_tier_a` ratchets **22 → 20**.

## Controls

- **Negative.** The new test file run against `origin/main` with the same code: 10 of 13 pass, 3 fail — the row rule names 3 of 5 rows, the silence rule names the same 3, and the page sweep names 7 claims over 8 pairs. All four fixtures pass on `main` too, so they pin the boundary rather than the fix.
- **Positive.** On this branch, 13 of 13.

## A blind spot worth naming

`rateLimit: "10-15 RPM, 50-150 req/day"` on the GitHub Models row was caught by **neither** half of the rule: the field is not named for the free tier and the value states no freeness. Every other row in that array writes `(free)` into the same field, which is how I found it. It is corrected by hand. A row can still restate a retired offer's figures in a field that neither names the free tier nor uses the word, and the second half of the rule is what limits the damage — the row now says there is no free tier beside it.

## Not in this change

`paidFrom: "$0.50/GiB transfer"` on the Momento row disagrees with its record, which prices Cache Flex from `$13 per GB-month`. That is a wrong price rather than a free-tier claim, it needs its own read of the vendor's page, and I left it.
