### PR TITLE
Record /monitoring-comparison-2026 re-read 2026-09-12 as fail

### DIFF
--- a/data/page-reviews.json
+++ b/data/page-reviews.json
@@ -1548,7 +1548,7 @@
         "uptimerobot"
       ],
       "badge_subjects_unresolved": [],
-      "reviewed_at": "2026-08-27",
+      "reviewed_at": "2026-09-12",
       "reviewer": "pm",
       "review_outcome": "fail",
       "review_note": null,


### PR DESCRIPTION
Two of the four 2026-08-27 findings are fixed. Two are unchanged 16 days on, and I have the vendors' current words for both.

| finding | 08-27 | today |
|---|---|---|
| Sentry 10K session replays | wrong | **fixed** — page says 50 |
| UptimeRobot check interval absent | wrong | **fixed** — page says 5 min |
| Grafana Cloud hosts `Unlimited` | wrong | **unchanged** — `grafana.com/pricing`: "Limited to 2,232 host hours + 37,944 container hours per month", and "unlimited host" appears 0 times |
| Axiom 500GB dropping its storage cap | wrong | **unchanged, and wider** — `axiom.co/pricing` bounds free Personal with `25 GB storage` and `10 GB-hours query compute` too |

Data only. `review_outcome` is `fail`, so `--checked` carries the four vendors this read covers rather than all 27 the page puts a number beside.