### PR TITLE
Let a record the detector wrote a direction on reach main, and read the vendor's own name for our free plan as that plan

### DIFF
--- a/scripts/census-1585-pinned-absences.mjs
+++ b/scripts/census-1585-pinned-absences.mjs
@@ -1,0 +1,181 @@
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import ts from "typescript";
+
+const REPO = path.join(path.dirname(fileURLToPath(import.meta.url)), "..");
+const TESTS = path.join(REPO, "test");
+
+const READS_THE_CATALOGUE_OFF_DISK =
+  /\bdata["'`]\s*,\s*["'`][a-z_]+\.json|loadOffers\(|loadDealChanges\(|loadIndex\(|loadCatalogue\(|readIndex\(|enrichOffers\(/;
+
+const ABSENT = new Set(["false", "null", "undefined", "0"]);
+
+const ASSERTIONS = new Set(["strictEqual", "deepStrictEqual", "equal", "deepEqual"]);
+
+const BUILT_IN = new Set(["length", "size", "name", "message", "stack", "text", "html", "body", "status"]);
+
+function textOf(node, source) {
+  return source.text.slice(node.getStart(source), node.getEnd());
+}
+
+function identifiersIn(node, source) {
+  const named = new Set();
+  const walk = (at) => {
+    if (ts.isPropertyAccessExpression(at)) {
+      walk(at.expression);
+      return;
+    }
+    if (ts.isPropertyAssignment(at) && !ts.isComputedPropertyName(at.name)) {
+      walk(at.initializer);
+      return;
+    }
+    if (ts.isIdentifier(at)) named.add(at.text);
+    ts.forEachChild(at, walk);
+  };
+  walk(node);
+  void source;
+  return named;
+}
+
+function liveBindingsIn(source) {
+  const live = new Set();
+  const declarations = [];
+  const collect = (node) => {
+    if (ts.isVariableDeclaration(node) && node.initializer && ts.isIdentifier(node.name)) {
+      declarations.push({
+        name: node.name.text,
+        reads: identifiersIn(node.initializer, source),
+        text: textOf(node.initializer, source),
+      });
+    }
+    ts.forEachChild(node, collect);
+  };
+  collect(source);
+
+  let grew = true;
+  while (grew) {
+    grew = false;
+    for (const declaration of declarations) {
+      if (live.has(declaration.name)) continue;
+      const fromDisk = READS_THE_CATALOGUE_OFF_DISK.test(declaration.text);
+      const fromLive = [...declaration.reads].some((read) => live.has(read));
+      if (!fromDisk && !fromLive) continue;
+      live.add(declaration.name);
+      grew = true;
+    }
+  }
+  return live;
+}
+
+function namesALiveBinding(node, source, live) {
+  return [...identifiersIn(node, source)].some((name) => live.has(name));
+}
+
+function enclosingTestName(node, source) {
+  for (let at = node.parent; at; at = at.parent) {
+    if (!ts.isCallExpression(at)) continue;
+    const callee = textOf(at.expression, source);
+    if (callee !== "it" && callee !== "test" && callee !== "describe") continue;
+    const first = at.arguments[0];
+    if (first && ts.isStringLiteralLike(first)) return first.text;
+  }
+  return "(unnamed)";
+}
+
+function pinnedAbsencesIn(file) {
+  const source = ts.createSourceFile(
+    file,
+    fs.readFileSync(file, "utf-8"),
+    ts.ScriptTarget.Latest,
+    true,
+  );
+  const live = liveBindingsIn(source);
+  if (live.size === 0) return { live, found: [] };
+
+  const found = [];
+  const inspect = (node, inLiveLoop) => {
+    let loop = inLiveLoop;
+    if (ts.isForOfStatement(node) && namesALiveBinding(node.expression, source, live)) {
+      loop = true;
+    }
+    if (loop && ts.isCallExpression(node) && ts.isPropertyAccessExpression(node.expression)) {
+      const object = textOf(node.expression.expression, source);
+      const member = node.expression.name.text;
+      const args = node.arguments;
+      const pinned =
+        object === "assert" &&
+        ((ASSERTIONS.has(member) &&
+          args.length >= 2 &&
+          (ABSENT.has(textOf(args[1], source)) || textOf(args[1], source) === "[]")) ||
+          (member === "ok" &&
+            args.length >= 1 &&
+            ts.isPrefixUnaryExpression(args[0]) &&
+            args[0].operator === ts.SyntaxKind.ExclamationToken));
+      if (pinned) {
+        const actual = textOf(args[0], source);
+        const bare = actual.replace(/^!/, "");
+        const callsAPredicate = /^[A-Za-z_$][\w$]*\s*\(/.test(bare);
+        const read = bare.match(/^[A-Za-z_$][\w$]*(?:\[[^\]]*\])?!?\.([A-Za-z_$][\w$]*)(\s*\()?/);
+        const field = read && !read[2] && !BUILT_IN.has(read[1]) ? read[1] : null;
+        found.push({
+          file: path.relative(REPO, file),
+          line: source.getLineAndCharacterOfPosition(node.getStart(source)).line + 1,
+          test: enclosingTestName(node, source),
+          actual: actual.replace(/\s+/g, " ").slice(0, 90),
+          expected: member === "ok" ? "!(…)" : textOf(args[1], source),
+          callsAPredicate,
+          field: callsAPredicate ? null : field,
+        });
+      }
+    }
+    ts.forEachChild(node, (child) => inspect(child, loop));
+  };
+  inspect(source, false);
+  return { live, found };
+}
+
+const files = fs
+  .readdirSync(TESTS)
+  .filter((name) => name.endsWith(".test.ts"))
+  .map((name) => path.join(TESTS, name));
+
+let withLiveData = 0;
+const all = [];
+for (const file of files) {
+  const { live, found } = pinnedAbsencesIn(file);
+  if (live.size > 0) withLiveData++;
+  all.push(...found);
+}
+
+const writers = ["scripts", "src"]
+  .flatMap((dir) =>
+    fs
+      .readdirSync(path.join(REPO, dir))
+      .filter((name) => /\.(ts|js|mjs)$/.test(name))
+      .map((name) => fs.readFileSync(path.join(REPO, dir, name), "utf-8")),
+  )
+  .join("\n");
+
+const writesTheField = (field) =>
+  field !== null &&
+  new RegExp(`(?:^|[^\\w$.])${field}\\s*:(?!:)|\\.${field}\\s*=(?!=)|\\[["'\`]${field}["'\`]\\]\\s*=`).test(writers);
+
+const callingAPredicate = all.filter((entry) => entry.callsAPredicate);
+const pinningAWrittenField = all.filter((entry) => writesTheField(entry.field));
+const inTheClass = [...callingAPredicate, ...pinningAWrittenField];
+const byFile = new Map();
+for (const entry of inTheClass) byFile.set(entry.file, (byFile.get(entry.file) ?? 0) + 1);
+
+console.log(`test files: ${files.length}`);
+console.log(`reading live catalogue data: ${withLiveData}`);
+console.log(`per-record absence assertions over live data: ${all.length}`);
+console.log(`  pinning a predicate the production path calls: ${callingAPredicate.length}`);
+console.log(`  pinning a field a writer in src/ or scripts/ sets: ${pinningAWrittenField.length}`);
+console.log(`the class: ${inTheClass.length}, spread over ${byFile.size} files\n`);
+
+for (const entry of inTheClass.sort((a, b) => a.file.localeCompare(b.file) || a.line - b.line)) {
+  console.log(`${entry.file}:${entry.line}  ${entry.expected}${entry.field ? `  (field ${entry.field})` : ""}`);
+  console.log(`    ${entry.test}`);
+  console.log(`    ${entry.actual}`);
+}

--- a/scripts/mutate-1585.mjs
+++ b/scripts/mutate-1585.mjs
@@ -1,0 +1,90 @@
+import { readFileSync, writeFileSync } from "node:fs";
+import { execFileSync } from "node:child_process";
+
+const TIER = "src/change-tier.ts";
+const REVIEW = "src/change-direction-review.ts";
+const LOG = "scripts/change-log.js";
+
+const LISTINGS = "test/superseded-terms-listings.test.ts";
+
+const SUITE = [
+  "test/tier-scoped-verdicts.test.ts",
+  "test/change-direction-review.test.ts",
+  LISTINGS,
+];
+
+const MUTANTS = [
+  ["a reading that says our tier narrowed is held off it again", TIER,
+    "  if (readingSaysTheListedTierNarrowed(change)) return false;\n",
+    ""],
+
+  ["the vendor's own name for our free plan is a different plan again", TIER,
+    "  return !readingNamesTheFreePlanWeList(change, tier);",
+    "  return true;"],
+
+  ["an edition's name stops carrying its own identity", TIER,
+    "  if (tierRecordsASelfHostedEdition(listed)) return false;\n",
+    ""],
+
+  ["any listed tier counts as a free plan, so a paid plan's reading grades it", TIER,
+    "  if (!tierRecordsAFreeTier(listed)) return false;\n",
+    ""],
+
+  ["the reading no longer has to describe a free plan at all", TIER,
+    '  return A_FREE_PLAN.test(`${change.summary ?? ""} ${change.current_state ?? ""}`);',
+    "  return true;"],
+
+  ["the reading is read for a free plan in its terms but not in its summary", TIER,
+    '  return A_FREE_PLAN.test(`${change.summary ?? ""} ${change.current_state ?? ""}`);',
+    '  return A_FREE_PLAN.test(`${change.current_state ?? ""}`);'],
+
+  ["the overlay writes over a direction the record was written with", REVIEW,
+    "    if (isTierDirection(change.tier_direction)) return change;\n",
+    ""],
+
+  ["the overlay reaches a record its review does not name", REVIEW,
+    "    const reviewed = byRecord.get(reviewKey(change));",
+    "    const reviewed = byRecord.get(reviewKey(change)) ?? [...byRecord.values()][0];"],
+
+  ["the detector stops storing the direction the reader gave", LOG,
+    "      ...(directionRead ? { tier_direction: directionRead } : {}),\n",
+    ""],
+
+  ["a record is identified by an opening another record shares", LISTINGS,
+    "    length < stored.length &&",
+    "    false &&"],
+];
+
+function run(cmd, args) {
+  try {
+    execFileSync(cmd, args, { stdio: "pipe", encoding: "utf-8", env: { ...process.env, TZ: "UTC" } });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+const survivors = [];
+const uncompiled = [];
+const skipped = [];
+for (const [name, file, from, to] of MUTANTS) {
+  const original = readFileSync(file, "utf-8");
+  if (!original.includes(from)) {
+    console.log(`SKIP  ${name} — the line it mutates is not in ${file}`);
+    skipped.push(name);
+    continue;
+  }
+  writeFileSync(file, original.replace(from, to));
+  const built = run("npm", ["run", "build"]);
+  const green = built && run("npx", ["tsx", "--test", "--test-concurrency", "1", ...SUITE]);
+  writeFileSync(file, original);
+  if (!built) uncompiled.push(name);
+  console.log(`${green ? "SURVIVED" : built ? "killed  " : "DID NOT COMPILE"}  ${name}`);
+  if (green) survivors.push(name);
+}
+run("npm", ["run", "build"]);
+const killed = MUTANTS.length - survivors.length - uncompiled.length - skipped.length;
+console.log(`\n${killed}/${MUTANTS.length} killed`);
+if (survivors.length > 0) console.log("survivors:", survivors.join(", "));
+if (uncompiled.length > 0) console.log("did not compile:", uncompiled.join(", "));
+if (skipped.length > 0) console.log("skipped — target string moved, so these scored nothing:", skipped.join(", "));

--- a/src/change-tier.ts
+++ b/src/change-tier.ts
@@ -1,12 +1,13 @@
 import { readingDescribesNoNarrowing } from "./change-direction.js";
-import { tierRecordsASelfHostedEdition } from "./free-tier-record.js";
-import { namesTheVendorsHostedEdition } from "./superseding-reading.js";
+import { tierRecordsAFreeTier, tierRecordsASelfHostedEdition } from "./free-tier-record.js";
+import { A_FREE_PLAN, namesTheVendorsHostedEdition } from "./superseding-reading.js";
 import type { DealChange } from "./types.js";
 
 export interface TieredChange extends Pick<DealChange, "change_type"> {
   tier?: string | null;
   tier_direction?: DealChange["tier_direction"];
   current_state?: string | null;
+  summary?: string | null;
 }
 
 export interface GradedOffer {
@@ -23,9 +24,25 @@ export function comparableTerms(text: string | null | undefined): string {
   return (text ?? "").replace(/\s+/g, " ").trim().toLowerCase();
 }
 
+export function readingSaysTheListedTierNarrowed(change: TieredChange): boolean {
+  return change.tier_direction === "narrowed";
+}
+
+export function readingNamesTheFreePlanWeList(
+  change: TieredChange,
+  tier: string | undefined,
+): boolean {
+  const listed = tier ?? "";
+  if (!tierRecordsAFreeTier(listed)) return false;
+  if (tierRecordsASelfHostedEdition(listed)) return false;
+  return A_FREE_PLAN.test(`${change.summary ?? ""} ${change.current_state ?? ""}`);
+}
+
 export function namesADifferentTier(change: TieredChange, tier: string | undefined): boolean {
   const named = comparableTerms(change.tier);
-  return named !== "" && named !== comparableTerms(tier);
+  if (named === "" || named === comparableTerms(tier)) return false;
+  if (readingSaysTheListedTierNarrowed(change)) return false;
+  return !readingNamesTheFreePlanWeList(change, tier);
 }
 
 export function readingGradesTheHostedEdition(change: TieredChange, offer: GradedOffer): boolean {

--- a/test/change-direction-review.test.ts
+++ b/test/change-direction-review.test.ts
@@ -276,23 +276,38 @@ describe("#1528 the review of the records already written", () => {
     }
   });
 
-  it("leaves every record it does not review carrying no direction", () => {
+  it("states a direction on no record its review does not name", () => {
     const reviewed = new Set(review.directions.map((entry) => reviewKey(entry)));
-    let unreviewed = 0;
-    for (const change of liveChanges) {
-      if (reviewed.has(reviewKey(change))) continue;
-      unreviewed++;
-      assert.strictEqual(
-        change.tier_direction ?? null,
-        null,
-        `${change.vendor} ${change.date} carries a direction from nowhere`,
+    const overlaid = applyReviewedDirections(stored);
+    assert.strictEqual(overlaid.length, stored.length, "the overlay changed the size of the log");
+    let stated = 0;
+    for (const [at, change] of overlaid.entries()) {
+      const before = stored[at]!.tier_direction ?? null;
+      const after = change.tier_direction ?? null;
+      if (after === before) continue;
+      stated++;
+      assert.ok(
+        reviewed.has(reviewKey(change)),
+        `${change.vendor} ${change.date} is given ${after} by a review that does not name it`,
       );
     }
     assert.strictEqual(
-      unreviewed + review.directions.length,
-      liveChanges.length,
-      "the sweep does not cover every record the catalogue loaded",
+      stated,
+      review.directions.length,
+      "the overlay does not reach every record its review names",
     );
+  });
+
+  it("keeps a direction the record was written with, which no review names", () => {
+    const fromTheDetector = { ...A_RECORD_TYPED_AS_A_REDUCTION, tier_direction: "widened" } as DealChange;
+    assert.strictEqual(applyReviewedDirections([fromTheDetector], [])[0]!.tier_direction, "widened");
+
+    const overlaid = applyReviewedDirections(stored);
+    for (const [at, change] of overlaid.entries()) {
+      const written = stored[at]!.tier_direction ?? null;
+      if (written === null) continue;
+      assert.strictEqual(change.tier_direction, written, `${change.vendor} ${change.date}`);
+    }
   });
 });
 

--- a/test/superseded-terms-listings.test.ts
+++ b/test/superseded-terms-listings.test.ts
@@ -53,14 +53,36 @@ const decodeEntities = (text: string): string =>
     .replace(/&amp;/g, "&");
 const withoutTags = (markup: string): string => decodeEntities(squash(markup.replace(/<[^>]*>/g, " ")));
 
-const headOf = (offer: Offer): string => squash(offer.description).slice(0, HEAD);
+const storedTermsOf = new Map<Offer, string>(offers.map((offer) => [offer, squash(offer.description)]));
+
+function headTellingItFromEveryOtherRecord(offer: Offer): string {
+  const stored = storedTermsOf.get(offer)!;
+  let length = Math.min(HEAD, stored.length);
+  while (
+    length < stored.length &&
+    offers.some(
+      (other) => other !== offer && storedTermsOf.get(other)!.startsWith(stored.slice(0, length)),
+    )
+  ) {
+    length++;
+  }
+  return stored.slice(0, length);
+}
+
+const headOfRecord = new Map<Offer, string>(
+  offers.map((offer) => [offer, headTellingItFromEveryOtherRecord(offer)]),
+);
+
+const headOf = (offer: Offer): string =>
+  headOfRecord.get(offer) ?? squash(offer.description).slice(0, HEAD);
 
 function publishesStoredTerms(slot: string, offer: Offer): boolean {
   const shown = squash(slot).replace(/(\.\.\.|…)$/, "");
-  const stored = squash(offer.description);
+  const stored = storedTermsOf.get(offer) ?? squash(offer.description);
+  const head = headOf(offer);
   if (shown.length < 25) return false;
-  if (stored.startsWith(shown.slice(0, HEAD))) return true;
-  return stored.length >= HEAD && shown.includes(stored.slice(0, HEAD));
+  if (shown.length >= head.length && stored.startsWith(shown.slice(0, head.length))) return true;
+  return stored.length >= head.length && shown.includes(head);
 }
 
 const STACK_AND_TABLE_PAGES = [
@@ -166,6 +188,52 @@ describe("#1395 the listing surfaces answer the stored-terms question the way th
       pages.size,
       categoryPaths.length + searchPaths.length + alternativePaths.length + STACK_AND_TABLE_PAGES.length + 2,
     );
+  });
+
+  it("reads no other record's published terms as this record's own", () => {
+    const sharingAnOpening = offers.filter((offer) =>
+      offers.some(
+        (other) =>
+          other !== offer &&
+          storedTermsOf.get(other)!.slice(0, HEAD) === storedTermsOf.get(offer)!.slice(0, HEAD),
+      ),
+    );
+    assertPopulationFloor(
+      sharingAnOpening.length,
+      14,
+      `records open with the same ${HEAD} characters as another record`,
+    );
+
+    let told = 0;
+    let inseparable = 0;
+    for (const offer of sharingAnOpening) {
+      const stored = storedTermsOf.get(offer)!;
+      assert.strictEqual(
+        publishesStoredTerms(stored, offer),
+        true,
+        `${offer.vendor} no longer recognises its own terms`,
+      );
+      for (const other of sharingAnOpening) {
+        if (other === offer) continue;
+        const theirs = storedTermsOf.get(other)!;
+        if (theirs.startsWith(stored) || stored.startsWith(theirs)) {
+          inseparable++;
+          continue;
+        }
+        told++;
+        assert.strictEqual(
+          publishesStoredTerms(theirs, offer),
+          false,
+          `${other.vendor}'s stored terms read as ${offer.vendor}'s`,
+        );
+      }
+    }
+    assert.strictEqual(
+      told + inseparable,
+      sharingAnOpening.length * (sharingAnOpening.length - 1),
+      "the sweep does not reach every pair of records that open alike",
+    );
+    assertPopulationFloor(told, 200, "pairs open alike and say different things further in");
   });
 
   it("publishes no superseded stored terms in a visible listing slot", () => {

--- a/test/tier-scoped-verdicts.test.ts
+++ b/test/tier-scoped-verdicts.test.ts
@@ -72,6 +72,32 @@ const A_READING_OF_THE_SELF_HOSTED_EDITION = {
 
 const THE_SAME_PAGE_LISTED_AS_A_HOSTED_TIER = { ...A_SELF_HOSTED_OFFER, tier: "Free" };
 
+const A_FREE_LISTING = {
+  vendor: "Dashcorp",
+  category: "Monitoring",
+  description: "2 team members, 5 monitors, a private status page.",
+  tier: "Free",
+  url: "https://dashcorp.example/pricing",
+  tags: ["monitoring"],
+  verifiedDate: "2026-09-01",
+};
+
+const A_STARTUP_PROGRAMME_LISTING = { ...A_FREE_LISTING, tier: "Startup Program" };
+
+const A_READING_OF_A_PLAN = {
+  vendor: "Dashcorp",
+  change_type: "limits_reduced",
+  date: "2026-09-12",
+  date_source: "discovered",
+  summary: "The plan moved.",
+  previous_state: A_FREE_LISTING.description,
+  current_state: "The plan moved.",
+  impact: "medium",
+  source_url: A_FREE_LISTING.url,
+  category: "Monitoring",
+  alternatives: [],
+};
+
 describe("#1526 a record names the tier it read, and only that tier's verdict follows from it", () => {
   it("decides nothing when the record names no tier", () => {
     for (const named of [undefined, null, "", "   "]) {
@@ -100,15 +126,92 @@ describe("#1526 a record names the tier it read, and only that tier's verdict fo
     assert.strictEqual(namesADifferentTier(named, "Dashcorp Cloud Free"), false);
   });
 
-  it("leaves every record stored today deciding exactly what it decided before", () => {
+  it("reads the vendor's own name for the plan we list as free as the plan we list", () => {
+    for (const [named, summary, current_state] of [
+      ["Hobby", "The free tier (Hobby) now only includes up to 2 users.", "Up to 2 users, 3 minute checks, limited status page."],
+      ["Basic", "The plan came down to 5 monitors and 3-minute checks.", "Basic $0 per month. 5 monitors, 3 minute checks."],
+      ["Dashcorp", "The pricing and limits for the free tier have been clarified.", "50 agentic requests, 1,000 lines of code a month."],
+    ] as const) {
+      const change = { ...A_READING_OF_A_PLAN, tier: named, summary, current_state };
+      assert.strictEqual(namesADifferentTier(change, "Free"), false, named);
+      assert.strictEqual(changeGradesTheListedTier(change, A_FREE_LISTING), true, named);
+    }
+  });
+
+  it("holds a reading that names a benefit of its own off a tier that is not a free plan", () => {
+    const credits = {
+      ...A_READING_OF_A_PLAN,
+      tier: "Dashcorp Activate Credits",
+      summary: "The programme now offers up to $200,000 in Activate Credits, not a year of Pro+.",
+      current_state: "Apply to receive up to $200,000 in Activate Credits against infrastructure.",
+      tier_direction: "unchanged",
+    };
+    assert.strictEqual(namesADifferentTier(credits, "Startup Program"), true);
+    assert.strictEqual(changeGradesTheListedTier(credits, A_STARTUP_PROGRAMME_LISTING), false);
+  });
+
+  it("holds a reading of the free plan off a tier we do not list as a free plan", () => {
+    const freePlan = {
+      ...A_READING_OF_A_PLAN,
+      tier: "Free",
+      summary: "The free tier now has limits of 5 monitors and 3-minute checks.",
+      current_state: "Free: 5 monitors, 3 minute checks.",
+      tier_direction: "unchanged",
+    };
+    assert.strictEqual(namesADifferentTier(freePlan, "Startup Program"), true);
+    assert.strictEqual(changeGradesTheListedTier(freePlan, A_STARTUP_PROGRAMME_LISTING), false);
+    assert.strictEqual(namesADifferentTier({ ...freePlan, tier: "Hobby" }, "Free"), false);
+  });
+
+  it("keeps a paid plan's reading off the free tier it does not describe", () => {
+    const paid = {
+      ...A_READING_OF_A_PLAN,
+      tier: "Pro",
+      summary: "The Pro plan now costs $29 per month, up from $19.",
+      current_state: "Pro: $29 per month per seat.",
+    };
+    assert.strictEqual(namesADifferentTier(paid, "Free"), true);
+    assert.strictEqual(changeGradesTheListedTier(paid, A_FREE_LISTING), false);
+  });
+
+  it("lets a reading that says our tier narrowed grade it, whatever plan it named", () => {
+    const paid = {
+      ...A_READING_OF_A_PLAN,
+      tier: "Pro",
+      summary: "The Pro plan now costs $29 per month, up from $19.",
+      current_state: "Pro: $29 per month per seat.",
+    };
+    assert.strictEqual(namesADifferentTier({ ...paid, tier_direction: "narrowed" }, "Free"), false);
+    for (const direction of [undefined, "unchanged", "widened"]) {
+      assert.strictEqual(
+        namesADifferentTier({ ...paid, tier_direction: direction }, "Free"),
+        true,
+        String(direction),
+      );
+    }
+  });
+
+  it("leaves an edition's name carrying its own identity", () => {
+    const named = {
+      ...A_READING_OF_THE_HOSTED_PRODUCT,
+      tier: "Dashcorp Cloud Free",
+      summary: "The Dashcorp Cloud free tier now includes 10k metrics.",
+    };
+    assert.strictEqual(namesADifferentTier(named, "Free OSS"), true);
+    assert.strictEqual(namesADifferentTier(named, "Open Source"), true);
+    assert.strictEqual(namesADifferentTier(named, "Free"), false);
+  });
+
+  it("suppresses no record whose own reading says the tier we list narrowed", () => {
     let pairs = 0;
     for (const offer of offers) {
       for (const change of changesFor(offer.vendor)) {
         pairs++;
+        if (change.tier_direction !== "narrowed") continue;
         assert.strictEqual(
           namesADifferentTier(change, offer.tier),
           false,
-          `${change.vendor} ${change.change_type} ${change.date} would stop grading ${offer.tier}`,
+          `${change.vendor} ${change.change_type} ${change.date} says ${offer.tier} narrowed and would stop grading it`,
         );
       }
     }


### PR DESCRIPTION
Refs #1585

The pipeline has published nothing since 09-10. Every change record the detector writes carries a `tier_direction`, and two assertions that merged on 09-10 refuse any record that carries one. Both were vacuously true the day they merged — all 596 stored records carried no direction — and both went live on the first run that wrote one.

Neither can converge. Each is `assert.strictEqual` inside a per-record loop, so it prints one offender per run, and `gate-data-push.sh` holds vendors back once per run by design. Clearance is one record per run per assertion; arrival is around ten.

## `change-direction-review.test.ts` — the overlay's coverage, read off the wrong side

The assertion read `loadDealChanges()`, which has already applied the review, so a direction the detector stored and a direction the overlay added are the same value on the same field. It could not tell them apart, and #1532's three sibling assertions in the same file state the opposite invariant.

It now diffs `applyReviewedDirections(stored)` against `stored` positionally and asserts the overlay states a direction on no record its review does not name. A record the detector wrote a direction on is not in the diff at all. The count it closes on is `review.directions.length` rather than a literal, so resolving a review entry moves both sides together.

A second assertion holds the other half: a direction the record was written with survives a review that names nothing.

## `tier-scoped-verdicts.test.ts` — and the defect underneath it

`namesADifferentTier` compared two labels from two vocabularies. We write `Free`; the detector asks the reader to name the plan *as the page names it*, so the reader writes `Hobby`, or `Basic`, or the product's own name. String inequality then stopped the record grading the offer, and under #1527 a record that does not grade the offer neither withholds its terms nor rates it.

So OnlineOrNot dropping to 2 users and 3 monitors and losing its private status page was recorded and published nothing.

Two things now stop a label mismatch suppressing a verdict:

- **A reading that says the tier we list narrowed grades the tier we list**, whatever plan it named. That is a different question, answered from the two sets of terms, and #1532 added it for exactly this.
- **The vendor's own name for the plan we list as free is that plan**, where our label is a free-tier label carrying no product identity of its own and the reading describes the plan as free. An `OSS`/`Open Source`/`Self-Hosted` label does carry identity, so it is excluded and #1526's hosted-versus-self-hosted fixture is untouched.

On the 13 records in the quarantined batch that name a tier, 4 name a label other than ours. Three are exempted and **both clauses fire independently on all three** — two questions the reader answered separately agree. `Amazon Kiro (AWS Startups)` is the fourth: `AWS Activate Credits` against our `Startup Program`, which is not a free-tier label and whose reading claims no free plan. It still names a different thing, and a reading of one benefit still cannot grade another.

The live replay no longer pins `namesADifferentTier` to `false` on every pair on disk — the feature exists to make that non-zero. It asserts the property the rule now guarantees: no record whose own reading says our tier narrowed is suppressed. The decision table is checked on fixtures in both directions, including a paid plan's reading still held off the free tier it does not describe, and a reading of the free plan still held off a tier we do not list as one.

## A third assertion, which was accusing the wrong vendor

Fixing the above made OnlineOrNot withhold, and `superseded-terms-listings.test.ts` then reported its stored terms published on `/category/monitoring` and `/best/free-monitoring`.

The page was innocent. Its row reads *"Superseded: as of 2026-09-12 … we are not publishing our stored OnlineOrNot terms beside it."* What the test matched was **Hyperping's** row — the structured-data node it flagged even carries `"name": "Hyperping"`. `publishesStoredTerms` identified a record by the first 45 characters of its description, and OnlineOrNot and Hyperping open with the same 45 characters: `Uptime and status page monitoring — free plan`.

**9 openings are shared by 20 of the 1,547 records.** A record is now identified by the shortest opening that no other record shares, and a new assertion reads one record's stored terms against every other record that opens alike and requires them to be told apart — 360 ordered pairs. The other 20 pairs are the 12 records whose stored terms are a prefix of another's, which no opening can separate; the sweep names them and closes on the whole 380 rather than on a literal.

## Controls

**Negative.** `origin/main`'s code against the quarantined batch `rolling-reverification-20260912T144014Z-980fd3c`, the two files #1585 names: 38 tests, 2 fail — `uptimetoolbox.com 2026-09-12 carries a direction from nowhere` and `Amazon Kiro (AWS Startups) pricing_restructured 2026-09-12 would stop grading Startup Program`. This branch on the same data: 44 tests, 0 fail.

**Verdict replay, whole catalogue, 1,547 offers.** On the quarantined batch **3 move**, and all three gain a verdict they were recorded for: OnlineOrNot, uptimetoolbox.com and Amazon Q Developer each go from published/stable to withheld/caution on their 09-12 record. Kiro does not move.

**Nothing moves silently.** On `main`'s 596 stored records the same replay moves **0 of 1,547**. Only two stored records name a tier and both name the one we list.

**Mutants.** `scripts/mutate-1585.mjs` — 10 of 10 killed, each by a test rather than by the compiler. Two survived the first run: my fixtures put the freeness claim in both the summary and the terms, and the real records put it in only one.

## The class

`scripts/census-1585-pinned-absences.mjs` censuses `test/` with the TypeScript parser: it resolves which bindings in each file derive from catalogue data on disk, walks the `for…of` loops over them, and collects assertions pinning an absence — a predicate the production path calls, or a field a writer in `src/` or `scripts/` sets.

On `origin/main`: 237 test files, 132 reading live catalogue data, 51 per-record absence assertions over it, of which **19 are in the class, over 11 files**. It finds both of the assertions #1585 is about, which is what says the query is looking at the right thing. The list is on the issue.
